### PR TITLE
[filigran-ui] Add searchbar for icons

### DIFF
--- a/projects/filigran-website/components/display-all-icons.tsx
+++ b/projects/filigran-website/components/display-all-icons.tsx
@@ -1,16 +1,48 @@
+'use client'
 import * as FiligranIcon from 'filigran-icon'
-import {Fragment} from 'react'
+import React, {Fragment,ReactElement,useState,useMemo} from 'react'
+import Popup from './icon-popup';
+import SearchBar from './icon-searchbar';
 
 export const DisplayAllIcons = () => {
+  const [selectedIcon, setSelectedIcon] = useState<ReactElement | null>(null);
+  const [selectedIconLabel, setSelectedIconLabel] = useState('');
+  const [isOpen, setIsOpen] = useState(false);
+  const [searchTerm, setSearchTerm] = useState('');
+
+  const handleIconClick = (Icon : React.ComponentType<any> ,icon : string) => {
+    setSelectedIcon(<Icon className="w-20 h-20"/>);
+    setSelectedIconLabel(icon);
+    setIsOpen(true);
+  }
+
+  const handleClose = () => {
+  setIsOpen(false);
+  setSelectedIcon(null);
+  setSelectedIconLabel('');
+  } 
+
   const allIcons = Object.keys(FiligranIcon).filter((key) => key !== 'default')
+
+  const filteredIcons = useMemo(() => {
+    return allIcons.filter(icon => 
+      icon.toLowerCase().includes(searchTerm.toLowerCase())
+    );
+  }, [allIcons, searchTerm]);
   const getIcon = (icon: string) => {
     // @ts-ignore
-    const Icon = FiligranIcon[icon]
-    return <Icon className="h-16 w-16" />
+    const Icon = FiligranIcon[icon]  as React.ComponentType<any>;
+    return <Icon className="h-16 w-16 hover:border-[1px] border-blue rounded-lg"  onClick={() => handleIconClick(Icon,icon)} />
   }
   return (
+    <div className='container'>
+    <SearchBar 
+    value={searchTerm}
+    onChange={setSearchTerm}
+    placeholder="Search Filigran icons..."
+      />
     <div className="grid grid-cols-[repeat(auto-fill,_100px)] gap-4">
-      {allIcons.map((icon) => (
+      {filteredIcons.map((icon) => (
         <div
           className="flex flex-col items-center"
           key={icon}>
@@ -18,6 +50,8 @@ export const DisplayAllIcons = () => {
           <label className="text-xs">{icon}</label>
         </div>
       ))}
+    </div>
+    {isOpen && <Popup icon={selectedIcon} iconName={selectedIconLabel} onClose={handleClose} />}
     </div>
   )
 }

--- a/projects/filigran-website/components/icon-popup.tsx
+++ b/projects/filigran-website/components/icon-popup.tsx
@@ -1,0 +1,72 @@
+import React, { FC, ReactElement, useState } from 'react';
+
+interface PopupProps {
+    icon: ReactElement | null;
+    iconName: string;
+    onClose: () => void;
+}
+
+const Popup: FC<PopupProps> = ({ icon, iconName, onClose }) => {
+    const [copySuccess, setCopySuccess] = useState(false);
+
+    const handleCopy = () => {
+        const statement = `import { ${iconName} } from '@filigran-ui';`;
+        navigator.clipboard.writeText(statement)
+            .then(() => {
+                setCopySuccess(true);
+                setTimeout(() => setCopySuccess(false), 2000);
+            })
+            .catch(err => console.error('Failed to copy:', err));
+    };
+
+    if (!icon) return null;
+
+    const handleBackgroundClick = (e: React.MouseEvent<HTMLDivElement>) => {
+        if (e.target === e.currentTarget) {
+            onClose();
+        }
+    };
+
+    return (
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black bg-opacity-50" onClick={handleBackgroundClick}>
+            <div className="bg-white shadow-lg rounded-lg max-w-lg w-full" onClick={(e) => e.stopPropagation()}>
+                <div className="p-6">
+                    <div className="relative mb-6">
+                        <div className="bg-gray-900 rounded-md p-4 font-mono text-sm overflow-x-auto">
+                            <span className="text-blue-400">import </span>
+                            <span className="text-purple-400">{'{ '}</span>
+                            <span className="text-white font-semibold">{iconName}</span>
+                            <span className="text-purple-400">{' }'}</span>
+                            <span className="text-blue-400"> from </span>
+                            <span className="text-green-400">'@filigran-icon'</span>
+                            <span className="text-blue-400">;</span>
+                        </div>
+                        <button 
+                            onClick={handleCopy}
+                            className={`absolute top-2 right-2 px-3 py-1 text-sm font-medium rounded-md transition-colors duration-200 ease-in-out ${
+                                copySuccess 
+                                    ? 'bg-green-500 text-white' 
+                                    : 'bg-blue-500 text-white hover:bg-blue-600'
+                            }`}
+                        >
+                            {copySuccess ? 'Copied!' : 'Copy'}
+                        </button>
+                    </div>
+                    <div className='flex items-center justify-center mb-6 max-w-30 max-h-30'>
+                        {icon}
+                    </div>
+                    <div className="flex justify-end">
+                        <button 
+                            onClick={onClose} 
+                            className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+                        >
+                            Close
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default Popup;

--- a/projects/filigran-website/components/icon-searchbar.tsx
+++ b/projects/filigran-website/components/icon-searchbar.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+interface SearchBarProps {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+}
+
+const SearchBar: React.FC<SearchBarProps> = ({ value, onChange, placeholder = 'Search icons...' }) => {
+  return (
+    <div className="relative w-full max-w-md mx-auto mb-6">
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        className="w-full pl-10 pr-4 py-2 text-gray-700 bg-white border border-gray-300 rounded-full focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+      />
+      <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+        <svg className="h-5 w-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor">
+          <path fillRule="evenodd" d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z" clipRule="evenodd" />
+        </svg>
+      </div>
+    </div>
+  );
+};
+
+export default SearchBar;


### PR DESCRIPTION
**Summary**
  This pull request adds Searchbar and Code usage for icons.

**Changes Made**

> Added searchbar component to search icons.

> Added popup component to show code usage like MUI [](https://mui.com/material-ui/material-icons/?selected=AddCircleOutline).

**Screenshots**
![image](https://github.com/user-attachments/assets/b2d2b0c9-7bf0-4c80-bc31-a951ef7b175b)

<img width="1503" alt="image" src="https://github.com/user-attachments/assets/32c0ad14-f8d6-433b-b525-2c4db25379d9">


Please review the implementation and provide feedback on the design and functionality. Suggestions for improvement are welcome!

