### PR TITLE
[filigran-ui] - (sheet): Adapt sheet to forbid closing

### DIFF
--- a/packages/filigran-ui/src/components/clients/sheet.tsx
+++ b/packages/filigran-ui/src/components/clients/sheet.tsx
@@ -17,8 +17,10 @@ const SheetPortal = SheetPrimitive.Portal
 
 const SheetOverlay = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Overlay>,
-  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>
->(({className, ...props}, ref) => (
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay> & {
+    closeOnClickOutside?: boolean
+  }
+>(({className, closeOnClickOutside = true, ...props}, ref) => (
   <SheetPrimitive.Overlay
     className={cn(
       'fixed inset-0 z-50 bg-gray-900/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
@@ -26,6 +28,11 @@ const SheetOverlay = React.forwardRef<
     )}
     {...props}
     ref={ref}
+    onPointerDown={(event) => {
+      if (!closeOnClickOutside) {
+        event.stopPropagation()
+      }
+    }}
   />
 ))
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
@@ -56,30 +63,37 @@ interface SheetContentProps
 const SheetContent = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Content>,
   SheetContentProps
->(({side = 'right', className, children, ...props}, ref) => (
-  <SheetPortal>
-    <SheetOverlay />
-    <SheetPrimitive.Content
-      ref={ref}
-      className={cn(sheetVariants({side}), className)}
-      {...props}>
-      <div className="max-h-full h-full min-h-full overflow-auto px-xl pt-xl">
-        {children}
-      </div>
-      <SheetPrimitive.Close asChild>
-        <div className="absolute left-3 top-0 flex h-16 items-center">
-          <Button
-            variant="ghost"
-            size="icon"
-            className="text-primary hover:bg-hover/50 focus:bg-hover/50">
-            <CloseIcon className="h-3 w-3" />
-            <span className="sr-only">Close</span>
-          </Button>
+>(
+  (
+    {side = 'right', className, children, closeOnClickOutside = true, ...props},
+    ref
+  ) => (
+    <SheetPortal>
+      <SheetOverlay closeOnClickOutside={closeOnClickOutside} />
+      <SheetPrimitive.Content
+        ref={ref}
+        className={cn(sheetVariants({side}), className)}
+        {...props}>
+        <div className="max-h-full h-full min-h-full overflow-auto px-xl pt-xl">
+          {children}
         </div>
-      </SheetPrimitive.Close>
-    </SheetPrimitive.Content>
-  </SheetPortal>
-))
+        {closeOnClickOutside && (
+          <SheetPrimitive.Close asChild>
+            <div className="absolute left-3 top-0 flex h-16 items-center">
+              <Button
+                variant="ghost"
+                size="icon"
+                className="text-primary hover:bg-hover/50 focus:bg-hover/50">
+                <CloseIcon className="h-3 w-3" />
+                <span className="sr-only">Close</span>
+              </Button>
+            </div>
+          </SheetPrimitive.Close>
+        )}
+      </SheetPrimitive.Content>
+    </SheetPortal>
+  )
+)
 SheetContent.displayName = SheetPrimitive.Content.displayName
 
 const SheetHeader = ({

--- a/projects/filigran-website/components/example/example-sheet.tsx
+++ b/projects/filigran-website/components/example/example-sheet.tsx
@@ -89,7 +89,7 @@ export const ExampleSheet = () => {
       <SheetTrigger asChild>
         <Button>Profile</Button>
       </SheetTrigger>
-      <SheetContent>
+      <SheetContent closeOnClickOutside={false}>
         <SheetHeader>
           <SheetTitle>Profile</SheetTitle>
           <SheetDescription>

--- a/projects/filigran-website/content/docs/components/sheet.mdx
+++ b/projects/filigran-website/content/docs/components/sheet.mdx
@@ -9,16 +9,17 @@ title: Sheet
 ## How to use this sheet
 ### Props
 
-| Name               | Type                                            | Default     | Description                                                                                                                        |
-| -------------      | --------                                        | ----------- | ----------------------------------------------------------------------------------------------------------------------------       |
-| **asChild**        | *boolean*                                       | false       | Change the default rendered element for the one passed as a child, merging their props and behavior.                               |
-| **defaultChecked** | *boolean \| "indeterminate"*                    | -           | The checked state of the checkbox when it is initially rendered. Use when you do not need to control its checked state.            |
-| **checked**        | *boolean \| "indeterminate"*                    | -           | The controlled checked state of the checkbox. Must be used in conjunction with onCheckedChange.                                    |
-| **onCheckedChange**| *(checked: boolean \| 'indeterminate') => void* | -           | Event handler called when the checked state of the checkbox changes.                                                               |
-| **disabled**       | *boolean*                                       | -           | When true, prevents the user from interacting with the checkbox.                                                                   |
-| **required**       | *boolean*                                       | -           | When true, indicates that the user must check the checkbox before the owning form can be submitted.                                |
-| **name**           | *string*                                        | -           | The name of the checkbox. Submitted with its owning form as part of a name/value pair.                                             |
-| **value**          | *string*                                        | -           | The value given as data when submitted with a name.                                                                                |
+| Name                    | Type                                            | Default     | Description                                                                                                                        |
+| -------------           | --------                                        | ----------- | ----------------------------------------------------------------------------------------------------------------------------       |
+| **asChild**             | *boolean*                                       | false       | Change the default rendered element for the one passed as a child, merging their props and behavior.                               |
+| **defaultChecked**      | *boolean \| "indeterminate"*                    | -           | The checked state of the checkbox when it is initially rendered. Use when you do not need to control its checked state.            |
+| **checked**             | *boolean \| "indeterminate"*                    | -           | The controlled checked state of the checkbox. Must be used in conjunction with onCheckedChange.                                    |
+| **onCheckedChange**     | *(checked: boolean \| 'indeterminate') => void* | -           | Event handler called when the checked state of the checkbox changes.                                                               |
+| **disabled**            | *boolean*                                       | -           | When true, prevents the user from interacting with the checkbox.                                                                   |
+| **required**            | *boolean*                                       | -           | When true, indicates that the user must check the checkbox before the owning form can be submitted.                                |
+| **name**                | *string*                                        | -           | The name of the checkbox. Submitted with its owning form as part of a name/value pair.                                             |
+| **value**               | *string*                                        | -           | The value given as data when submitted with a name.                                                                                |
+| **closeOnClickOutside** | *boolean*                                       | true        | When true, allow user to quit the sheet by clicking elsewhere                                                                                |
 
 ### Playground
 *Import from filigran-ui :*


### PR DESCRIPTION
By adding a closeOnClickOutside params with "false" value, we can forbid the user to close the sheet by clicking on the close-cross/elsewhere. 

By default, closeOnClickOutside  is true, just like before this PR

https://www.loom.com/share/d9256ddcc574482a81b6005b41d0825a?sid=eb196ebf-652d-4367-ba90-d73f5932e4bf