### PR TITLE
[filigran-ui] fix(MultiSelect): adapt size of popover to long options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.idea/
 /yarn-error.log
 *~
+ui-library.iml

--- a/packages/filigran-ui/src/components/clients/multi-select.tsx
+++ b/packages/filigran-ui/src/components/clients/multi-select.tsx
@@ -181,7 +181,7 @@ const MultiSelectFormField = React.forwardRef<
           </Button>
         </PopoverTrigger>
         <PopoverContent
-          className="w-[200px] p-0 drop-shadow-sm"
+          className="w-auto p-0 drop-shadow-sm"
           align="start"
           onEscapeKeyDown={() => setIsPopoverOpen(false)}>
           <Command>


### PR DESCRIPTION
# Update

Fix the issue where the multiselect option is hidden when it's too long to be displayed, by adapting the popover size to the content size.

## Before

<img width="284" alt="Capture d’écran 2025-06-06 à 10 33 06" src="https://github.com/user-attachments/assets/212d3bc0-8487-4856-8b0e-7c2226652f19" />

## After

<img width="346" alt="Capture d’écran 2025-06-06 à 10 33 26" src="https://github.com/user-attachments/assets/2b3ffde9-6df2-4c9c-89ba-1ffa04fb64dc" />