### PR TITLE
[filigran-ui]Update multiselect to save less space on the right

### DIFF
--- a/packages/filigran-ui/src/components/clients/multi-select.tsx
+++ b/packages/filigran-ui/src/components/clients/multi-select.tsx
@@ -98,7 +98,8 @@ const MultiSelectFormField = React.forwardRef<
 
       const container = badgesContainerRef.current
       const measurementContainer = measurementRef.current
-      const containerWidth = container.offsetWidth - 100 // Save space for controls
+
+      const containerWidth = container.offsetWidth - 10 // Save space for controls
 
       let totalWidth = 0
       let lastVisibleIndex = 0


### PR DESCRIPTION
Update multiselect to save less space on the right

better:
![image](https://github.com/user-attachments/assets/e1d5b88f-d92e-4baa-8ec1-298d946fdb67)
