### PR TITLE
[filigran-ui] - Improve switch design

### DIFF
--- a/packages/filigran-ui/src/components/clients/switch.tsx
+++ b/packages/filigran-ui/src/components/clients/switch.tsx
@@ -10,14 +10,53 @@ const Switch = React.forwardRef<
 >(({className, ...props}, ref) => (
   <SwitchPrimitives.Root
     className={cn(
-      'peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input',
+      'group peer inline-flex h-4 w-11 shrink-0 cursor-pointer items-center rounded-full transition-colors',
+
+      // OFF
+      'bg-gray/50',
+
+      // ON
+      'data-[state=checked]:bg-primary/50',
+
+      // disabled
+      'data-[disabled]:cursor-not-allowed',
+      'data-[disabled]:bg-gray-300',
+
       className
     )}
     {...props}
-    ref={ref}>
+    ref={ref}
+  >
     <SwitchPrimitives.Thumb
       className={cn(
-        'pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0'
+        'pointer-events-none block h-5 w-5 rounded-full shadow-md transition-all',
+
+        'translate-x-0 data-[state=checked]:translate-x-6',
+
+        'bg-gray',
+
+        'data-[state=checked]:bg-primary',
+
+        // disabled
+        'group-data-[disabled]:!bg-gray-500',
+
+        // halo
+        'before:absolute before:inset-0 before:rounded-full before:scale-0 before:opacity-0 before:transition-all',
+        'before:bg-primary/20',
+        'group-focus-visible:before:scale-[2.5]',
+        'group-focus-visible:before:opacity-100',
+
+        'after:absolute after:inset-0 after:rounded-full',
+        'after:scale-0 after:opacity-0',
+        'after:bg-primary/30',
+        'after:transition-all',
+        'group-active:after:scale-[2.5]',
+        'group-active:after:opacity-100',
+
+        'group-hover:before:scale-[2]',
+        'group-hover:before:opacity-100',
+        'group-hover:before:scale-[2]',
+        'group-hover:before:opacity-100',
       )}
     />
   </SwitchPrimitives.Root>

--- a/projects/filigran-website/content/docs/components/switch.mdx
+++ b/projects/filigran-website/content/docs/components/switch.mdx
@@ -1,0 +1,59 @@
+---
+title: Switch
+---
+
+# Switch example
+
+Displays a switch that can be clicked.
+
+
+         <div className="flex items-center gap-m">
+              <Switch id="notifications" checked={showFinished} onCheckedChange={onShowFinishedChange}/>
+              <label htmlFor="notifications" className="cursor-pointer">
+                This is a free switch!
+              </label>
+        </div>
+        <div className="flex items-center gap-m">
+                      <Switch id="notifications" checked onCheckedChange={onShowFinishedChange}/>
+                      <label htmlFor="notifications" className="cursor-pointer">
+                        This is a free switch checked!
+                      </label>
+                </div>
+       <div className="flex items-center gap-m">
+              <Switch id="notifications2"  disabled checked onCheckedChange={onShowFinishedChange}/>
+              <label htmlFor="notifications2" className="cursor-pointer">
+                This is a disabled checked switch!
+              </label>
+        </div>
+       <div className="flex items-center gap-m">
+              <Switch id="notifications3"  disabled onCheckedChange={onShowFinishedChange}/>
+              <label htmlFor="notifications3" className="cursor-pointer">
+                This is a disabled switch!
+              </label>
+        </div>
+
+## How to use this accordion
+
+### Props :
+
+| Name              | Type                                | Default  | Description                                                                                                                                  |
+| ----------------- | ----------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| **asChild**       | _boolean_                           | false    | Change the default rendered element for the one passed as a child, merging their props and behavior.                                         |
+| **checked**       | _boolean_                           | false    | When when checked is true, displays with the primary color and translate the thumb to the right.                                                         |
+| **onCheckedChange**| _() => void_                       | _        | Function called on click.                                                         |
+| **disabled**      | _boolean_                           | false    | When true, prevents the user from interacting with the accordion and all its items.                                                          |
+
+### Playground
+
+Import from @filigran/ui :
+
+Import \{Switch\} from '@filigran/ui'
+
+<ReactLiveDisplay
+  codeExample={`
+
+  <Switch
+          checked={isChecked}
+          onCheckedChange={onCheckChange}
+        />`}
+/>


### PR DESCRIPTION
This PR improve Filigran-UI Switch to fit with other product's switch : 
<img width="347" height="344" alt="image" src="https://github.com/user-attachments/assets/2cea3d15-01e4-4a08-8613-c905d2f95597" />. 
Design validated by @elisavaldegas 
