### PR TITLE
[filigran-ui] - (multi-select): Fix mouse wheel scroll inside popover

### DIFF
--- a/packages/filigran-ui/src/components/clients/multi-select.tsx
+++ b/packages/filigran-ui/src/components/clients/multi-select.tsx
@@ -319,7 +319,11 @@ const MultiSelectFormField = React.forwardRef<
                 placeholder="Search..."
                 onKeyDown={handleInputKeyDown}
               />
-              <CommandList>
+              <CommandList
+                onWheel={(e) => {
+                  e.currentTarget.scrollTop += e.deltaY;
+                  e.stopPropagation();
+                }}>
                 <CommandEmpty>{noResultString}</CommandEmpty>
                 <CommandGroup>
                   {options.map((option) => {


### PR DESCRIPTION
## Context
When `MultiSelectFormField` is used inside a Radix `Sheet` or `Dialog`, mouse wheel and trackpad scroll inside the options list is blocked. Users can only navigate using keyboard arrows or by typing to filter.

This bug is reproducible in XTM Hub on several creation drawers (RSS Feed, Scenario, Dashboard, Integration). See [xtm-hub#2132](https://github.com/FiligranHQ/xtm-hub/issues/2132).

## Root cause
The `wheel` event is intercepted in the `Sheet > Popover > cmdk` component chain. Radix modal layers combined with cmdk's pointer-event management prevent the native browser scroll from reaching the `CommandList` container.

CSS is correct (`max-h-[300px]` and `overflow-y-auto` are applied) — the container is technically scrollable, but the event is swallowed before reaching it.

## Fix
Add an `onWheel` handler on `CommandList` that manually applies the scroll and stops event propagation. This bypasses the interception while preserving all existing behaviors.

[Capture vidéo du 2026-04-16 15-27-17.webm](https://github.com/user-attachments/assets/48b1d667-ebb2-4ecd-a44c-14b180dc508d)


## Alternatives considered
- Setting `modal={false}` on the internal `Popover`: fixes the symptom but removes the focus trap, degrading keyboard accessibility.
- Exposing a `modal` prop on `MultiSelectFormField`: shifts responsibility to consumers — easy to forget, fragile long-term.

The `onWheel` approach was preferred because it fixes the issue globally with zero API change and no accessibility trade-off.

## Tested
- Mouse wheel scroll works inside the popover
- Trackpad scroll works
- Keyboard arrow navigation still works
- Option selection still works
- Scroll chaining prevented (drawer behind doesn't scroll at list boundaries)