### PR TITLE
[filigran-ui] - (multi-select): Fix button nesting in PopoverTrigger

### DIFF
--- a/packages/filigran-ui/src/components/clients/multi-select.tsx
+++ b/packages/filigran-ui/src/components/clients/multi-select.tsx
@@ -275,18 +275,28 @@ const MultiSelectFormField = React.forwardRef<
                     )}
                   </div>
                   <div className="flex items-center shrink-0">
-                    <button
-                      type="button"
+                    <span
+                      role="button"
+                      tabIndex={0}
                       className="flex items-center justify-center"
                       onClick={(event) => {
+                        event.stopPropagation()
                         setSelectedValues([])
                         selectedValuesSet.current.clear()
                         onValueChange([])
-                        event.stopPropagation()
+                      }}
+                      onKeyDown={(event) => {
+                        if (event.key === 'Enter' || event.key === ' ') {
+                          event.preventDefault()
+                          event.stopPropagation()
+                          setSelectedValues([])
+                          selectedValuesSet.current.clear()
+                          onValueChange([])
+                        }
                       }}
                       aria-label="Clear all selections">
                       <CloseIcon className="mx-s h-3 cursor-pointer text-muted-foreground" />
-                    </button>
+                    </span>
                     <Separator
                       orientation="vertical"
                       className="h-6"


### PR DESCRIPTION
## Context
React warns `<button> cannot be a descendant of <button>` when `MultiSelectFormField` is used inside a form (particularly in a Sheet/Drawer context). See [xtm-hub#1748](https://github.com/FiligranHQ/xtm-hub/issues/1748).

## Root cause
The "Clear all selections" action inside the `PopoverTrigger` was rendered as a `<button>`, nested inside the trigger's `<Button>` component (which also renders a `<button>`). This is invalid HTML and causes hydration errors in SSR contexts.

## Fix
Replace the inner `<button>` with a `<span role="button" tabIndex={0}>` with proper ARIA attributes and keyboard handling (Enter/Space activation). This follows the existing pattern used for badge removal in the same component.

Accessibility preserved:
- `role="button"` for screen readers
- `tabIndex={0}` for keyboard focusability
- `onKeyDown` handler for Enter and Space activation
- `aria-label` retained

## Ref
- Internal doc: [Issue on dropdown/drawer](https://www.notion.so/filigran/Issue-on-dropdown-drawer-2858fce17f2a80bab052dea0764c8194)