### PR TITLE
[filigran-ui] - Add radio button style

### DIFF
--- a/packages/filigran-ui/src/components/auto-form/fields/radio-group.tsx
+++ b/packages/filigran-ui/src/components/auto-form/fields/radio-group.tsx
@@ -1,5 +1,11 @@
-import {FormControl, FormItem, FormLabel, FormMessage} from '../../clients'
-import {RadioGroup, RadioGroupItem} from '../../clients/radio-group'
+import {
+  FormControl,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  RadioGroup,
+  RadioGroupItem,
+} from '../../clients'
 import AutoFormLabel from '../common/label'
 import AutoFormTooltip from '../common/tooltip'
 import type {AutoFormInputComponentProps} from '../types'
@@ -18,14 +24,20 @@ export default function AutoFormRadioGroup({
 
   if (baseSchema) {
     const def = (baseSchema as any)._def
+    const enumValues = def.entries ?? def.values
+    const isEnumType =
+      def.type === 'enum' ||
+      def.type === 'nativeEnum' ||
+      def.typeName === 'enum' ||
+      def.typeName === 'nativeEnum'
 
-    if (def.typeName === 'enum' && def.values) {
-      const baseValues = def.values
-
-      if (!Array.isArray(baseValues)) {
-        values = Object.entries(baseValues).map(([key, value]) => key)
+    if (isEnumType && enumValues) {
+      if (Array.isArray(enumValues)) {
+        values = enumValues
       } else {
-        values = baseValues
+        values = Object.values(enumValues)
+          .filter((value) => typeof value === 'string')
+          .filter((value, index, array) => array.indexOf(value) === index)
       }
     }
   }
@@ -41,15 +53,16 @@ export default function AutoFormRadioGroup({
           <RadioGroup
             onValueChange={field.onChange}
             defaultValue={field.value}
+            className="flex flex-wrap items-center gap-x-6 gap-y-2"
             {...fieldProps}>
             {values?.map((value: any) => (
               <FormItem
                 key={value}
-                className="mb-2 flex items-center gap-3 space-y-0">
+                className="flex flex-row items-center gap-3 space-y-0">
                 <FormControl>
                   <RadioGroupItem value={value} />
                 </FormControl>
-                <FormLabel className="font-normal">{value}</FormLabel>
+                <FormLabel className="cursor-pointer font-normal">{value}</FormLabel>
               </FormItem>
             ))}
           </RadioGroup>

--- a/packages/filigran-ui/src/components/clients/radio-group.tsx
+++ b/packages/filigran-ui/src/components/clients/radio-group.tsx
@@ -3,7 +3,6 @@
 import * as RadioGroupPrimitive from '@radix-ui/react-radio-group'
 import * as React from 'react'
 import {cn} from '../../lib/utils'
-import {CircleIcon} from '@filigran/icon'
 
 const RadioGroup = React.forwardRef<
   React.ElementRef<typeof RadioGroupPrimitive.Root>,
@@ -27,12 +26,14 @@ const RadioGroupItem = React.forwardRef<
     <RadioGroupPrimitive.Item
       ref={ref}
       className={cn(
-        'aspect-square h-4 w-4 rounded-full border border-primary text-primary ring-offset-background focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+        'relative flex h-5 w-5 cursor-pointer items-center justify-center rounded-full border-2 border-muted-foreground/60 text-primary ring-offset-background transition-colors before:absolute before:-inset-2 before:rounded-full before:bg-current before:opacity-0 before:transition-opacity hover:before:opacity-10 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 data-[state=checked]:border-primary disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:before:opacity-0',
         className
       )}
       {...props}>
-      <RadioGroupPrimitive.Indicator className="flex items-center justify-center">
-        <CircleIcon className="h-2.5 w-2.5 fill-current text-current" />
+      <RadioGroupPrimitive.Indicator
+        forceMount
+        className="flex items-center justify-center transition-all duration-150 ease-out data-[state=checked]:scale-100 data-[state=checked]:opacity-100 data-[state=unchecked]:scale-0 data-[state=unchecked]:opacity-0">
+        <span className="h-2.5 w-2.5 origin-center rounded-full bg-current" />
       </RadioGroupPrimitive.Indicator>
     </RadioGroupPrimitive.Item>
   )

--- a/projects/filigran-website/components/autoform/autoform-test.tsx
+++ b/projects/filigran-website/components/autoform/autoform-test.tsx
@@ -179,6 +179,9 @@ export const AutoFormTest = () => {
             // Booleans use a checkbox by default, you can use a switch instead
             fieldType: 'switch',
           },
+          color: {
+            fieldType: 'radio',
+          },
           document: {
             label: 'Add a file',
             fieldType: 'file',


### PR DESCRIPTION
This PR adds the radio button on the OpenCTI design : 
<img width="295" height="124" alt="image" src="https://github.com/user-attachments/assets/f3b01100-2403-4993-bb6a-d7f8fe335cb8" />

It enable XTM Hub team to use it :) 