### PR TITLE
[@filigran/ui] Strip required attribute from AutoForm file field

### DIFF
--- a/packages/filigran-ui/src/components/auto-form/fields/file.tsx
+++ b/packages/filigran-ui/src/components/auto-form/fields/file.tsx
@@ -8,7 +8,11 @@ export default function AutoFormFile({
   fieldConfigItem,
   fieldProps,
 }: AutoFormInputComponentProps) {
-  const {showLabel: _showLabel, ...fieldPropsWithoutShowLabel} = fieldProps
+  const {
+    showLabel: _showLabel,
+    required: _required,
+    ...fieldPropsWithoutShowLabel
+  } = fieldProps
   const showLabel = _showLabel === undefined ? true : _showLabel
 
   return (


### PR DESCRIPTION
Context
Investigation traced from XTM Hub issue FiligranHQ/xtm-hub#2298 where 8 resource creation forms silently failed validation when the file field was empty.
Root cause
AutoFormObject derives required: true from non-optional Zod fields and spreads it onto FileInput, producing <input type="file" required class="hidden">. HTML5 pre-validation cannot focus a hidden required input and cancels the submit silently before react-hook-form runs — so Zod never evaluates and no <FormMessage /> is displayed.
Console signature: An invalid form control with name='X' is not focusable.
Fix
Strip required from the fieldProps spread in fields/file.tsx. The label asterisk is preserved via isRequired (a separate prop), and Zod validation now works as expected through FormMessage.
Alternatives considered
Adding noValidate on the <form> in auto-form.tsx would fix the underlying HTML5/resolver duplication globally (recommended pattern from RHF docs when using a resolver), but changes default behaviour for all AutoForm consumers. Worth a separate discussion.
Testing
Built locally with yarn build and replaced the dist/ in xtm-hub's node_modules/@filigran/ui/dist/. Validated end-to-end on multiple resource creation forms (CSV Feed, Custom Dashboard) — both now display Zod error messages on empty submit, and the is not focusable console warning is gone.

