### PR TITLE
Change primary button ui when disabled

### DIFF
--- a/packages/filigran-ui/src/components/servers/button.tsx
+++ b/packages/filigran-ui/src/components/servers/button.tsx
@@ -7,7 +7,8 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default: 'bg-primary text-primary-foreground hover:bg-primary/75 focus-visible:ring-primary/50',
+        default:
+          'bg-primary text-primary-foreground hover:bg-primary/75 focus-visible:ring-primary/50 disabled:bg-ds-bg-disabled disabled:text-text disabled:opacity-100',
         destructive:
           'bg-destructive text-destructive-foreground hover:bg-destructive/75 focus-visible:ring-destructive/50',
         outline: 'border border-border-medium bg-transparent hover:bg-hover',
@@ -42,7 +43,6 @@ const buttonVariants = cva(
     },
   }
 )
-
 
 import {cn} from '../../lib/utils'
 


### PR DESCRIPTION
For the Playbooks library in hub, it has been asked to change the disabled UI only for primary buttons 
https://www.figma.com/design/Gpp4y1YOpvJ6ZCuez3tgzO/DS_Design_System-WIP?node-id=137-423&t=VMuQihMIJEuHlN4u-0
BEFORE:
<img width="190" height="84" alt="Capture d’écran 2026-05-22 à 10 31 16" src="https://github.com/user-attachments/assets/13ed1080-1295-42e4-8681-13ac04d21452" />



AFTER:
<img width="190" height="97" alt="Capture d’écran 2026-05-22 à 10 30 28" src="https://github.com/user-attachments/assets/5266b168-1d32-4a70-a4d7-8e230a33d34a" />
