### PR TITLE
feat(chatbot): render agent-generated file attachments + strip [[FILE:]] markers (#277)

### DIFF
--- a/packages/filigran-chatbot/README.md
+++ b/packages/filigran-chatbot/README.md
@@ -7,6 +7,7 @@ Filigran chat panel — a standalone React + Tailwind chatbot component with SSE
 - 🔄 **SSE Message Streaming** — Real-time response streaming with status indicators
 - 🤖 **Multi-Agent Support** — Switch between different AI agents
 - 📎 **File Attachments** — Upload and paste files (PDF, TXT, images)
+- 📥 **Agent-Generated Files** — Renders downloadable file cards from agent output and strips the `[[FILE:id]]` markers from the prose
 - 📝 **Full Markdown** — Tables, code blocks with copy button, lists, blockquotes
 - 🎨 **Customizable Theme** — Accent color and logo customization
 - 📱 **3 Display Modes** — Floating, sidebar (resizable), and fullscreen
@@ -184,6 +185,29 @@ data: {"type": "stream", "content": "today is sunny."}
 data: {"type": "done", "content": "The weather today is sunny.", "conversation_id": "new-uuid", "tool_names": ["search_web"], "tool_call_count": 1, "iterations": 1}
 ```
 
+#### Agent-generated file attachments
+
+When an agent produces a downloadable file, the `done` event carries an `attachments` array and the streamed prose embeds `[[FILE:<file_id>]]` markers. The component strips those markers and renders a download card per attachment:
+
+```json
+{
+  "type": "done",
+  "content": "Here is your export. [[FILE:0f3a...]]",
+  "conversation_id": "uuid",
+  "attachments": [
+    { "file_id": "0f3a...", "filename": "iocs.csv", "type": "csv", "size": 2048, "content_type": "text/csv", "file_tag": "download_file" }
+  ]
+}
+```
+
+Each attachment carries only `file_id` + display metadata — **never an absolute download URL**. Clicking a card issues:
+
+```
+GET {apiBaseUrl}{apiEndpoints.download ?? '/chat/files'}/{file_id}/download
+```
+
+with `credentials: 'include'` and your `requestHeaders`. Point `apiEndpoints.download` at your **own backend proxy** so the download is authenticated by your platform (the proxy mints any upstream token server-side) — the user never authenticates to the upstream chat service directly. Set `apiEndpoints.download` to `null` to disable download cards.
+
 **Status values:**
 
 - `thinking` — Agent is processing
@@ -261,6 +285,7 @@ function App() {
 - `'Browse agents'`
 - `'Create agent'`
 - `'Reasoning details'`
+- `'Download'`
 - `'tool call'` / `'tool calls'`
 - `'Uses AI. Verify results.'`
 - `'How can I help you, '`

--- a/packages/filigran-chatbot/README.md
+++ b/packages/filigran-chatbot/README.md
@@ -208,6 +208,8 @@ GET {apiBaseUrl}{apiEndpoints.download ?? '/chat/files'}/{file_id}/download
 
 with `credentials: 'include'` and your `requestHeaders`. Point `apiEndpoints.download` at your **own backend proxy** so the download is authenticated by your platform (the proxy mints any upstream token server-side) — the user never authenticates to the upstream chat service directly. Set `apiEndpoints.download` to `null` to disable download cards.
 
+Download failures (403/404/5xx/network) are reported through the optional `onDownloadError(error, attachment)` callback so the host can surface them via its own notification system (the chatbot has no toast surface of its own).
+
 **Status values:**
 
 - `thinking` — Agent is processing

--- a/packages/filigran-chatbot/README.md
+++ b/packages/filigran-chatbot/README.md
@@ -159,6 +159,26 @@ Restores conversation history.
 }
 ```
 
+Assistant history messages **should echo the same `attachments[]` array** that
+was sent on the original `done` event (see [Agent-generated file attachments](#agent-generated-file-attachments)),
+keyed by `file_id`. The component re-surfaces the download cards on restore,
+so omitting them means download cards silently disappear after a page reload
+even though streaming downloads work:
+
+```json
+{
+  "messages": [
+    {
+      "role": "assistant",
+      "content": "Here is your export. [[FILE:0f3a...]]",
+      "attachments": [
+        { "file_id": "0f3a...", "filename": "iocs.csv", "type": "csv", "size": 2048, "content_type": "text/csv", "file_tag": "download_file" }
+      ]
+    }
+  ]
+}
+```
+
 ### `POST {apiBaseUrl}/chat/messages`
 
 Sends a message and streams the response via SSE.

--- a/packages/filigran-chatbot/README.md
+++ b/packages/filigran-chatbot/README.md
@@ -228,6 +228,8 @@ GET {apiBaseUrl}{apiEndpoints.download ?? '/chat/files'}/{file_id}/download
 
 with `credentials: 'include'` and your `requestHeaders`. Point `apiEndpoints.download` at your **own backend proxy** so the download is authenticated by your platform (the proxy mints any upstream token server-side) — the user never authenticates to the upstream chat service directly. Set `apiEndpoints.download` to `null` to disable download cards.
 
+The `/chat/files` default applies to REST-style endpoints. In `singleEndpoint` mode there is no per-path routing, so the default is **not** applied — download cards stay disabled unless you set `apiEndpoints.download` explicitly to a proxy route.
+
 Download failures (403/404/5xx/network) are reported through the optional `onDownloadError(error, attachment)` callback so the host can surface them via its own notification system (the chatbot has no toast surface of its own).
 
 **Status values:**

--- a/packages/filigran-chatbot/package.json
+++ b/packages/filigran-chatbot/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "git+https://github.com/FiligranHQ/filigran-ui.git"
   },
-  "version": "3.2.2",
+  "version": "3.3.0",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/filigran-chatbot/src/components/ChatMessages.tsx
+++ b/packages/filigran-chatbot/src/components/ChatMessages.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import type { AgentStatusState, ChatAttachment, ChatMessage } from '../types';
-import { stripFileMarkers } from '../utils';
+import { splitFileMarkers } from '../utils';
 import { DownloadIcon, FileIcon, InfoIcon } from './icons';
 import { ChatThinking, ThinkingTextBubble } from './ChatThinking';
 import { MarkdownMessage } from './MarkdownMessage';
@@ -32,17 +32,98 @@ export const ChatMessages = ({ messages, isLoading, agentStatus, agentName, logo
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages]);
 
+  const renderAttachmentCard = (att: ChatAttachment, key: string) => {
+    const isWorking = att.fileTag === 'working_file';
+    const sizeLabel = formatFileSize(att.size);
+    return (
+      <button
+        key={key}
+        type="button"
+        onClick={() => onDownloadFile?.(att)}
+        title={t('Download')}
+        className={`group flex items-center gap-2 text-left rounded-lg border px-2.5 py-1.5 transition-colors cursor-pointer max-w-[90%] ${
+          isWorking
+            ? 'border-gray-200 dark:border-white/10 bg-transparent'
+            : 'border-gray-200 dark:border-white/10 bg-gray-50 dark:bg-white/[0.04] hover:border-[var(--chat-accent)] hover:bg-[var(--chat-accent)]/5'
+        }`}
+      >
+        <span className={`shrink-0 ${isWorking ? 'text-gray-400 dark:text-white/40' : 'text-[var(--chat-accent)]'}`}>
+          <FileIcon size={16} />
+        </span>
+        <span className="flex flex-col min-w-0 flex-1">
+          <span className="truncate text-[0.75rem] text-gray-900 dark:text-white">{att.filename}</span>
+          {(att.type || sizeLabel) && (
+            <span className="text-[0.65rem] text-gray-400 dark:text-white/40 uppercase">
+              {[att.type, sizeLabel].filter(Boolean).join(' · ')}
+            </span>
+          )}
+        </span>
+        <span className="shrink-0 text-gray-400 dark:text-white/30 group-hover:text-[var(--chat-accent)]">
+          <DownloadIcon size={15} />
+        </span>
+      </button>
+    );
+  };
+
+  // Render assistant content as an ordered interleave of prose segments and
+  // download cards, so a reply with markers like
+  // `text [[FILE:a]] more text [[FILE:b]]` keeps the cards at their source
+  // position. Cards only render when a download handler is wired
+  // (`onDownloadFile`); attachments whose marker isn't found in the prose are
+  // appended as a fallback. During streaming the attachments aren't hydrated
+  // yet, so only prose (markers stripped) renders.
+  const buildAssistantBlocks = (msg: ChatMessage, loading: boolean): React.ReactNode[] => {
+    const parts = splitFileMarkers(msg.content);
+    const attByFileId = new Map((msg.attachments ?? []).map((a) => [a.fileId, a] as const));
+    const used = new Set<string>();
+    const blocks: React.ReactNode[] = [];
+
+    parts.forEach((part, i) => {
+      if (part.type === 'text') {
+        if (part.value.trim()) {
+          blocks.push(
+            <div key={`t-${i}`} className="max-w-[90%] pl-1 py-1 text-[0.8125rem] leading-7">
+              <MarkdownMessage content={part.value} onRelativeLinkClick={onRelativeLinkClick} />
+            </div>,
+          );
+        }
+      } else if (onDownloadFile) {
+        const att = attByFileId.get(part.fileId);
+        if (att) {
+          used.add(part.fileId);
+          blocks.push(renderAttachmentCard(att, `f-${part.fileId}-${i}`));
+        }
+      }
+    });
+
+    if (onDownloadFile) {
+      (msg.attachments ?? []).forEach((att) => {
+        if (!used.has(att.fileId)) {
+          blocks.push(renderAttachmentCard(att, `orphan-${att.fileId}`));
+        }
+      });
+    }
+
+    // An assistant reply that is *only* a file marker leaves no prose; show a
+    // subtle ellipsis (not an empty padded bubble) when nothing else rendered
+    // and we're not still streaming.
+    if (blocks.length === 0 && !loading) {
+      blocks.push(
+        <span key="empty" className="pl-1 text-[0.8125rem] text-gray-400 dark:text-white/40 italic">
+          ...
+        </span>,
+      );
+    }
+
+    return blocks;
+  };
+
   return (
     <div className="flex-1 overflow-y-auto px-4 py-3 flex flex-col gap-4 filigran-chat-scrollable">
       {messages.map((msg) => {
         const isAssistant = msg.role === 'assistant';
         const isEmpty = !msg.content;
         const isThinking = isAssistant && isEmpty && isLoading;
-        // Strip the [[FILE:<id>]] deliverable markers from assistant prose —
-        // the generated files render as separate download cards below. User
-        // text is never altered.
-        const displayContent = isAssistant ? stripFileMarkers(msg.content) : msg.content;
-        const downloadable = isAssistant ? (msg.attachments ?? []) : [];
 
         if (isThinking) {
           return (
@@ -79,67 +160,16 @@ export const ChatMessages = ({ messages, isLoading, agentStatus, agentName, logo
               </div>
             )}
 
-            <div
-              className={`max-w-[90%] ${
-                isAssistant
-                  ? 'pl-1 py-1 text-[0.8125rem] leading-7'
-                  : 'px-3.5 py-2 rounded-[14px_14px_4px_14px] bg-[var(--chat-accent-dark)] text-white text-[0.8125rem] leading-6'
-              }`}
-            >
-              {isAssistant ? <MarkdownMessage content={displayContent} onRelativeLinkClick={onRelativeLinkClick} /> : msg.content}
-              {isAssistant && isEmpty && !isLoading && <span className="text-[0.8125rem] text-gray-400 dark:text-white/40 italic">...</span>}
-              {isAssistant && !isEmpty && isLoading && (
-                <span className="inline-block w-1.5 h-4 bg-[var(--chat-accent)]/70 rounded-xs ml-0.5 animate-pulse align-text-bottom" />
-              )}
-            </div>
-
-            {/* Only render download cards when a download handler is wired.
-                When the host disables downloads (`apiEndpoints.download = null`)
-                `onDownloadFile` is undefined and we surface no cards at all,
-                rather than non-clickable ones.
-                Not gated on the global `isLoading`: attachments are only
-                hydrated on a message's own `done` event, so a streaming
-                message never has cards anyway — gating on `isLoading` would
-                wrongly hide already-completed cards while a *later* message
-                streams. */}
-            {downloadable.length > 0 && onDownloadFile && (
-              <div className="flex flex-col gap-1.5 mt-1.5 max-w-[90%] w-full">
-                {downloadable.map((att) => {
-                  const isWorking = att.fileTag === 'working_file';
-                  const sizeLabel = formatFileSize(att.size);
-                  return (
-                    <button
-                      key={att.fileId}
-                      type="button"
-                      onClick={() => onDownloadFile(att)}
-                      title={t('Download')}
-                      className={`group flex items-center gap-2 text-left rounded-lg border px-2.5 py-1.5 transition-colors cursor-pointer ${
-                        isWorking
-                          ? 'border-gray-200 dark:border-white/10 bg-transparent'
-                          : 'border-gray-200 dark:border-white/10 bg-gray-50 dark:bg-white/[0.04] hover:border-[var(--chat-accent)] hover:bg-[var(--chat-accent)]/5'
-                      }`}
-                    >
-                      <span
-                        className={`shrink-0 ${
-                          isWorking ? 'text-gray-400 dark:text-white/40' : 'text-[var(--chat-accent)]'
-                        }`}
-                      >
-                        <FileIcon size={16} />
-                      </span>
-                      <span className="flex flex-col min-w-0 flex-1">
-                        <span className="truncate text-[0.75rem] text-gray-900 dark:text-white">{att.filename}</span>
-                        {(att.type || sizeLabel) && (
-                          <span className="text-[0.65rem] text-gray-400 dark:text-white/40 uppercase">
-                            {[att.type, sizeLabel].filter(Boolean).join(' · ')}
-                          </span>
-                        )}
-                      </span>
-                      <span className="shrink-0 text-gray-400 dark:text-white/30 group-hover:text-[var(--chat-accent)]">
-                        <DownloadIcon size={15} />
-                      </span>
-                    </button>
-                  );
-                })}
+            {isAssistant ? (
+              <div className="flex flex-col gap-1.5 w-full items-start">
+                {buildAssistantBlocks(msg, isLoading)}
+                {!isEmpty && isLoading && (
+                  <span className="inline-block w-1.5 h-4 bg-[var(--chat-accent)]/70 rounded-xs ml-1 animate-pulse" />
+                )}
+              </div>
+            ) : (
+              <div className="max-w-[90%] px-3.5 py-2 rounded-[14px_14px_4px_14px] bg-[var(--chat-accent-dark)] text-white text-[0.8125rem] leading-6">
+                {msg.content}
               </div>
             )}
 

--- a/packages/filigran-chatbot/src/components/ChatMessages.tsx
+++ b/packages/filigran-chatbot/src/components/ChatMessages.tsx
@@ -123,12 +123,12 @@ export const ChatMessages = ({ messages, isLoading, agentStatus, agentName, logo
       {messages.map((msg, index) => {
         const isAssistant = msg.role === 'assistant';
         const isEmpty = !msg.content;
-        const isThinking = isAssistant && isEmpty && isLoading;
         // The streaming response is always the last message, so the live
-        // cursor / thinking bubble must be gated on it — otherwise every
-        // previously completed assistant message would also show them while a
-        // *later* response is streaming.
+        // cursor / thinking bubble / ChatThinking state must be gated on it —
+        // otherwise every previously completed assistant message would also
+        // show them while a *later* response is streaming.
         const isStreamingMessage = isLoading && index === messages.length - 1;
+        const isThinking = isAssistant && isEmpty && isStreamingMessage;
 
         if (isThinking) {
           return (

--- a/packages/filigran-chatbot/src/components/ChatMessages.tsx
+++ b/packages/filigran-chatbot/src/components/ChatMessages.tsx
@@ -120,10 +120,15 @@ export const ChatMessages = ({ messages, isLoading, agentStatus, agentName, logo
 
   return (
     <div className="flex-1 overflow-y-auto px-4 py-3 flex flex-col gap-4 filigran-chat-scrollable">
-      {messages.map((msg) => {
+      {messages.map((msg, index) => {
         const isAssistant = msg.role === 'assistant';
         const isEmpty = !msg.content;
         const isThinking = isAssistant && isEmpty && isLoading;
+        // The streaming response is always the last message, so the live
+        // cursor / thinking bubble must be gated on it — otherwise every
+        // previously completed assistant message would also show them while a
+        // *later* response is streaming.
+        const isStreamingMessage = isLoading && index === messages.length - 1;
 
         if (isThinking) {
           return (
@@ -144,7 +149,7 @@ export const ChatMessages = ({ messages, isLoading, agentStatus, agentName, logo
               </div>
             )}
 
-            {isAssistant && !isEmpty && isLoading && agentStatus?.thinkingContent && <ThinkingTextBubble content={agentStatus.thinkingContent} />}
+            {isAssistant && !isEmpty && isStreamingMessage && agentStatus?.thinkingContent && <ThinkingTextBubble content={agentStatus.thinkingContent} />}
 
             {msg.files && msg.files.length > 0 && (
               <div className="flex gap-1.5 flex-wrap mb-1.5">
@@ -162,8 +167,8 @@ export const ChatMessages = ({ messages, isLoading, agentStatus, agentName, logo
 
             {isAssistant ? (
               <div className="flex flex-col gap-1.5 w-full items-start">
-                {buildAssistantBlocks(msg, isLoading)}
-                {!isEmpty && isLoading && (
+                {buildAssistantBlocks(msg, isStreamingMessage)}
+                {!isEmpty && isStreamingMessage && (
                   <span className="inline-block w-1.5 h-4 bg-[var(--chat-accent)]/70 rounded-xs ml-1 animate-pulse" />
                 )}
               </div>

--- a/packages/filigran-chatbot/src/components/ChatMessages.tsx
+++ b/packages/filigran-chatbot/src/components/ChatMessages.tsx
@@ -96,8 +96,13 @@ export const ChatMessages = ({ messages, isLoading, agentStatus, agentName, logo
             {/* Only render download cards when a download handler is wired.
                 When the host disables downloads (`apiEndpoints.download = null`)
                 `onDownloadFile` is undefined and we surface no cards at all,
-                rather than non-clickable ones. */}
-            {downloadable.length > 0 && !isLoading && onDownloadFile && (
+                rather than non-clickable ones.
+                Not gated on the global `isLoading`: attachments are only
+                hydrated on a message's own `done` event, so a streaming
+                message never has cards anyway — gating on `isLoading` would
+                wrongly hide already-completed cards while a *later* message
+                streams. */}
+            {downloadable.length > 0 && onDownloadFile && (
               <div className="flex flex-col gap-1.5 mt-1.5 max-w-[90%] w-full">
                 {downloadable.map((att) => {
                   const isWorking = att.fileTag === 'working_file';

--- a/packages/filigran-chatbot/src/components/ChatMessages.tsx
+++ b/packages/filigran-chatbot/src/components/ChatMessages.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
-import type { AgentStatusState, ChatMessage } from '../types';
-import { FileIcon, InfoIcon } from './icons';
+import type { AgentStatusState, ChatAttachment, ChatMessage } from '../types';
+import { stripFileMarkers } from '../utils';
+import { DownloadIcon, FileIcon, InfoIcon } from './icons';
 import { ChatThinking, ThinkingTextBubble } from './ChatThinking';
 import { MarkdownMessage } from './MarkdownMessage';
 
@@ -11,10 +12,19 @@ interface ChatMessagesProps {
   agentName: string;
   logoIcon: React.ReactNode;
   onRelativeLinkClick?: (href: string) => void;
+  /** Download an agent-generated file via the host app's backend proxy. */
+  onDownloadFile?: (attachment: ChatAttachment) => void;
   t: (key: string) => string;
 }
 
-export const ChatMessages = ({ messages, isLoading, agentStatus, agentName, logoIcon, onRelativeLinkClick, t }: ChatMessagesProps) => {
+function formatFileSize(bytes?: number): string {
+  if (!bytes || bytes <= 0) return '';
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export const ChatMessages = ({ messages, isLoading, agentStatus, agentName, logoIcon, onRelativeLinkClick, onDownloadFile, t }: ChatMessagesProps) => {
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const [toolDetailMsgId, setToolDetailMsgId] = useState<string | null>(null);
 
@@ -28,6 +38,11 @@ export const ChatMessages = ({ messages, isLoading, agentStatus, agentName, logo
         const isAssistant = msg.role === 'assistant';
         const isEmpty = !msg.content;
         const isThinking = isAssistant && isEmpty && isLoading;
+        // Strip the [[FILE:<id>]] deliverable markers from assistant prose —
+        // the generated files render as separate download cards below. User
+        // text is never altered.
+        const displayContent = isAssistant ? stripFileMarkers(msg.content) : msg.content;
+        const downloadable = isAssistant ? (msg.attachments ?? []) : [];
 
         if (isThinking) {
           return (
@@ -71,12 +86,56 @@ export const ChatMessages = ({ messages, isLoading, agentStatus, agentName, logo
                   : 'px-3.5 py-2 rounded-[14px_14px_4px_14px] bg-[var(--chat-accent-dark)] text-white text-[0.8125rem] leading-6'
               }`}
             >
-              {isAssistant ? <MarkdownMessage content={msg.content} onRelativeLinkClick={onRelativeLinkClick} /> : msg.content}
+              {isAssistant ? <MarkdownMessage content={displayContent} onRelativeLinkClick={onRelativeLinkClick} /> : msg.content}
               {isAssistant && isEmpty && !isLoading && <span className="text-[0.8125rem] text-gray-400 dark:text-white/40 italic">...</span>}
               {isAssistant && !isEmpty && isLoading && (
                 <span className="inline-block w-1.5 h-4 bg-[var(--chat-accent)]/70 rounded-xs ml-0.5 animate-pulse align-text-bottom" />
               )}
             </div>
+
+            {downloadable.length > 0 && !isLoading && (
+              <div className="flex flex-col gap-1.5 mt-1.5 max-w-[90%] w-full">
+                {downloadable.map((att) => {
+                  const isWorking = att.fileTag === 'working_file';
+                  const sizeLabel = formatFileSize(att.size);
+                  return (
+                    <button
+                      key={att.fileId}
+                      type="button"
+                      onClick={() => onDownloadFile?.(att)}
+                      disabled={!onDownloadFile}
+                      title={t('Download')}
+                      className={`group flex items-center gap-2 text-left rounded-lg border px-2.5 py-1.5 transition-colors ${
+                        isWorking
+                          ? 'border-gray-200 dark:border-white/10 bg-transparent'
+                          : 'border-gray-200 dark:border-white/10 bg-gray-50 dark:bg-white/[0.04] hover:border-[var(--chat-accent)] hover:bg-[var(--chat-accent)]/5'
+                      } ${onDownloadFile ? 'cursor-pointer' : 'cursor-default'}`}
+                    >
+                      <span
+                        className={`shrink-0 ${
+                          isWorking ? 'text-gray-400 dark:text-white/40' : 'text-[var(--chat-accent)]'
+                        }`}
+                      >
+                        <FileIcon size={16} />
+                      </span>
+                      <span className="flex flex-col min-w-0 flex-1">
+                        <span className="truncate text-[0.75rem] text-gray-900 dark:text-white">{att.filename}</span>
+                        {(att.type || sizeLabel) && (
+                          <span className="text-[0.65rem] text-gray-400 dark:text-white/40 uppercase">
+                            {[att.type, sizeLabel].filter(Boolean).join(' · ')}
+                          </span>
+                        )}
+                      </span>
+                      {onDownloadFile && (
+                        <span className="shrink-0 text-gray-400 dark:text-white/30 group-hover:text-[var(--chat-accent)]">
+                          <DownloadIcon size={15} />
+                        </span>
+                      )}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
 
             {isAssistant && !isEmpty && !isLoading && msg.toolNames && msg.toolNames.length > 0 && (
               <>

--- a/packages/filigran-chatbot/src/components/ChatMessages.tsx
+++ b/packages/filigran-chatbot/src/components/ChatMessages.tsx
@@ -93,7 +93,11 @@ export const ChatMessages = ({ messages, isLoading, agentStatus, agentName, logo
               )}
             </div>
 
-            {downloadable.length > 0 && !isLoading && (
+            {/* Only render download cards when a download handler is wired.
+                When the host disables downloads (`apiEndpoints.download = null`)
+                `onDownloadFile` is undefined and we surface no cards at all,
+                rather than non-clickable ones. */}
+            {downloadable.length > 0 && !isLoading && onDownloadFile && (
               <div className="flex flex-col gap-1.5 mt-1.5 max-w-[90%] w-full">
                 {downloadable.map((att) => {
                   const isWorking = att.fileTag === 'working_file';
@@ -102,14 +106,13 @@ export const ChatMessages = ({ messages, isLoading, agentStatus, agentName, logo
                     <button
                       key={att.fileId}
                       type="button"
-                      onClick={() => onDownloadFile?.(att)}
-                      disabled={!onDownloadFile}
+                      onClick={() => onDownloadFile(att)}
                       title={t('Download')}
-                      className={`group flex items-center gap-2 text-left rounded-lg border px-2.5 py-1.5 transition-colors ${
+                      className={`group flex items-center gap-2 text-left rounded-lg border px-2.5 py-1.5 transition-colors cursor-pointer ${
                         isWorking
                           ? 'border-gray-200 dark:border-white/10 bg-transparent'
                           : 'border-gray-200 dark:border-white/10 bg-gray-50 dark:bg-white/[0.04] hover:border-[var(--chat-accent)] hover:bg-[var(--chat-accent)]/5'
-                      } ${onDownloadFile ? 'cursor-pointer' : 'cursor-default'}`}
+                      }`}
                     >
                       <span
                         className={`shrink-0 ${
@@ -126,11 +129,9 @@ export const ChatMessages = ({ messages, isLoading, agentStatus, agentName, logo
                           </span>
                         )}
                       </span>
-                      {onDownloadFile && (
-                        <span className="shrink-0 text-gray-400 dark:text-white/30 group-hover:text-[var(--chat-accent)]">
-                          <DownloadIcon size={15} />
-                        </span>
-                      )}
+                      <span className="shrink-0 text-gray-400 dark:text-white/30 group-hover:text-[var(--chat-accent)]">
+                        <DownloadIcon size={15} />
+                      </span>
                     </button>
                   );
                 })}

--- a/packages/filigran-chatbot/src/components/ChatPanel.tsx
+++ b/packages/filigran-chatbot/src/components/ChatPanel.tsx
@@ -136,8 +136,17 @@ export const ChatPanel: FunctionComponent<ChatPanelProps> = ({
   // authenticated to the host platform (e.g. OpenCTI / OpenAEV) only and
   // never logs in to the upstream service. Same-origin cookies +
   // requestHeaders (CSRF / draft context) carry the host-app auth.
+  // Downloads need a path to build the URL from. Enabled for the REST
+  // backend unless explicitly disabled (`download === null`). In
+  // single-endpoint mode there is no per-path routing, so a download path
+  // must be provided explicitly (e.g. an OpenCTI-style proxy route);
+  // otherwise the default REST `/chat/files` path is used.
+  const downloadPathProvided =
+    apiEndpoints?.download !== null && apiEndpoints?.download !== undefined;
   const canDownload =
-    backendType === 'rest' && !apiEndpoints?.singleEndpoint && apiEndpoints?.download !== null;
+    backendType === 'rest' &&
+    apiEndpoints?.download !== null &&
+    (!apiEndpoints?.singleEndpoint || downloadPathProvided);
 
   const handleDownloadFile = useCallback(
     async (att: ChatAttachment) => {

--- a/packages/filigran-chatbot/src/components/ChatPanel.tsx
+++ b/packages/filigran-chatbot/src/components/ChatPanel.tsx
@@ -42,6 +42,7 @@ export const ChatPanel: FunctionComponent<ChatPanelProps> = ({
   onResizeEnd,
   disableFileManagement = false,
   onRelativeLinkClick,
+  onDownloadError,
   maxFileCount,
   maxTotalSize,
   requestHeaders,
@@ -168,12 +169,15 @@ export const ChatPanel: FunctionComponent<ChatPanelProps> = ({
         link.click();
         link.remove();
         URL.revokeObjectURL(objectUrl);
-      } catch {
-        // Best-effort: the host app surfaces network/permission errors via
-        // its own console; the lib has no toast surface of its own.
+      } catch (err) {
+        // Surface the failure (403/404/5xx/network) to the host so it can
+        // notify the user — the chatbot has no toast surface of its own.
+        // If the host doesn't provide a handler the error is intentionally
+        // not thrown further (a rejected click handler has nowhere to go).
+        onDownloadError?.(err, att);
       }
     },
-    [apiBaseUrl, apiEndpoints, requestHeaders],
+    [apiBaseUrl, apiEndpoints, requestHeaders, onDownloadError],
   );
 
   const cssVars = {

--- a/packages/filigran-chatbot/src/components/ChatPanel.tsx
+++ b/packages/filigran-chatbot/src/components/ChatPanel.tsx
@@ -1,6 +1,7 @@
-import { type FunctionComponent, useEffect, useState } from 'react';
-import type { ChatMessage, ChatPanelProps } from '../types';
+import { type FunctionComponent, useCallback, useEffect, useState } from 'react';
+import type { ChatAttachment, ChatMessage, ChatPanelProps } from '../types';
 import { hexAlpha, identity } from '../utils';
+import { parseAttachments } from '../hooks/protocols/parseRestEvent';
 import { useChat } from '../hooks/useChat';
 import { useAgents } from '../hooks/useAgents';
 import { useSidebarResize } from '../hooks/useSidebarResize';
@@ -129,6 +130,43 @@ export const ChatPanel: FunctionComponent<ChatPanelProps> = ({
   const firstName = user.firstName;
   const agentName = transferredAgent?.name || selectedAgent?.name || 'Assistant';
 
+  // Download an agent-generated file. The URL is resolved against the host
+  // app's own backend proxy (apiBaseUrl), NOT the upstream chat service:
+  // the proxy mints any upstream token server-side, so the user stays
+  // authenticated to the host platform (e.g. OpenCTI / OpenAEV) only and
+  // never logs in to the upstream service. Same-origin cookies +
+  // requestHeaders (CSRF / draft context) carry the host-app auth.
+  const canDownload =
+    backendType === 'rest' && !apiEndpoints?.singleEndpoint && apiEndpoints?.download !== null;
+
+  const handleDownloadFile = useCallback(
+    async (att: ChatAttachment) => {
+      const base = apiEndpoints?.download ?? '/chat/files';
+      const url = `${apiBaseUrl}${base}/${encodeURIComponent(att.fileId)}/download`;
+      try {
+        const res = await fetch(url, {
+          method: 'GET',
+          credentials: 'include',
+          headers: { ...(requestHeaders ?? {}) },
+        });
+        if (!res.ok) throw new Error(`Download failed: ${res.status}`);
+        const blob = await res.blob();
+        const objectUrl = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = objectUrl;
+        link.download = att.filename || 'download';
+        document.body.appendChild(link);
+        link.click();
+        link.remove();
+        URL.revokeObjectURL(objectUrl);
+      } catch {
+        // Best-effort: the host app surfaces network/permission errors via
+        // its own console; the lib has no toast surface of its own.
+      }
+    },
+    [apiBaseUrl, apiEndpoints, requestHeaders],
+  );
+
   const cssVars = {
     '--chat-accent': accentColor,
     '--chat-accent-10': hexAlpha(accentColor, 0.1),
@@ -167,12 +205,18 @@ export const ChatPanel: FunctionComponent<ChatPanelProps> = ({
       })
       .then((data) => {
         if (!data?.messages?.length) return;
-        const restored: ChatMessage[] = data.messages.map((m: { role: string; content: string }, i: number) => ({
-          id: `restored-${i}`,
-          role: m.role as 'user' | 'assistant',
-          content: m.content,
-          timestamp: new Date(),
-        }));
+        const restored: ChatMessage[] = data.messages.map(
+          (m: { role: string; content: string; attachments?: unknown }, i: number) => ({
+            id: `restored-${i}`,
+            role: m.role as 'user' | 'assistant',
+            content: m.content,
+            timestamp: new Date(),
+            // Re-surface agent-generated download chips on conversation
+            // restore (the [[FILE:…]] markers in content are stripped at
+            // render time by ChatMessages).
+            attachments: m.role === 'assistant' ? parseAttachments(m.attachments) : undefined,
+          }),
+        );
         setMessages(restored);
       })
       .catch(() => {
@@ -247,6 +291,7 @@ export const ChatPanel: FunctionComponent<ChatPanelProps> = ({
           agentName={agentName}
           logoIcon={resolvedLogo}
           onRelativeLinkClick={onRelativeLinkClick}
+          onDownloadFile={canDownload ? handleDownloadFile : undefined}
           t={t}
         />
       )}

--- a/packages/filigran-chatbot/src/components/icons/DownloadIcon.tsx
+++ b/packages/filigran-chatbot/src/components/icons/DownloadIcon.tsx
@@ -1,0 +1,20 @@
+import type { IconProps } from '../../types';
+
+export const DownloadIcon = ({ className, size = 24 }: IconProps) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className}
+  >
+    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+    <polyline points="7 10 12 15 17 10" />
+    <line x1="12" x2="12" y1="15" y2="3" />
+  </svg>
+);

--- a/packages/filigran-chatbot/src/components/icons/index.ts
+++ b/packages/filigran-chatbot/src/components/icons/index.ts
@@ -6,6 +6,7 @@ export * from './CloseIcon';
 export * from './CopyIcon';
 export * from './DatabaseIcon';
 export * from './DefaultLogoIcon';
+export * from './DownloadIcon';
 export * from './EditIcon';
 export * from './ExternalLinkIcon';
 export * from './FileIcon';

--- a/packages/filigran-chatbot/src/hooks/protocols/parseRestEvent.ts
+++ b/packages/filigran-chatbot/src/hooks/protocols/parseRestEvent.ts
@@ -1,4 +1,31 @@
+import type { ChatAttachment } from '../../types';
 import type { ParsedAction, ProtocolContext } from './types';
+
+/**
+ * Normalize the raw `attachments` array from a backend `done` event into
+ * typed {@link ChatAttachment} objects. Defensive: skips non-object entries
+ * and entries without a `file_id`. Returns `undefined` when there is nothing
+ * renderable so the `done` action stays lean for backends without #810.
+ */
+export function parseAttachments(raw: unknown): ChatAttachment[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const out: ChatAttachment[] = [];
+  for (const item of raw) {
+    if (!item || typeof item !== 'object') continue;
+    const a = item as Record<string, unknown>;
+    const fileId = a.file_id;
+    if (typeof fileId !== 'string' || !fileId) continue;
+    out.push({
+      fileId,
+      filename: typeof a.filename === 'string' ? a.filename : 'file',
+      type: typeof a.type === 'string' ? a.type : undefined,
+      size: typeof a.size === 'number' ? a.size : undefined,
+      contentType: typeof a.content_type === 'string' ? a.content_type : undefined,
+      fileTag: a.file_tag === 'working_file' ? 'working_file' : 'download_file',
+    });
+  }
+  return out.length > 0 ? out : undefined;
+}
 
 /**
  * Parse an XTM One (REST) SSE event into a normalized action.
@@ -45,6 +72,7 @@ export function parseRestEvent(evt: Record<string, unknown>, ctx: ProtocolContex
       iterations: evt.iterations as number | undefined,
       transferAgentId: evt.transfer_agent_id as string | undefined,
       transferAgentName: evt.transfer_agent_name as string | undefined,
+      attachments: parseAttachments(evt.attachments),
     };
   }
 

--- a/packages/filigran-chatbot/src/hooks/protocols/types.ts
+++ b/packages/filigran-chatbot/src/hooks/protocols/types.ts
@@ -1,3 +1,5 @@
+import type { ChatAttachment } from '../../types';
+
 /**
  * Normalized action produced by all protocol parsers.
  * The SSE read loop is protocol-agnostic — only the JSON-to-action mapping differs.
@@ -14,6 +16,7 @@ export type ParsedAction =
       iterations?: number;
       transferAgentId?: string;
       transferAgentName?: string;
+      attachments?: ChatAttachment[];
     }
   | { action: 'error'; content: string }
   | { action: 'set_chat_id'; chatId: string }

--- a/packages/filigran-chatbot/src/hooks/useChat.ts
+++ b/packages/filigran-chatbot/src/hooks/useChat.ts
@@ -438,6 +438,7 @@ export function useChat({
                           toolNames: parsed.toolNames,
                           toolCallCount: parsed.toolCallCount,
                           iterations: parsed.iterations,
+                          attachments: parsed.attachments,
                         }
                       : m,
                   ),

--- a/packages/filigran-chatbot/src/index.ts
+++ b/packages/filigran-chatbot/src/index.ts
@@ -1,5 +1,5 @@
 import './assets/index.css';
 
 export { ChatPanel, ChatToggleButton } from './components';
-export type { ChatMode, BackendType, ChatPanelProps, ChatToggleButtonProps, ChatMessage, ChatFile, XtmAgent, ApiEndpoints } from './types';
+export type { ChatMode, BackendType, ChatPanelProps, ChatToggleButtonProps, ChatMessage, ChatAttachment, ChatFile, XtmAgent, ApiEndpoints } from './types';
 export type { TransferredAgent } from './hooks/useChat';

--- a/packages/filigran-chatbot/src/types.ts
+++ b/packages/filigran-chatbot/src/types.ts
@@ -59,6 +59,12 @@ export interface ChatPanelProps {
   disableFileManagement?: boolean;
   /** Called when a relative markdown link is clicked in assistant messages. */
   onRelativeLinkClick?: (href: string) => void;
+  /**
+   * Called when an agent-generated file download fails (non-2xx response or
+   * network error). Lets the host surface the failure through its own
+   * notification system (the chatbot has no toast surface of its own).
+   */
+  onDownloadError?: (error: unknown, attachment: ChatAttachment) => void;
   /** Maximum number of files attachable in one chat context. Default: 10. */
   maxFileCount?: number;
   /** Maximum total size in bytes for attached files. Default: 50 * 1024 * 1024 (50 MB). */

--- a/packages/filigran-chatbot/src/types.ts
+++ b/packages/filigran-chatbot/src/types.ts
@@ -25,6 +25,10 @@ export interface ApiEndpoints {
    * the host platform (e.g. OpenCTI / OpenAEV session) — the proxy mints
    * any upstream token server-side, so the user never authenticates to the
    * upstream chat service directly. Set to null to disable download chips.
+   *
+   * Exception: in `singleEndpoint` mode the `/chat/files` default is NOT
+   * applied (there is no per-path routing), so download cards stay disabled
+   * unless this path is set explicitly to a proxy route.
    */
   download?: string | null;
 }

--- a/packages/filigran-chatbot/src/types.ts
+++ b/packages/filigran-chatbot/src/types.ts
@@ -17,6 +17,16 @@ export interface ApiEndpoints {
   sessions?: string | null;
   /** Path for uploading files. Default: '/chat/upload'. Set to null to disable file uploads. */
   upload?: string | null;
+  /**
+   * Base path for downloading agent-generated files. Default: '/chat/files'.
+   * The download URL is built as
+   * `${apiBaseUrl}${download}/${fileId}/download`, resolved against the
+   * host app's own backend proxy. This keeps the download authenticated by
+   * the host platform (e.g. OpenCTI / OpenAEV session) — the proxy mints
+   * any upstream token server-side, so the user never authenticates to the
+   * upstream chat service directly. Set to null to disable download chips.
+   */
+  download?: string | null;
 }
 
 export interface ChatPanelProps {
@@ -84,9 +94,34 @@ export interface ChatMessage {
   content: string;
   timestamp: Date;
   files?: ChatFile[];
+  /** Agent-generated downloadable files attached to an assistant message. */
+  attachments?: ChatAttachment[];
   toolNames?: string[];
   toolCallCount?: number;
   iterations?: number;
+}
+
+/**
+ * An agent-generated file produced during a chat turn (via the backend
+ * `generate_file` tool / custom-tool `$output_files`). Rendered as a
+ * download card in assistant messages.
+ *
+ * Intentionally carries no absolute URL: the download is resolved against
+ * the host app's backend proxy from `fileId` (see `ApiEndpoints.download`)
+ * so the user stays authenticated to the host platform only.
+ */
+export interface ChatAttachment {
+  fileId: string;
+  filename: string;
+  /** Short extension-style label surfaced under the filename (e.g. "PDF"). */
+  type?: string;
+  size?: number;
+  contentType?: string;
+  /**
+   * `download_file` → prominent download card (user deliverable).
+   * `working_file` → de-emphasized scratch/working artifact chip.
+   */
+  fileTag?: 'download_file' | 'working_file';
 }
 
 export interface AgentStatusState {

--- a/packages/filigran-chatbot/src/utils/index.ts
+++ b/packages/filigran-chatbot/src/utils/index.ts
@@ -24,18 +24,51 @@ const PARTIAL_FILE_MARKER_RE = /\[\[FILE(?::[^\]]*)?\]?$/;
  * generated files. The actual files render as separate download chips, so the
  * raw markers must be removed from the prose. Complete markers are removed
  * anywhere; an incomplete marker at the end is also removed so a partially
- * streamed token never flickers as raw `[[FILE:...` text. Whitespace/blank
- * lines left behind by the removal are collapsed.
+ * streamed token never flickers as raw `[[FILE:...` text.
+ *
+ * When no marker is present the content is returned **untouched** — we must
+ * not trim or collapse blank lines on ordinary prose, which would clobber
+ * intentional leading/trailing whitespace (e.g. indented Markdown / code).
+ * Whitespace is only normalized when a marker was actually removed.
  *
  * Applied to assistant content only — user-typed text is never touched, so a
  * user who literally types `[[FILE:x]]` still sees their own text.
  */
 export function stripFileMarkers(content: string): string {
   if (!content) return content;
-  return content
-    .replace(FILE_MARKER_RE, '')
-    .replace(PARTIAL_FILE_MARKER_RE, '')
+  const stripped = content.replace(FILE_MARKER_RE, '').replace(PARTIAL_FILE_MARKER_RE, '');
+  if (stripped === content) return content;
+  return stripped
     .replace(/[ \t]+\n/g, '\n')
     .replace(/\n{3,}/g, '\n\n')
     .trim();
+}
+
+/** An ordered piece of assistant content: prose text or a file marker. */
+export type FileMarkerPart = { type: 'text'; value: string } | { type: 'file'; fileId: string };
+
+/**
+ * Split assistant content into ordered text/file parts around complete
+ * `[[FILE:<id>]]` markers, so the renderer can place each download card at the
+ * marker's source position (preserving interleaved order). A trailing
+ * incomplete marker (an SSE token split mid-stream) is removed from the final
+ * text part so it never shows as raw `[[FILE:...` text.
+ */
+export function splitFileMarkers(content: string): FileMarkerPart[] {
+  if (!content) return [];
+  const parts: FileMarkerPart[] = [];
+  const re = /\[\[FILE:([^\]]+)\]\]/g;
+  let lastIndex = 0;
+  let match: RegExpExecArray | null = re.exec(content);
+  while (match !== null) {
+    if (match.index > lastIndex) {
+      parts.push({ type: 'text', value: content.slice(lastIndex, match.index) });
+    }
+    parts.push({ type: 'file', fileId: match[1] });
+    lastIndex = re.lastIndex;
+    match = re.exec(content);
+  }
+  const tail = content.slice(lastIndex).replace(PARTIAL_FILE_MARKER_RE, '');
+  if (tail) parts.push({ type: 'text', value: tail });
+  return parts;
 }

--- a/packages/filigran-chatbot/src/utils/index.ts
+++ b/packages/filigran-chatbot/src/utils/index.ts
@@ -7,14 +7,25 @@ export function hexAlpha(hex: string, alpha: number): string {
 
 export const identity = (key: string) => key;
 
-/** Matches the `[[FILE:<id>]]` deliverable markers agents embed in prose. */
+/** Matches a complete `[[FILE:<id>]]` deliverable marker agents embed in prose. */
 const FILE_MARKER_RE = /\[\[FILE:[^\]]+\]\]/g;
+
+/**
+ * Matches an INCOMPLETE marker at the very end of the string. SSE streams can
+ * split a `[[FILE:<id>]]` token before the closing `]]` arrives, so the tail
+ * may be `[[FILE`, `[[FILE:`, `[[FILE:abc`, or `[[FILE:abc]` mid-stream. We
+ * anchor on the literal `[[FILE` prefix (which is vanishingly unlikely to
+ * appear legitimately at the end of prose) so it never clips real content.
+ */
+const PARTIAL_FILE_MARKER_RE = /\[\[FILE(?::[^\]]*)?\]?$/;
 
 /**
  * Strip the `[[FILE:<id>]]` markers an agent embeds in its reply to point at
  * generated files. The actual files render as separate download chips, so the
- * raw markers must be removed from the prose. Whitespace/blank lines left
- * behind by the removal are collapsed.
+ * raw markers must be removed from the prose. Complete markers are removed
+ * anywhere; an incomplete marker at the end is also removed so a partially
+ * streamed token never flickers as raw `[[FILE:...` text. Whitespace/blank
+ * lines left behind by the removal are collapsed.
  *
  * Applied to assistant content only — user-typed text is never touched, so a
  * user who literally types `[[FILE:x]]` still sees their own text.
@@ -23,6 +34,7 @@ export function stripFileMarkers(content: string): string {
   if (!content) return content;
   return content
     .replace(FILE_MARKER_RE, '')
+    .replace(PARTIAL_FILE_MARKER_RE, '')
     .replace(/[ \t]+\n/g, '\n')
     .replace(/\n{3,}/g, '\n\n')
     .trim();

--- a/packages/filigran-chatbot/src/utils/index.ts
+++ b/packages/filigran-chatbot/src/utils/index.ts
@@ -6,3 +6,24 @@ export function hexAlpha(hex: string, alpha: number): string {
 }
 
 export const identity = (key: string) => key;
+
+/** Matches the `[[FILE:<id>]]` deliverable markers agents embed in prose. */
+const FILE_MARKER_RE = /\[\[FILE:[^\]]+\]\]/g;
+
+/**
+ * Strip the `[[FILE:<id>]]` markers an agent embeds in its reply to point at
+ * generated files. The actual files render as separate download chips, so the
+ * raw markers must be removed from the prose. Whitespace/blank lines left
+ * behind by the removal are collapsed.
+ *
+ * Applied to assistant content only — user-typed text is never touched, so a
+ * user who literally types `[[FILE:x]]` still sees their own text.
+ */
+export function stripFileMarkers(content: string): string {
+  if (!content) return content;
+  return content
+    .replace(FILE_MARKER_RE, '')
+    .replace(/[ \t]+\n/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}


### PR DESCRIPTION
## Summary

Closes #277.

XTM One PR #810 (*agent-generated file attachments*) lets agents emit downloadable files. The agent embeds a `[[FILE:<id>]]` marker in its reply and the backend `done` event carries an `attachments[]` array. `@filigran/chatbot` — embedded as **"Ask Ariane"** in OpenCTI and OpenAEV — ignored both, so generated files surfaced as raw `[[FILE:...]]` tokens with no way to download them.

## What changed

- **`parseRestEvent`** — parses `attachments` on the `done` event via a new defensive `parseAttachments` helper.
- **types** — adds `ChatAttachment`, `ChatMessage.attachments`, and `ApiEndpoints.download`.
- **`useChat`** — hydrates attachments onto the assistant message on `done`.
- **`ChatMessages`** — strips `[[FILE:<id>]]` markers from **assistant** prose (user text untouched) and renders a download card per attachment (de-emphasized chip for `working_file`).
- **`ChatPanel`** — authenticated download handler + re-surfaces attachments on session restore.
- Adds `DownloadIcon`, `stripFileMarkers` util, README docs, and bumps the package to **3.3.0**.

## Downloads never require an upstream login

Each attachment carries only `file_id` + display metadata — **never an absolute URL**. Clicking a card issues:

```
GET {apiBaseUrl}{apiEndpoints.download ?? '/chat/files'}/{file_id}/download
```

with `credentials: 'include'` + `requestHeaders`. `apiBaseUrl` points at the **host app's own backend proxy** (OpenCTI `/chatbot`, OpenAEV `/api/xtmone/chat`), which mints the upstream (XTM One) JWT server-side. The end user stays authenticated to the host platform only and never logs in to XTM One. Set `apiEndpoints.download = null` to disable download cards.

Marker stripping is applied unconditionally, so a chatbot pointed at a pre-#810 backend never shows raw `[[FILE:...]]` tokens.

## Test plan

- [x] `tsc --noEmit` (check-ts) clean.
- [x] `rollup` build produces `dist/index.js` + `dist/index.d.ts`.
- [ ] CI lint (the local `eslint.config.ts` `@eslint/js` resolution is an environment-only issue here).

## Cross-repo
- XTM One backend (emit attachments): XTM-One-Platform/xtm-one#1120 (closes #1119)
- OpenCTI proxy + lib bump: OpenCTI-Platform/opencti#16294
- OpenAEV proxy + lib bump: OpenAEV-Platform/openaev#5992
