### PR TITLE
feat(chatbot): forward host page context (current URL) to the agent on each message

### DIFF
--- a/packages/filigran-chatbot/README.md
+++ b/packages/filigran-chatbot/README.md
@@ -67,7 +67,7 @@ import { ChatPanel } from '@filigran/chatbot';
 | `accentColor`       | `string`                                  | `'#7b5cff'`  | Primary accent color (hex)                                       |
 | `logoIcon`          | `React.ReactNode`                         | default icon | Custom logo/icon for the assistant                               |
 | `promptSuggestions` | `string[]`                                | default list | Prompt suggestions shown on welcome screen                       |
-| `pageContext`       | `Record<string, unknown>`                 | —            | Arbitrary host page context (e.g. `{ url: '/dashboard/...' }`) sent as `context` on each `rest` message so the agent knows where the user is. Read fresh at send time; omitted when empty. |
+| `pageContext`       | `Record<string, unknown>`                 | —            | Arbitrary host page context (e.g. `{ url: '/dashboard/...' }`) sent as `context` on each `rest` message so the agent knows where the user is. Must be JSON-serializable (skipped if not). Read fresh at send time; omitted when empty. |
 | `resizable`         | `boolean`                                 | `false`      | Enable drag-to-resize for sidebar mode                           |
 | `onWidthChange`     | `(width: number) => void`                 | —            | Called when sidebar width changes during resize                  |
 | `onResizeStart`     | `() => void`                              | —            | Called when resize drag starts                                   |
@@ -199,6 +199,8 @@ The optional `context` object is forwarded verbatim from the `pageContext`
 prop (REST backend only) and is omitted entirely when empty. Use it to make
 the agent aware of the user's current location/page; the shape is up to the
 host and can be extended later (page title, selected entity, user role, etc.).
+It must be JSON-serializable — a non-serializable value (circular reference,
+`BigInt`, …) is skipped rather than breaking the request.
 
 **Response:** Server-Sent Events stream with these event types:
 

--- a/packages/filigran-chatbot/README.md
+++ b/packages/filigran-chatbot/README.md
@@ -67,6 +67,7 @@ import { ChatPanel } from '@filigran/chatbot';
 | `accentColor`       | `string`                                  | `'#7b5cff'`  | Primary accent color (hex)                                       |
 | `logoIcon`          | `React.ReactNode`                         | default icon | Custom logo/icon for the assistant                               |
 | `promptSuggestions` | `string[]`                                | default list | Prompt suggestions shown on welcome screen                       |
+| `pageContext`       | `Record<string, unknown>`                 | —            | Arbitrary host page context (e.g. `{ url: '/dashboard/...' }`) sent as `context` on each `rest` message so the agent knows where the user is. Read fresh at send time; omitted when empty. |
 | `resizable`         | `boolean`                                 | `false`      | Enable drag-to-resize for sidebar mode                           |
 | `onWidthChange`     | `(width: number) => void`                 | —            | Called when sidebar width changes during resize                  |
 | `onResizeStart`     | `() => void`                              | —            | Called when resize drag starts                                   |
@@ -189,9 +190,15 @@ Sends a message and streams the response via SSE.
 {
   "content": "What is the weather?",
   "conversation_id": "uuid-or-null",
-  "agent_slug": "general"
+  "agent_slug": "general",
+  "context": { "url": "/dashboard/analyses/reports/<id>/overview" }
 }
 ```
+
+The optional `context` object is forwarded verbatim from the `pageContext`
+prop (REST backend only) and is omitted entirely when empty. Use it to make
+the agent aware of the user's current location/page; the shape is up to the
+host and can be extended later (page title, selected entity, user role, etc.).
 
 **Response:** Server-Sent Events stream with these event types:
 

--- a/packages/filigran-chatbot/package.json
+++ b/packages/filigran-chatbot/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "git+https://github.com/FiligranHQ/filigran-ui.git"
   },
-  "version": "3.3.1",
+  "version": "3.4.0",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/filigran-chatbot/package.json
+++ b/packages/filigran-chatbot/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "git+https://github.com/FiligranHQ/filigran-ui.git"
   },
-  "version": "3.4.0",
+  "version": "3.3.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/filigran-chatbot/src/components/ChatPanel.tsx
+++ b/packages/filigran-chatbot/src/components/ChatPanel.tsx
@@ -46,6 +46,7 @@ export const ChatPanel: FunctionComponent<ChatPanelProps> = ({
   maxFileCount,
   maxTotalSize,
   requestHeaders,
+  pageContext,
   pushContentSelector,
   backendType = 'rest',
 }) => {
@@ -82,6 +83,7 @@ export const ChatPanel: FunctionComponent<ChatPanelProps> = ({
     backendType,
     agentSlug: selectedAgent?.slug,
     requestHeaders,
+    pageContext,
     t,
     maxFileCount,
     maxTotalSize,

--- a/packages/filigran-chatbot/src/hooks/useChat.ts
+++ b/packages/filigran-chatbot/src/hooks/useChat.ts
@@ -91,10 +91,14 @@ function buildRequestBody(
       // non-serializable value (circular reference, BigInt, …) would otherwise
       // throw and break the message send. Drop the context instead — page
       // context is supplementary and must never prevent a message from going out.
+      // Decide using the serialized result so values that normalize to an empty
+      // object (e.g. `{ url: undefined }`, `{ fn: () => {} }`) are also omitted.
       if (opts.pageContext && Object.keys(opts.pageContext).length > 0) {
         try {
-          JSON.stringify(opts.pageContext);
-          body.context = opts.pageContext;
+          const serialized = JSON.stringify(opts.pageContext);
+          if (serialized && serialized !== '{}') {
+            body.context = opts.pageContext;
+          }
         } catch {
           // Non-serializable page context — skip it rather than fail the send.
         }

--- a/packages/filigran-chatbot/src/hooks/useChat.ts
+++ b/packages/filigran-chatbot/src/hooks/useChat.ts
@@ -87,8 +87,17 @@ function buildRequestBody(
       const body: Record<string, unknown> = { content, conversation_id: opts.conversationId, agent_slug: opts.agentSlug };
       // Forward arbitrary host page context (e.g. current URL) so the agent
       // knows where the user is. Omitted when empty to keep payloads lean.
+      // Guard serialization: the whole body is later JSON.stringify'd, so a
+      // non-serializable value (circular reference, BigInt, …) would otherwise
+      // throw and break the message send. Drop the context instead — page
+      // context is supplementary and must never prevent a message from going out.
       if (opts.pageContext && Object.keys(opts.pageContext).length > 0) {
-        body.context = opts.pageContext;
+        try {
+          JSON.stringify(opts.pageContext);
+          body.context = opts.pageContext;
+        } catch {
+          // Non-serializable page context — skip it rather than fail the send.
+        }
       }
       return body;
     }

--- a/packages/filigran-chatbot/src/hooks/useChat.ts
+++ b/packages/filigran-chatbot/src/hooks/useChat.ts
@@ -17,6 +17,8 @@ interface UseChatOptions {
   backendType?: BackendType;
   agentSlug: string | null | undefined;
   requestHeaders?: Record<string, string>;
+  /** Arbitrary host page/application context, sent as `context` on the REST message body. */
+  pageContext?: Record<string, unknown>;
   t: (key: string) => string;
   maxFileCount?: number;
   maxTotalSize?: number;
@@ -61,7 +63,12 @@ function getParser(backendType: BackendType): (evt: Record<string, unknown>, ctx
 function buildRequestBody(
   backendType: BackendType,
   content: string,
-  opts: { legacyChatId: string | null; conversationId: string | null; agentSlug: string | null | undefined },
+  opts: {
+    legacyChatId: string | null;
+    conversationId: string | null;
+    agentSlug: string | null | undefined;
+    pageContext?: Record<string, unknown>;
+  },
 ): Record<string, unknown> {
   switch (backendType) {
     case 'legacy':
@@ -76,8 +83,15 @@ function buildRequestBody(
         state: {},
         forwardedProps: opts.agentSlug ? { agentSlug: opts.agentSlug } : {},
       };
-    default:
-      return { content, conversation_id: opts.conversationId, agent_slug: opts.agentSlug };
+    default: {
+      const body: Record<string, unknown> = { content, conversation_id: opts.conversationId, agent_slug: opts.agentSlug };
+      // Forward arbitrary host page context (e.g. current URL) so the agent
+      // knows where the user is. Omitted when empty to keep payloads lean.
+      if (opts.pageContext && Object.keys(opts.pageContext).length > 0) {
+        body.context = opts.pageContext;
+      }
+      return body;
+    }
   }
 }
 
@@ -87,6 +101,7 @@ export function useChat({
   backendType = 'rest',
   agentSlug,
   requestHeaders,
+  pageContext,
   t,
   maxFileCount = DEFAULT_MAX_FILE_COUNT,
   maxTotalSize = DEFAULT_MAX_TOTAL_SIZE,
@@ -112,6 +127,10 @@ export function useChat({
   const hasUsedToolsRef = useRef(false);
   // Ref mirror of conversationId — always current across async boundaries
   const conversationIdRef = useRef(conversationId);
+  // Ref mirror of pageContext so the value sent reflects the page the user is
+  // on at send time, regardless of when the send handler closure was created.
+  const pageContextRef = useRef(pageContext);
+  pageContextRef.current = pageContext;
   // Mutex to prevent concurrent session creation
   const creatingSessionRef = useRef<Promise<string | null> | null>(null);
   // Abort controller for in-flight file uploads (cancelled on new chat)
@@ -350,6 +369,7 @@ export function useChat({
         legacyChatId,
         conversationId: conversationIdRef.current,
         agentSlug,
+        pageContext: pageContextRef.current,
       });
       if (fileIds.length > 0) {
         (requestBody as Record<string, unknown>).file_ids = fileIds;

--- a/packages/filigran-chatbot/src/types.ts
+++ b/packages/filigran-chatbot/src/types.ts
@@ -76,6 +76,21 @@ export interface ChatPanelProps {
   /** Additional HTTP headers added to chatbot API requests (messages, sessions, agents, uploads). */
   requestHeaders?: Record<string, string>;
   /**
+   * Arbitrary contextual metadata about the host page/application, forwarded
+   * to the backend alongside every message as a `context` JSON object so the
+   * agent is aware of where the user is.
+   *
+   * The shape is up to the host. Today it typically carries the current
+   * relative URL, e.g.
+   * `{ url: '/dashboard/analyses/reports/<id>/overview' }`, and can be
+   * extended later (page title, selected entity, user role, etc.).
+   *
+   * Read fresh at send time, so it always reflects the page the user is on
+   * when the message is sent (not when the panel was opened). Only emitted
+   * for the `rest` backend, and omitted entirely when empty.
+   */
+  pageContext?: Record<string, unknown>;
+  /**
    * CSS selector for the main content element that should be pushed when sidebar is open.
    * When set, the component will automatically apply margin-right to push the content.
    * Example: '#main-content' or '.app-content'

--- a/packages/filigran-chatbot/src/types.ts
+++ b/packages/filigran-chatbot/src/types.ts
@@ -85,6 +85,10 @@ export interface ChatPanelProps {
    * `{ url: '/dashboard/analyses/reports/<id>/overview' }`, and can be
    * extended later (page title, selected entity, user role, etc.).
    *
+   * Must be JSON-serializable — it is sent via `JSON.stringify`. A
+   * non-serializable value (circular reference, `BigInt`, etc.) is skipped
+   * rather than thrown, so it can never break message sending.
+   *
    * Read fresh at send time, so it always reflects the page the user is on
    * when the message is sent (not when the panel was opened). Only emitted
    * for the `rest` backend, and omitted entirely when empty.


### PR DESCRIPTION
## Summary

- Adds an optional `pageContext?: Record<string, unknown>` prop to `ChatPanel`.
- When provided (REST backend), it is forwarded verbatim as a `context` JSON object on every `/chat/messages` request, so the agent is aware of where the user is in the host application.
- Read **fresh at send time** via a ref, so it reflects the page the user is on when the message is sent (not when the panel opened). Omitted entirely when empty.
- Serialization is guarded: a non-JSON-serializable `pageContext` (circular reference, `BigInt`, …) is skipped rather than thrown, so it can never break message sending.
- The shape is intentionally generic — hosts start with just the current URL (`{ url: '/dashboard/...' }`) and can extend later (page title, selected entity, user role, …).
- Documents the prop + request contract (incl. the JSON-serializable requirement) in the README.
- No manual version bump: `release-version.yml` owns versioning (it runs `yarn version <type>` at dispatch). This ships as a **patch** release — `3.3.1` → **`3.3.2`** — when the operator dispatches the workflow for `@filigran/chatbot`.

Closes #279

## Coordinated cross-repo change

This is the upstream piece. Consumers pin `@filigran/chatbot@3.3.2` and pass `pageContext`:
- `OpenCTI-Platform/opencti` #16298 — `AskArianePanel` passes the current URL
- `OpenAEV-Platform/openaev` #5996 — `AskArianePanel` passes the current URL; the XTM One proxy forwards `context`
- `XTM-One-Platform/xtm-one` #1122 — accepts `context` and injects it into the agent system prompt

## Release

Merge, then dispatch **Release and Publish to NPM** with `package = @filigran/chatbot`, `version_type = patch` → publishes `3.3.2`.

## Test plan

- [x] `yarn workspace @filigran/chatbot run check-ts` / `lint` pass (only the pre-existing `eslint.config.ts` env warning, unrelated to this diff)
- [ ] In an embedding app, open the chat, navigate between pages, send a message, and confirm the `POST /chat/messages` body includes `context: { url: ... }` matching the current page
- [ ] Confirm `context` is omitted from the request body when `pageContext` is empty/unset
- [ ] Confirm a non-serializable `pageContext` does not break sending (context dropped, message still sent)
- [ ] Confirm non-REST backends (`legacy`, `ag-ui`) are unaffected
