### PR TITLE
fix(chatbot): recover from a stale conversation id instead of erroring

### DIFF
--- a/packages/filigran-chatbot/README.md
+++ b/packages/filigran-chatbot/README.md
@@ -138,7 +138,7 @@ Returns available AI agents.
 
 ### `POST {apiBaseUrl}/chat/sessions`
 
-Restores conversation history.
+Restores conversation history (and, implicitly, resolves the session).
 
 **Request:**
 
@@ -153,12 +153,24 @@ Restores conversation history.
 
 ```json
 {
+  "conversation_id": "uuid-here",
   "messages": [
     { "role": "user", "content": "Hello" },
     { "role": "assistant", "content": "Hi! How can I help?" }
   ]
 }
 ```
+
+The response **should echo a `conversation_id`**. When the stored
+`conversation_id` no longer exists (e.g. the platform was reset but the
+browser kept an old id in `localStorage`), the backend is expected to
+transparently create a fresh conversation and return its **new** id with an
+empty `messages` array. The component adopts whatever id the response returns
+(persisting it to `localStorage`), so subsequent messages are never sent
+against a dead conversation — which would otherwise fail with a
+"conversation does not exist" error and force the user to manually start a new
+conversation. If the endpoint responds with a non-2xx status, the component
+silently resets the stored id and starts fresh on the next message.
 
 Assistant history messages **should echo the same `attachments[]` array** that
 was sent on the original `done` event (see [Agent-generated file attachments](#agent-generated-file-attachments)),

--- a/packages/filigran-chatbot/src/components/ChatPanel.tsx
+++ b/packages/filigran-chatbot/src/components/ChatPanel.tsx
@@ -198,6 +198,13 @@ export const ChatPanel: FunctionComponent<ChatPanelProps> = ({
     historyLoadedRef.current = true;
     const sessionsUrl = `${apiBaseUrl}${apiEndpoints?.sessions ?? '/chat/sessions'}`;
 
+    // If a new chat is started or the agent is switched while this request is
+    // in flight, `handleNewChat()` resets the conversation id / selected agent
+    // (both effect dependencies), so this effect is cleaned up. Ignore the
+    // late response in that case, otherwise it could resurrect a dead id or
+    // overwrite the freshly-started conversation with restored history.
+    let cancelled = false;
+
     fetch(sessionsUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', ...(requestHeaders ?? {}) },
@@ -207,6 +214,7 @@ export const ChatPanel: FunctionComponent<ChatPanelProps> = ({
       }),
     })
       .then((res) => {
+        if (cancelled) return null;
         if (!res.ok) {
           // Stale or invalid stored id (e.g. the platform was reset but the
           // browser kept an old id) — silently reset so a fresh conversation
@@ -218,7 +226,7 @@ export const ChatPanel: FunctionComponent<ChatPanelProps> = ({
         return res.json();
       })
       .then((data) => {
-        if (!data) return;
+        if (cancelled || !data) return;
         // The backend resolves the session: it returns the same id when the
         // conversation still exists, or transparently creates a fresh one and
         // returns its NEW id when the stored id is stale. Adopt whatever id it
@@ -244,8 +252,13 @@ export const ChatPanel: FunctionComponent<ChatPanelProps> = ({
         setMessages(restored);
       })
       .catch(() => {
+        if (cancelled) return;
         updateConversationId(null);
       });
+
+    return () => {
+      cancelled = true;
+    };
   }, [conversationId, selectedAgent, apiBaseUrl, apiEndpoints, backendType, historyLoadedRef, requestHeaders, setMessages, updateConversationId]);
 
   const onSwitchAgent = (agent: typeof selectedAgent) => {

--- a/packages/filigran-chatbot/src/components/ChatPanel.tsx
+++ b/packages/filigran-chatbot/src/components/ChatPanel.tsx
@@ -76,7 +76,7 @@ export const ChatPanel: FunctionComponent<ChatPanelProps> = ({
     handleStopGenerating,
     setAttachedFiles,
     setMessages,
-    setConversationId,
+    updateConversationId,
   } = useChat({
     apiBaseUrl,
     apiEndpoints,
@@ -198,11 +198,6 @@ export const ChatPanel: FunctionComponent<ChatPanelProps> = ({
     historyLoadedRef.current = true;
     const sessionsUrl = `${apiBaseUrl}${apiEndpoints?.sessions ?? '/chat/sessions'}`;
 
-    const clearStaleConversation = () => {
-      setConversationId(null);
-      localStorage.removeItem('filigranChatConversationId');
-    };
-
     fetch(sessionsUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', ...(requestHeaders ?? {}) },
@@ -213,13 +208,27 @@ export const ChatPanel: FunctionComponent<ChatPanelProps> = ({
     })
       .then((res) => {
         if (!res.ok) {
-          clearStaleConversation();
+          // Stale or invalid stored id (e.g. the platform was reset but the
+          // browser kept an old id) — silently reset so a fresh conversation
+          // is created on the next message instead of surfacing an error and
+          // forcing the user to click "New conversation".
+          updateConversationId(null);
           return null;
         }
         return res.json();
       })
       .then((data) => {
-        if (!data?.messages?.length) return;
+        if (!data) return;
+        // The backend resolves the session: it returns the same id when the
+        // conversation still exists, or transparently creates a fresh one and
+        // returns its NEW id when the stored id is stale. Adopt whatever id it
+        // returns (and persist it) so we never send subsequent messages
+        // against a dead conversation — which would 404 with
+        // "conversation does not exist".
+        if (typeof data.conversation_id === 'string' && data.conversation_id && data.conversation_id !== conversationId) {
+          updateConversationId(data.conversation_id);
+        }
+        if (!data.messages?.length) return;
         const restored: ChatMessage[] = data.messages.map(
           (m: { role: string; content: string; attachments?: unknown }, i: number) => ({
             id: `restored-${i}`,
@@ -235,9 +244,9 @@ export const ChatPanel: FunctionComponent<ChatPanelProps> = ({
         setMessages(restored);
       })
       .catch(() => {
-        clearStaleConversation();
+        updateConversationId(null);
       });
-  }, [conversationId, selectedAgent, apiBaseUrl, apiEndpoints, historyLoadedRef, requestHeaders, setMessages, setConversationId]);
+  }, [conversationId, selectedAgent, apiBaseUrl, apiEndpoints, backendType, historyLoadedRef, requestHeaders, setMessages, updateConversationId]);
 
   const onSwitchAgent = (agent: typeof selectedAgent) => {
     if (!agent) return;

--- a/packages/filigran-chatbot/src/hooks/useChat.ts
+++ b/packages/filigran-chatbot/src/hooks/useChat.ts
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import type { AgentStatusState, ApiEndpoints, BackendType, ChatFile, ChatMessage } from '../types';
 import type { ParsedAction, ProtocolContext } from './protocols';
 import { parseAgUiEvent, parseLegacyEvent, parseRestEvent } from './protocols';
@@ -46,7 +46,14 @@ interface UseChatReturn {
   handleStopGenerating: () => void;
   setAttachedFiles: React.Dispatch<React.SetStateAction<ChatFile[]>>;
   setMessages: React.Dispatch<React.SetStateAction<ChatMessage[]>>;
-  setConversationId: React.Dispatch<React.SetStateAction<string | null>>;
+  /**
+   * Set (or clear) the active conversation id, keeping React state, the
+   * cross-async-boundary ref mirror, and localStorage all in sync. Pass
+   * `null` to reset. Prefer this over a raw state setter so the id consumed
+   * by `handleSendMessage` (which reads the ref) never drifts from what the
+   * UI shows.
+   */
+  updateConversationId: (id: string | null) => void;
 }
 
 function getParser(backendType: BackendType): (evt: Record<string, unknown>, ctx: ProtocolContext) => ParsedAction {
@@ -178,9 +185,10 @@ export function useChat({
   };
 
   /**
-   * Update conversationId in both React state and the ref mirror.
+   * Update conversationId in React state, the ref mirror, and localStorage.
+   * Stable identity (useCallback) so it can be used as an effect dependency.
    */
-  const updateConversationId = (id: string | null) => {
+  const updateConversationId = useCallback((id: string | null) => {
     conversationIdRef.current = id;
     setConversationId(id);
     if (id) {
@@ -188,7 +196,7 @@ export function useChat({
     } else {
       localStorage.removeItem(STORAGE_KEY);
     }
-  };
+  }, []);
 
   /**
    * Ensure a conversation exists. Uses a mutex so concurrent callers
@@ -565,6 +573,6 @@ export function useChat({
     handleStopGenerating,
     setAttachedFiles,
     setMessages,
-    setConversationId,
+    updateConversationId,
   };
 }


### PR DESCRIPTION
## Summary

Fixes a chatbot UX bug where reopening the panel on a **fresh platform** while the browser still has an old `conversationId` in `localStorage` surfaced a `conversation does not exist` error and forced the user to manually click **New conversation**.

This happens whenever the same URL is reused for a new/reset platform (e.g. demo or staging environments), or after the conversation was deleted server-side. It is most visible in the "Ask Ariane" embedded chat in **OpenCTI** and **OpenAEV**, which consume this package.

### Root cause

`POST {apiBaseUrl}/chat/sessions` already *resolves* the session server-side: it returns the same `conversation_id` when the conversation still exists, or transparently creates a fresh conversation and returns its **new** id when the stored one is stale.

But `ChatPanel`'s history-load effect only read `data.messages` and ignored the returned `conversation_id`, so it kept the **dead** id in state/`localStorage`. The next message was then POSTed against a non-existent conversation and the backend replied `404 — Conversation not found`.

A secondary latent bug: the exposed `setConversationId` updated React state + `localStorage` but **not** `conversationIdRef`, which is the value `handleSendMessage` actually reads across async boundaries. So even the previous "clear stale conversation" path left the ref pointing at the dead id.

### Changes

- `ChatPanel` now **adopts whatever `conversation_id` the session endpoint returns** (and persists it), so we never message a dead conversation.
- Non-2xx / network responses **silently reset** the stored id and start fresh on the next message (no error shown, no manual click required).
- All conversation-id mutations now go through a single `updateConversationId` helper in `useChat` that keeps **state + ref + localStorage** in lockstep (stable identity via `useCallback`).
- The history-load effect now ignores its own **late response** via a cleanup-scoped `cancelled` flag: if the user starts a new chat or switches agent while the `/chat/sessions` request is in flight, `handleNewChat()` resets the conversation id / selected agent (both effect dependencies), tearing down the effect — so the stale `res`/`data`/`catch` handlers no longer resurrect a dead id or overwrite the freshly-started conversation with restored history.
- README: documented that the `/chat/sessions` response should echo a `conversation_id` and the auto-recovery contract.

No public prop changes. `useChat` is internal (only `ChatPanel`/`ChatToggleButton` are exported).

## Test plan

- [ ] With a valid stored `conversationId`, reopening the panel restores history (unchanged behaviour).
- [ ] With a **stale** stored `conversationId` (valid UUID, no longer exists), reopening the panel silently switches to a fresh conversation; the first message sends successfully with no error and no need to click "New conversation".
- [ ] With a malformed/garbage stored id (session endpoint returns non-2xx), the stored id is reset and a new conversation starts on the next message.
- [ ] After adoption, sending a message uses the adopted id (verify the `conversation_id` in the `/chat/messages` request body matches the freshly returned id).
- [ ] Starting a new chat (or switching agent) while the `/chat/sessions` restore is in flight does not resurrect the old conversation or overwrite the fresh chat once the late response arrives.
