### PR TITLE
fix(chatbot): keep the in-flight session restore unless the conversation actually changed

### DIFF
--- a/packages/filigran-chatbot/src/components/ChatPanel.tsx
+++ b/packages/filigran-chatbot/src/components/ChatPanel.tsx
@@ -69,6 +69,7 @@ export const ChatPanel: FunctionComponent<ChatPanelProps> = ({
     conversationId,
     transferredAgent,
     historyLoadedRef,
+    conversationIdRef,
     handleFileAdd,
     handlePaste,
     handleSendMessage,
@@ -198,12 +199,19 @@ export const ChatPanel: FunctionComponent<ChatPanelProps> = ({
     historyLoadedRef.current = true;
     const sessionsUrl = `${apiBaseUrl}${apiEndpoints?.sessions ?? '/chat/sessions'}`;
 
-    // If a new chat is started or the agent is switched while this request is
-    // in flight, `handleNewChat()` resets the conversation id / selected agent
-    // (both effect dependencies), so this effect is cleaned up. Ignore the
-    // late response in that case, otherwise it could resurrect a dead id or
-    // overwrite the freshly-started conversation with restored history.
-    let cancelled = false;
+    // The conversation this restore is being issued for. A host re-render that
+    // churns an inline `apiEndpoints` / `requestHeaders` prop, or a React
+    // StrictMode double-invoke, tears this effect down and re-runs it while the
+    // request is still in flight — but the conversation itself hasn't changed.
+    // We must NOT drop the restore in those benign cases (doing so left the
+    // panel looking like a brand-new chat, randomly, on reload). Only a real
+    // change — the user starting a new chat or switching agent, both of which
+    // reset the id via `handleNewChat()` — should abandon the response, so it
+    // can't resurrect a dead id or overwrite the freshly-started conversation.
+    // Compare the live ref at apply time (not a blanket teardown flag) so the
+    // legitimate restore always lands while a superseded one is still ignored.
+    const requestedConversationId = conversationId;
+    const isStale = () => conversationIdRef.current !== requestedConversationId;
 
     fetch(sessionsUrl, {
       method: 'POST',
@@ -214,7 +222,7 @@ export const ChatPanel: FunctionComponent<ChatPanelProps> = ({
       }),
     })
       .then((res) => {
-        if (cancelled) return null;
+        if (isStale()) return null;
         if (!res.ok) {
           // Stale or invalid stored id (e.g. the platform was reset but the
           // browser kept an old id) — silently reset so a fresh conversation
@@ -226,14 +234,14 @@ export const ChatPanel: FunctionComponent<ChatPanelProps> = ({
         return res.json();
       })
       .then((data) => {
-        if (cancelled || !data) return;
+        if (!data || isStale()) return;
         // The backend resolves the session: it returns the same id when the
         // conversation still exists, or transparently creates a fresh one and
         // returns its NEW id when the stored id is stale. Adopt whatever id it
         // returns (and persist it) so we never send subsequent messages
         // against a dead conversation — which would 404 with
         // "conversation does not exist".
-        if (typeof data.conversation_id === 'string' && data.conversation_id && data.conversation_id !== conversationId) {
+        if (typeof data.conversation_id === 'string' && data.conversation_id && data.conversation_id !== requestedConversationId) {
           updateConversationId(data.conversation_id);
         }
         if (!data.messages?.length) return;
@@ -255,14 +263,10 @@ export const ChatPanel: FunctionComponent<ChatPanelProps> = ({
         setMessages(restored);
       })
       .catch(() => {
-        if (cancelled) return;
+        if (isStale()) return;
         updateConversationId(null);
       });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [conversationId, selectedAgent, apiBaseUrl, apiEndpoints, backendType, historyLoadedRef, requestHeaders, setMessages, updateConversationId]);
+  }, [conversationId, selectedAgent, apiBaseUrl, apiEndpoints, backendType, historyLoadedRef, conversationIdRef, requestHeaders, setMessages, updateConversationId]);
 
   const onSwitchAgent = (agent: typeof selectedAgent) => {
     if (!agent) return;

--- a/packages/filigran-chatbot/src/components/ChatPanel.tsx
+++ b/packages/filigran-chatbot/src/components/ChatPanel.tsx
@@ -1,4 +1,4 @@
-import { type FunctionComponent, useCallback, useEffect, useState } from 'react';
+import { type FunctionComponent, useCallback, useEffect, useRef, useState } from 'react';
 import type { ChatAttachment, ChatMessage, ChatPanelProps } from '../types';
 import { hexAlpha, identity } from '../utils';
 import { parseAttachments } from '../hooks/protocols/parseRestEvent';
@@ -191,6 +191,23 @@ export const ChatPanel: FunctionComponent<ChatPanelProps> = ({
     '--chat-accent-dark': accentColor,
   } as React.CSSProperties;
 
+  // Tracks whether this panel is still mounted. Flipped to false ONLY on a
+  // real unmount (empty-deps cleanup) — never on the benign teardowns that an
+  // inline `apiEndpoints` / `requestHeaders` prop churn or a StrictMode
+  // double-invoke trigger. The restore effect below reads it so an in-flight
+  // `/chat/sessions` response that outlives the panel — the host renders
+  // `<ChatPanel />` conditionally and the user closes it mid-request — can't
+  // call `setMessages` / `updateConversationId` after unmount, while a restore
+  // merely interrupted by a re-render still lands. Re-set to true on setup so
+  // StrictMode's mount → unmount → remount of the same instance leaves it true.
+  const isMountedRef = useRef(true);
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
   // Load conversation history when agent is selected
   useEffect(() => {
     // Skip session history if disabled, using single endpoint mode, or non-REST backend
@@ -209,9 +226,11 @@ export const ChatPanel: FunctionComponent<ChatPanelProps> = ({
     // reset the id via `handleNewChat()` — should abandon the response, so it
     // can't resurrect a dead id or overwrite the freshly-started conversation.
     // Compare the live ref at apply time (not a blanket teardown flag) so the
-    // legitimate restore always lands while a superseded one is still ignored.
+    // legitimate restore always lands while a superseded one is still ignored —
+    // and bail out entirely once the panel has actually unmounted, so a late
+    // response can't write to localStorage / state after the panel is gone.
     const requestedConversationId = conversationId;
-    const isStale = () => conversationIdRef.current !== requestedConversationId;
+    const isStale = () => !isMountedRef.current || conversationIdRef.current !== requestedConversationId;
 
     fetch(sessionsUrl, {
       method: 'POST',
@@ -266,7 +285,7 @@ export const ChatPanel: FunctionComponent<ChatPanelProps> = ({
         if (isStale()) return;
         updateConversationId(null);
       });
-  }, [conversationId, selectedAgent, apiBaseUrl, apiEndpoints, backendType, historyLoadedRef, conversationIdRef, requestHeaders, setMessages, updateConversationId]);
+  }, [conversationId, selectedAgent, apiBaseUrl, apiEndpoints, backendType, historyLoadedRef, conversationIdRef, isMountedRef, requestHeaders, setMessages, updateConversationId]);
 
   const onSwitchAgent = (agent: typeof selectedAgent) => {
     if (!agent) return;

--- a/packages/filigran-chatbot/src/hooks/useChat.ts
+++ b/packages/filigran-chatbot/src/hooks/useChat.ts
@@ -39,6 +39,15 @@ interface UseChatReturn {
   conversationId: string | null;
   transferredAgent: TransferredAgent | null;
   historyLoadedRef: React.MutableRefObject<boolean>;
+  /**
+   * Ref mirror of {@link conversationId}, always current across async
+   * boundaries. Exposed so the history-restore effect can tell, when its
+   * `/chat/sessions` response arrives, whether the conversation it was issued
+   * for is still the active one — and ignore a genuinely superseded response
+   * (new chat / agent switch) without discarding a restore that was merely
+   * torn down by a benign host re-render or a StrictMode double-invoke.
+   */
+  conversationIdRef: React.MutableRefObject<string | null>;
   handleFileAdd: (fileList: FileList | null) => void;
   handlePaste: (e: React.ClipboardEvent) => void;
   handleSendMessage: () => Promise<void>;
@@ -566,6 +575,7 @@ export function useChat({
     conversationId,
     transferredAgent,
     historyLoadedRef,
+    conversationIdRef,
     handleFileAdd,
     handlePaste,
     handleSendMessage,


### PR DESCRIPTION
## Summary

Fixes a regression introduced by #281 (`@filigran/chatbot` `3.3.3`): reopening / reloading the chat panel **randomly** discards the previous session and starts a brand-new conversation. Sometimes the history restores, sometimes it doesn't — for the same stored `conversationId`. Most visible in the **"Ask Ariane"** embedded chat in **OpenCTI** and **OpenAEV**.

Closes #284.

### Root cause

The history-restore effect in `ChatPanel.tsx` sets `historyLoadedRef.current = true` **before** awaiting `POST /chat/sessions`, and the `cancelled` cleanup flag added in #281 (commit `bb0e8e4`) is flipped on **any** effect teardown.

But `apiEndpoints` and `requestHeaders` are effect dependencies, and hosts pass them as **fresh inline objects on every render** (e.g. OpenCTI's `AskArianePanel` does `apiEndpoints={{ ... }}`). So whenever the host re-renders while `/chat/sessions` is in flight — which happens nondeterministically as auth/banners/theme/location settle on initial load, and *always* under React StrictMode's double-invoke:

1. the effect cleanup fires → `cancelled = true` → the in-flight restore response (history + adopted `conversation_id`) is **discarded**;
2. the re-run hits `historyLoadedRef.current === true` → it **never re-issues** the fetch.

Net effect: the restore is silently dropped → the panel looks like a fresh chat. If the fetch resolves before any re-render, history restores fine → hence the **random** behaviour.

The `cancelled`-on-any-teardown guard was meant to ignore a late `/chat/sessions` response *only* when the user started a new chat or switched agent mid-flight. It is too blunt: it also kills the single legitimate restore on benign re-renders, and nothing retries because the `historyLoadedRef` latch is already set.

### Changes

* `useChat` now exposes `conversationIdRef` (the always-current ref mirror of `conversationId`).
* `ChatPanel`'s restore effect replaces the blanket `cancelled`-on-teardown flag with a **precise staleness check** (`isStale()`): the `/chat/sessions` response is abandoned only when `conversationIdRef.current` no longer equals the id the restore was issued for — i.e. the user started a new chat or switched agent (both reset the id via `handleNewChat`). Benign re-renders and StrictMode double-invokes keep the id unchanged, so the legitimate restore always lands.
* Added an `isMountedRef` — flipped to `false` **only** on a real unmount (dedicated empty-deps effect, re-set to `true` on setup so StrictMode's mount → unmount → remount leaves it `true`) — and folded it into `isStale()`. Hosts render `<ChatPanel />` conditionally (e.g. the playground's `{isOpen && <ChatPanel />}`), so this stops a late `/chat/sessions` response from calling `setMessages` / `updateConversationId` (a real `localStorage` write) after the panel has closed, while still letting a restore that was merely interrupted by a re-render land. Addresses the Copilot review feedback.
* Removed the effect cleanup that set `cancelled` (no longer needed; the ref comparison + mount check are the precise guards).

No public prop or contract changes. `useChat` is internal (only `ChatPanel` / `ChatToggleButton` are exported), so the new `conversationIdRef` return is not part of the public API.

## Test plan

* **Reload with a valid stored `conversationId`** → history restores **every time** (no longer random), including under React StrictMode and while the host re-renders during the `/chat/sessions` request.
* **Stale stored id** (valid UUID, no longer exists) → silently adopts the backend-returned fresh id; first message sends with no error, no manual "New conversation".
* **Garbage / non-2xx** → stored id reset, new conversation on next message.
* **New chat while restore in flight** → late response is ignored (no dead-id resurrection, no overwrite of the fresh chat).
* **Agent switch while restore in flight** → same: late response ignored, fresh chat for the new agent.
* **Panel unmounted (closed) while restore in flight** → late response is ignored; no `setMessages` / `updateConversationId` after unmount.
* `tsc` (`yarn check-ts`) and `rollup` (`yarn build`) of the changed source pass; the only diagnostic is the pre-existing `eslint.config.ts` → `@eslint/js` resolution quirk, unrelated to this PR and not part of required CI. Required `Test Build Packages` CI is green.
