### PR TITLE
feat(rich-text-editor): introduce new rich text editor package

### DIFF
--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -20,6 +20,7 @@ on:
         options:
           - '@filigran/chatbot'
           - '@filigran/icon'
+          - '@filigran/rich-text-editor'
           - '@filigran/ui'
           - all
 
@@ -64,6 +65,9 @@ jobs:
           if [[ "${{ github.event.inputs.package }}" == "@filigran/icon" ]] || [[ "${{ github.event.inputs.package }}" == "all" ]]; then
             echo "FILIGRAN_ICON_CURRENT_VERSION=$(node -p "require('./packages/filigran-icon/package.json').version")" >> $GITHUB_ENV
           fi
+          if [[ "${{ github.event.inputs.package }}" == "@filigran/rich-text-editor" ]] || [[ "${{ github.event.inputs.package }}" == "all" ]]; then
+            echo "FILIGRAN_RTE_CURRENT_VERSION=$(node -p "require('./packages/filigran-rich-text-editor/package.json').version")" >> $GITHUB_ENV
+          fi
           if [[ "${{ github.event.inputs.package }}" == "@filigran/ui" ]] || [[ "${{ github.event.inputs.package }}" == "all" ]]; then
             echo "FILIGRAN_UI_CURRENT_VERSION=$(node -p "require('./packages/filigran-ui/package.json').version")" >> $GITHUB_ENV
           fi
@@ -79,6 +83,12 @@ jobs:
         run: |
           yarn version ${{ github.event.inputs.version_type }}
           echo "FILIGRAN_ICON_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_ENV
+      - name: Update version for @filigran/rich-text-editor
+        if: github.event.inputs.package == '@filigran/rich-text-editor' || github.event.inputs.package == 'all'
+        working-directory: ./packages/filigran-rich-text-editor
+        run: |
+          yarn version ${{ github.event.inputs.version_type }}
+          echo "FILIGRAN_RTE_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_ENV
       - name: Update version for @filigran/ui
         if: github.event.inputs.package == '@filigran/ui' || github.event.inputs.package == 'all'
         working-directory: ./packages/filigran-ui
@@ -177,6 +187,10 @@ jobs:
             [ -n "$PARTS" ] && PARTS="$PARTS, "
             PARTS="${PARTS}@filigran/icon to v$FILIGRAN_ICON_VERSION"
           fi
+          if [ -n "$FILIGRAN_RTE_VERSION" ]; then
+            [ -n "$PARTS" ] && PARTS="$PARTS, "
+            PARTS="${PARTS}@filigran/rich-text-editor to v$FILIGRAN_RTE_VERSION"
+          fi
           
           if [ -z "$PARTS" ]; then
             echo "No version changes to commit"
@@ -195,6 +209,10 @@ jobs:
             git tag "@filigran/icon-v$FILIGRAN_ICON_VERSION"
             echo "Created tag: @filigran/icon-v$FILIGRAN_ICON_VERSION"
           fi
+          if [ -n "$FILIGRAN_RTE_VERSION" ]; then
+            git tag "@filigran/rich-text-editor-v$FILIGRAN_RTE_VERSION"
+            echo "Created tag: @filigran/rich-text-editor-v$FILIGRAN_RTE_VERSION"
+          fi
           if [ -n "$FILIGRAN_UI_VERSION" ]; then
             git tag "@filigran/ui-v$FILIGRAN_UI_VERSION"
             echo "Created tag: @filigran/ui-v$FILIGRAN_UI_VERSION"
@@ -210,6 +228,10 @@ jobs:
             echo "Building @filigran/icon..."
             yarn workspace @filigran/icon run build
           fi
+          if [ -n "$FILIGRAN_RTE_VERSION" ]; then
+            echo "Building @filigran/rich-text-editor..."
+            yarn workspace @filigran/rich-text-editor run build
+          fi
           if [ -n "$FILIGRAN_UI_VERSION" ]; then
             echo "Building @filigran/ui..."
             yarn workspace @filigran/ui run build
@@ -224,6 +246,13 @@ jobs:
       - name: Publish @filigran/icon to NPM
         if: (github.event.inputs.package == '@filigran/icon' || github.event.inputs.package == 'all') && env.FILIGRAN_ICON_VERSION != ''
         working-directory: ./packages/filigran-icon
+        run: yarn npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish @filigran/rich-text-editor to NPM
+        if: (github.event.inputs.package == '@filigran/rich-text-editor' || github.event.inputs.package == 'all') && env.FILIGRAN_RTE_VERSION != ''
+        working-directory: ./packages/filigran-rich-text-editor
         run: yarn npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -255,6 +284,21 @@ jobs:
             
             ### Issues Closed
             ${{ steps.changelog.outputs.icon_issues }}
+          draft: false
+          prerelease: false
+      - name: Create GitHub Release for @filigran/rich-text-editor
+        if: (github.event.inputs.package == '@filigran/rich-text-editor' || github.event.inputs.package == 'all') && env.FILIGRAN_RTE_VERSION != ''
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: '@filigran/rich-text-editor-v${{ env.FILIGRAN_RTE_VERSION }}'
+          name: 'Filigran Rich Text Editor v${{ env.FILIGRAN_RTE_VERSION }}'
+          body: |
+            ## Filigran Rich Text Editor v${{ env.FILIGRAN_RTE_VERSION }}
+            
+            ### Installation
+            ```bash
+            yarn add @filigran/rich-text-editor@${{ env.FILIGRAN_RTE_VERSION }}
+            ```
           draft: false
           prerelease: false
       - name: Create GitHub Release for @filigran/ui

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This project draws inspiration from popular libraries such as **Shadcn**, **Radi
 - **Website:** A dedicated website that hosts both libraries
 - **Filigran-UI:** Component library
 - **Filigran-Icon:** Icon library
+- **Filigran-Rich-Text-Editor:** [Rich text editor package](./packages/filigran-rich-text-editor/README.md)
 
 > **Note:** The work is currently in progress, and the project is not yet officially released.
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build:filigran-chatbot": "yarn workspace @filigran/chatbot run build",
     "build:filigran-email": "yarn workspace @filigran/email run build",
     "build:filigran-icon": "yarn workspace @filigran/icon run build",
+    "build:filigran-rich-text-editor": "yarn workspace @filigran/rich-text-editor run build",
     "build:filigran-ui": "yarn workspace @filigran/ui run build",
     "build:filigran-website": "yarn workspace @filigran/website run build",
     "dev": "yarn workspace @filigran/website run dev",

--- a/packages/filigran-rich-text-editor/.gitignore
+++ b/packages/filigran-rich-text-editor/.gitignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/packages/filigran-rich-text-editor/.npmignore
+++ b/packages/filigran-rich-text-editor/.npmignore
@@ -1,0 +1,6 @@
+dist/
+node_modules/
+src/
+*.config.*
+tsconfig*.json
+base.json

--- a/packages/filigran-rich-text-editor/README.md
+++ b/packages/filigran-rich-text-editor/README.md
@@ -1,0 +1,35 @@
+# @filigran/rich-text-editor
+
+TipTap-based rich text editor component with MUI toolbar for Filigran products.
+
+## Installation
+
+```bash
+yarn add @filigran/rich-text-editor
+```
+
+### Peer dependencies
+
+```bash
+yarn add react react-dom \
+  @mui/material @mui/icons-material @mui/styles \
+  @tiptap/core @tiptap/react @tiptap/starter-kit \
+  @tiptap/extension-color @tiptap/extension-highlight @tiptap/extension-image \
+  @tiptap/extension-mention @tiptap/extension-paragraph @tiptap/extension-placeholder \
+  @tiptap/extension-subscript @tiptap/extension-superscript @tiptap/extension-table \
+  @tiptap/extension-task-item @tiptap/extension-task-list @tiptap/extension-text-align \
+  @tiptap/extension-text-style @tiptap/extension-typography @tiptap/pm \
+  react-color
+```
+
+## Usage
+
+```tsx
+import { RichTextEditor } from '@filigran/rich-text-editor'
+import '@filigran/rich-text-editor/styles.css'
+
+<RichTextEditor
+  value={content}
+  onChange={setContent}
+/>
+```

--- a/packages/filigran-rich-text-editor/base.json
+++ b/packages/filigran-rich-text-editor/base.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "Default",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": true,
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "inlineSources": false,
+    "isolatedModules": true,
+    "moduleResolution": "bundler",
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "preserveWatchOutput": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "downlevelIteration": true
+  },
+  "exclude": ["node_modules"]
+}

--- a/packages/filigran-rich-text-editor/package.json
+++ b/packages/filigran-rich-text-editor/package.json
@@ -20,7 +20,7 @@
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
-    "./styles.css": "./dist/styles.css"
+    "./styles.css": "./dist/index.css"
   },
   "scripts": {
     "build": "rimraf dist && tsup",

--- a/packages/filigran-rich-text-editor/package.json
+++ b/packages/filigran-rich-text-editor/package.json
@@ -27,8 +27,6 @@
     "check-ts": "tsc --noEmit"
   },
   "peerDependencies": {
-    "react": ">=18",
-    "react-dom": ">=18",
     "@mui/icons-material": ">=5",
     "@mui/material": ">=5",
     "@mui/styles": ">=5",
@@ -50,7 +48,9 @@
     "@tiptap/pm": ">=3",
     "@tiptap/react": ">=3",
     "@tiptap/starter-kit": ">=3",
-    "react-color": ">=2"
+    "react": ">=18",
+    "react-color": ">=2",
+    "react-dom": ">=18"
   },
   "devDependencies": {
     "@mui/icons-material": "6.5.0",

--- a/packages/filigran-rich-text-editor/package.json
+++ b/packages/filigran-rich-text-editor/package.json
@@ -1,0 +1,86 @@
+{
+  "name": "@filigran/rich-text-editor",
+  "description": "Filigran Rich Text Editor",
+  "author": "Filigran",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/FiligranHQ/filigran-ui.git"
+  },
+  "version": "1.0.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./styles.css": "./dist/styles.css"
+  },
+  "scripts": {
+    "build": "rimraf dist && tsup",
+    "check-ts": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "react": ">=18",
+    "react-dom": ">=18",
+    "@mui/icons-material": ">=5",
+    "@mui/material": ">=5",
+    "@mui/styles": ">=5",
+    "@tiptap/core": ">=3",
+    "@tiptap/extension-color": ">=3",
+    "@tiptap/extension-highlight": ">=3",
+    "@tiptap/extension-image": ">=3",
+    "@tiptap/extension-mention": ">=3",
+    "@tiptap/extension-paragraph": ">=3",
+    "@tiptap/extension-placeholder": ">=3",
+    "@tiptap/extension-subscript": ">=3",
+    "@tiptap/extension-superscript": ">=3",
+    "@tiptap/extension-table": ">=3",
+    "@tiptap/extension-task-item": ">=3",
+    "@tiptap/extension-task-list": ">=3",
+    "@tiptap/extension-text-align": ">=3",
+    "@tiptap/extension-text-style": ">=3",
+    "@tiptap/extension-typography": ">=3",
+    "@tiptap/pm": ">=3",
+    "@tiptap/react": ">=3",
+    "@tiptap/starter-kit": ">=3",
+    "react-color": ">=2"
+  },
+  "devDependencies": {
+    "@mui/icons-material": "6.5.0",
+    "@mui/material": "6.5.0",
+    "@mui/styles": "6.5.0",
+    "@tiptap/core": "3.23.1",
+    "@tiptap/extension-color": "3.23.1",
+    "@tiptap/extension-highlight": "3.23.1",
+    "@tiptap/extension-image": "3.23.1",
+    "@tiptap/extension-mention": "3.23.1",
+    "@tiptap/extension-paragraph": "3.23.1",
+    "@tiptap/extension-placeholder": "3.23.1",
+    "@tiptap/extension-subscript": "3.23.1",
+    "@tiptap/extension-superscript": "3.23.1",
+    "@tiptap/extension-table": "3.23.1",
+    "@tiptap/extension-task-item": "3.23.1",
+    "@tiptap/extension-task-list": "3.23.1",
+    "@tiptap/extension-text-align": "3.23.1",
+    "@tiptap/extension-text-style": "3.23.1",
+    "@tiptap/extension-typography": "3.23.1",
+    "@tiptap/pm": "3.23.1",
+    "@tiptap/react": "3.23.1",
+    "@tiptap/starter-kit": "3.23.1",
+    "@types/react": "19.2.14",
+    "@types/react-color": "3.0.13",
+    "react": "19.2.4",
+    "react-color": "2.19.3",
+    "react-dom": "19.2.4",
+    "rimraf": "6.0.1",
+    "tsup": "8.5.0",
+    "typescript": "5.9.3"
+  }
+}

--- a/packages/filigran-rich-text-editor/src/RichTextEditor.tsx
+++ b/packages/filigran-rich-text-editor/src/RichTextEditor.tsx
@@ -39,7 +39,7 @@ import type { Theme } from '@mui/material/styles';
 import { TaskList } from './richTextEditor/extensions/TaskList';
 import { TaskItem } from './richTextEditor/extensions/TaskListItem';
 
-import '../static/css/TiptapEditor.css';
+import './styles/TiptapEditor.css';
 
 export const TIPTAP_EDITOR_SELECTOR = '.tiptap-editor-content.ProseMirror';
 

--- a/packages/filigran-rich-text-editor/src/RichTextEditor.tsx
+++ b/packages/filigran-rich-text-editor/src/RichTextEditor.tsx
@@ -1,0 +1,1048 @@
+import { Editor, EditorContent, useEditor } from '@tiptap/react';
+import { TextSelection, NodeSelection } from '@tiptap/pm/state';
+import StarterKit from '@tiptap/starter-kit';
+import { ImageWithOptions } from './richTextEditor/extensions/ImageWithOptions';
+import Subscript from '@tiptap/extension-subscript';
+import Superscript from '@tiptap/extension-superscript';
+import TextAlign from '@tiptap/extension-text-align';
+import { Highlight } from './richTextEditor/extensions/Highlight';
+import { TextStyle } from './richTextEditor/extensions/TextStyle';
+import Color from '@tiptap/extension-color';
+import { FontFamily } from '@tiptap/extension-text-style/font-family';
+import { BackgroundColor } from '@tiptap/extension-text-style/background-color';
+import Typography from '@tiptap/extension-typography';
+import Mention from '@tiptap/extension-mention';
+import { TableRow } from '@tiptap/extension-table';
+import { Table } from './richTextEditor/extensions/Table';
+import { NestedTableCell } from './richTextEditor/extensions/TableCell';
+import { NestedTableHeader } from './richTextEditor/extensions/TableHeader';
+import Placeholder from '@tiptap/extension-placeholder';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useTheme } from '@mui/styles';
+import Popover from '@mui/material/Popover';
+import TextField from '@mui/material/TextField';
+import Button from '@mui/material/Button';
+import Stack from '@mui/material/Stack';
+import Tabs from '@mui/material/Tabs';
+import Tab from '@mui/material/Tab';
+import MuiTypography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
+import IconButton from '@mui/material/IconButton';
+import { EditOutlined } from '@mui/icons-material';
+import { TiptapEditorToolbar } from './richTextEditor/TiptapEditorToolbar';
+import { TableContextMenu } from './richTextEditor/TableContextMenu';
+import { PageBreak } from './richTextEditor/extensions/PageBreak';
+import { TableCellSplit } from './richTextEditor/extensions/TableCellSplit';
+import { FontSize } from './richTextEditor/extensions/FontSize';
+import { Paragraph } from './richTextEditor/extensions/Paragraph';
+import type { Theme } from '@mui/material/styles';
+import { TaskList } from './richTextEditor/extensions/TaskList';
+import { TaskItem } from './richTextEditor/extensions/TaskListItem';
+
+import '../static/css/TiptapEditor.css';
+
+export const TIPTAP_EDITOR_SELECTOR = '.tiptap-editor-content.ProseMirror';
+
+export interface RichTextEditorAdapter {
+  getData: () => string;
+}
+
+export interface RichTextEditorProps {
+  id?: string;
+  data?: string;
+  onChange?: (evt: unknown, editor: RichTextEditorAdapter) => void;
+  onReady?: (editor: Editor) => void;
+  onBlur?: (evt: unknown, editor: RichTextEditorAdapter) => void;
+  onFocus?: (evt: unknown) => void;
+  disabled?: boolean;
+  disableWatchdog?: boolean;
+  placeholder?: string;
+}
+
+const createEditorAdapter = (editor: Editor): RichTextEditorAdapter => ({
+  getData: () => editor.getHTML(),
+});
+
+export const RichTextEditor: React.FC<RichTextEditorProps> = ({
+  id,
+  data = '',
+  onChange,
+  onReady,
+  onBlur,
+  onFocus,
+  disabled = false,
+  placeholder = '',
+}) => {
+  const theme = useTheme<Theme>();
+  const isDark = theme.palette?.mode === 'dark';
+  const initialContentRef = useRef(data);
+  const onChangeRef = useRef(onChange);
+  const editorRef = useRef<Editor | null>(null);
+  onChangeRef.current = onChange;
+
+  const [sourceMode, setSourceMode] = useState(false);
+  const [sourceHtml, setSourceHtml] = useState('');
+
+  const formatHtml = (html: string): string => {
+    let indent = 0;
+    const tab = '  ';
+    // Split on tags while keeping the delimiters
+    return html
+      .replace(/>\s*</g, '><')
+      .split(/(<[^>]+>)/)
+      .reduce((acc, token) => {
+        if (!token) return acc;
+        if (/^<\//.test(token)) {
+          indent = Math.max(0, indent - 1);
+          return `${acc}\n${tab.repeat(indent)}${token}`;
+        }
+        if (/^<[^/!][^>]*[^/]>$/.test(token) && !/^<(br|hr|img|input|link|meta|area|base|col|embed|param|source|track|wbr)[\s/>]/i.test(token)) {
+          const line = `\n${tab.repeat(indent)}${token}`;
+          indent += 1;
+          return acc + line;
+        }
+        return `${acc}\n${tab.repeat(indent)}${token}`;
+      }, '')
+      .trimStart();
+  };
+
+  const toggleSourceMode = useCallback(() => {
+    if (!editorRef.current) return;
+    if (!sourceMode) {
+      // switching TO source mode: snapshot current HTML, pretty-printed
+      setSourceHtml(formatHtml(editorRef.current.getHTML()));
+    } else {
+      // switching FROM source mode: apply textarea content back to editor
+      editorRef.current.commands.setContent(sourceHtml);
+      onChangeRef.current?.(undefined, createEditorAdapter(editorRef.current));
+    }
+    setSourceMode((prev) => !prev);
+  }, [sourceMode, sourceHtml]);
+
+  const [linkPopover, setLinkPopover] = useState<{
+    open: boolean;
+    position: { top: number; left: number } | null;
+    url: string;
+    text: string;
+    selectionRange: { from: number; to: number } | null; /* stored when opening - used when applying */
+  }>({ open: false, position: null, url: '', text: '', selectionRange: null });
+  const linkPopoverCallbackRef = useRef<(
+    open: boolean,
+    position: { top: number; left: number } | null,
+    url: string,
+    text: string,
+    selectionRange: { from: number; to: number } | null,
+  ) => void>(() => {});
+
+  const [imagePopover, setImagePopover] = useState<{
+    open: boolean;
+    position: { top: number; left: number } | null;
+    url: string;
+    tab: 'url' | 'upload';
+    alt: string;
+    title: string;
+  }>({ open: false, position: null, url: '', tab: 'url', alt: '', title: '' });
+  const imageFileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const [imageOptionsPopover, setImageOptionsPopover] = useState<{
+    open: boolean;
+    position: { top: number; left: number } | null;
+    /** Node position of the image being edited; needed to restore selection before updateAttributes */
+    imagePos: number | null;
+    alt: string;
+    title: string;
+    caption: string;
+    href: string;
+  }>({ open: false, position: null, imagePos: null, alt: '', title: '', caption: '', href: '' });
+
+  const [tableContextMenu, setTableContextMenu] = useState<{
+    open: boolean;
+    position: { top: number; left: number } | null;
+  }>({ open: false, position: null });
+
+  /** When an image is selected, show edit icon (do not auto-open options popover). Popover opens only on icon click. */
+  const [imageEditButton, setImageEditButton] = useState<{
+    pos: number;
+    attrs: Record<string, unknown>;
+    rect: { top: number; right: number; bottom: number; left: number };
+    /** Position relative to editor wrapper so icon scrolls with content */
+    relativeTop: number;
+    relativeLeft: number;
+  } | null>(null);
+  const editorWrapRef = useRef<HTMLDivElement | null>(null);
+  const editorContentWrapRef = useRef<HTMLDivElement | null>(null);
+  const imageEditPosRef = useRef<number | null>(null);
+  const imageOptionsPopoverOpenRef = useRef(false);
+  imageEditPosRef.current = imageEditButton?.pos ?? null;
+  imageOptionsPopoverOpenRef.current = imageOptionsPopover.open;
+
+  const editor = useEditor({
+    immediatelyRender: false,
+    extensions: [
+      StarterKit.configure({
+        heading: { levels: [1, 2, 3] },
+        paragraph: false,
+        link: {
+          autolink: true,
+          linkOnPaste: true,
+          openOnClick: false,
+          HTMLAttributes: {
+            style: `color: ${isDark ? '#00b1ff' : '#0066cc'}`,
+            target: '_blank',
+            rel: 'noopener noreferrer',
+          },
+        },
+      }),
+      ImageWithOptions.configure({
+        inline: false,
+        allowBase64: true,
+        resize: {
+          enabled: true,
+          directions: ['bottom-right', 'bottom-left', 'top-right', 'top-left'],
+          minWidth: 8,
+          minHeight: 8,
+          alwaysPreserveAspectRatio: true,
+        },
+      }),
+      Subscript,
+      Superscript,
+      TextAlign.configure({ types: ['heading', 'paragraph'] }),
+      Paragraph,
+      Highlight,
+      TextStyle,
+      Color,
+      BackgroundColor,
+      FontFamily,
+      FontSize,
+      Typography,
+      Mention.configure({
+        HTMLAttributes: {
+          class: 'mention',
+        },
+        suggestion: {
+          char: '@',
+          allowSpaces: false,
+          items: async () => [],
+        },
+      }),
+      TaskList,
+      TaskItem.configure({
+        nested: true,
+        HTMLAttributes: { class: 'tiptap-task-item' },
+      }),
+      Table.configure({ resizable: true }),
+      TableRow,
+      NestedTableHeader,
+      NestedTableCell,
+      Placeholder.configure({ placeholder }),
+      PageBreak,
+      TableCellSplit,
+    ],
+    content: initialContentRef.current,
+    editable: !disabled,
+    editorProps: {
+      attributes: {
+        class: 'tiptap-editor-content',
+        'aria-label': 'Editing area: main',
+        ...(id ? { 'data-editor-id': id } : {}),
+      },
+      handlePaste: (_view, event) => {
+        const items = event.clipboardData?.items;
+        if (!items) return false;
+        for (const item of Array.from(items)) {
+          if (item.type.startsWith('image/')) {
+            const file = item.getAsFile();
+            if (file) {
+              const reader = new FileReader();
+              reader.onload = () => {
+                const result = reader.result as string;
+                if (result) {
+                  editorRef.current?.chain().focus().setImage({ src: result }).run();
+                }
+              };
+              reader.readAsDataURL(file);
+              return true;
+            }
+          }
+        }
+        return false;
+      },
+      handleClick: (view, pos, event) => {
+        if (disabled) return false;
+        const target = event.target as HTMLElement;
+        const link = target.closest('a');
+        if (link) {
+          // Linked images are edited through image options, not link popover.
+          const clickedImage = target.closest('img');
+          if (clickedImage && link.contains(clickedImage)) {
+            event.preventDefault();
+            return true;
+          }
+
+          // Text links: keep click-to-edit behavior (no navigation).
+          event.preventDefault();
+          const href = link.getAttribute('href') ?? '';
+          const linkStart = view.posAtDOM(link, 0);
+          const linkEnd = view.posAtDOM(link, 1);
+          editorRef.current?.chain().focus().setTextSelection({ from: linkStart, to: linkEnd }).run();
+          const coords = view.coordsAtPos(pos);
+          linkPopoverCallbackRef.current(true, { top: coords.bottom + 4, left: coords.left }, href, link.textContent ?? '', {
+            from: linkStart,
+            to: linkEnd,
+          });
+          return true;
+        }
+        return false;
+      },
+      handleDrop: (_view, event) => {
+        const files = event.dataTransfer?.files;
+        if (!files?.length) return false;
+        const file = files[0];
+        if (file.type.startsWith('image/')) {
+          const reader = new FileReader();
+          reader.onload = () => {
+            const result = reader.result as string;
+            if (result) {
+              editorRef.current?.chain().focus().setImage({ src: result }).run();
+            }
+          };
+          reader.readAsDataURL(file);
+          event.preventDefault();
+          return true;
+        }
+        return false;
+      },
+    },
+  } as Parameters<typeof useEditor>[0]);
+
+  useEffect(() => {
+    editorRef.current = editor ?? null;
+  }, [editor]);
+
+  linkPopoverCallbackRef.current = (
+    open: boolean,
+    position: { top: number; left: number } | null,
+    url: string,
+    text: string,
+    selectionRange: { from: number; to: number } | null,
+  ) => {
+    setLinkPopover({ open, position, url, text, selectionRange });
+  };
+
+  const openLinkPopoverFromToolbar = useCallback(() => {
+    if (!editor) return;
+    const { from, to } = editor.state.selection;
+    const coords = editor.view.coordsAtPos(from);
+    const hasSelection = from !== to;
+    setLinkPopover({
+      open: true,
+      position: { top: coords.bottom + 4, left: coords.left },
+      url: editor.getAttributes('link').href ?? '',
+      text: hasSelection ? editor.state.doc.textBetween(from, to, ' ') : '',
+      selectionRange: hasSelection ? { from, to } : null,
+    });
+  }, [editor]);
+
+  const closeLinkPopover = useCallback(() => {
+    setLinkPopover((p) => ({ ...p, open: false }));
+  }, []);
+
+  const moveCursorAfterLink = useCallback((pos: number) => {
+    if (!editor) return;
+    const { state, view } = editor;
+    const tr = state.tr
+      .setSelection(TextSelection.create(state.doc, pos))
+      .setStoredMarks([]);
+    view.dispatch(tr);
+  }, [editor]);
+
+  const applyLink = useCallback(() => {
+    if (!editor) return;
+    const url = linkPopover.url.trim();
+    const storedRange = linkPopover.selectionRange;
+    const linkText = linkPopover.text;
+
+    if (url === '') {
+      if (storedRange) {
+        editor.chain().focus().setTextSelection(storedRange).unsetLink().run();
+        moveCursorAfterLink(storedRange.to);
+      } else if (editor.isActive('link')) {
+        editor.chain().focus().extendMarkRange('link').unsetLink().run();
+      }
+    } else if (storedRange) {
+      const currentText = editor.state.doc.textBetween(storedRange.from, storedRange.to, ' ');
+      const nextText = linkText !== '' ? linkText : currentText;
+      editor
+        .chain()
+        .focus()
+        .insertContentAt({ from: storedRange.from, to: storedRange.to }, nextText)
+        .setTextSelection({ from: storedRange.from, to: storedRange.from + nextText.length })
+        .setLink({ href: url })
+        .run();
+      moveCursorAfterLink(storedRange.from + nextText.length);
+    } else {
+      const text = linkText.trim() || url;
+      const escapedUrl = url
+        .replace(/&/g, '&amp;')
+        .replace(/"/g, '&quot;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+      const escapedText = text
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+      editor
+        .chain()
+        .focus()
+        .insertContent(`<a href="${escapedUrl}">${escapedText}</a>`)
+        .run();
+      moveCursorAfterLink(editor.state.selection.to);
+    }
+    closeLinkPopover();
+  }, [editor, linkPopover.url, linkPopover.text, linkPopover.selectionRange, closeLinkPopover, moveCursorAfterLink]);
+
+  const removeLink = useCallback(() => {
+    if (!editor) return;
+    const storedRange = linkPopover.selectionRange;
+    if (storedRange) {
+      editor.chain().focus().setTextSelection(storedRange).unsetLink().run();
+    } else {
+      editor.chain().focus().extendMarkRange('link').unsetLink().run();
+    }
+    closeLinkPopover();
+  }, [editor, linkPopover.selectionRange, closeLinkPopover]);
+
+  const openImagePopoverFromToolbar = useCallback(() => {
+    if (!editor) return;
+    const { from } = editor.state.selection;
+    const coords = editor.view.coordsAtPos(from);
+    setImagePopover({
+      open: true,
+      position: { top: coords.bottom + 4, left: coords.left },
+      url: '',
+      tab: 'url',
+      alt: '',
+      title: '',
+    });
+  }, [editor]);
+
+  const closeImagePopover = useCallback(() => {
+    setImagePopover((p) => ({ ...p, open: false }));
+    if (imageFileInputRef.current) {
+      imageFileInputRef.current.value = '';
+    }
+  }, []);
+
+  const applyImageFromUrl = useCallback(() => {
+    if (!editor) return;
+    const url = imagePopover.url.trim();
+    if (url) {
+      editor.chain().focus().setImage({
+        src: url,
+        alt: imagePopover.alt || undefined,
+        title: imagePopover.title || undefined,
+      }).run();
+    }
+    closeImagePopover();
+  }, [editor, imagePopover.url, imagePopover.alt, imagePopover.title, closeImagePopover]);
+
+  const handleImageFileSelect = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (!file || !file.type.startsWith('image/') || !editor) return;
+      const reader = new FileReader();
+      reader.onload = () => {
+        const result = reader.result as string;
+        if (result) {
+          editor.chain().focus().setImage({
+            src: result,
+            alt: imagePopover.alt || undefined,
+            title: imagePopover.title || undefined,
+          }).run();
+        }
+        closeImagePopover();
+        if (imageFileInputRef.current) {
+          imageFileInputRef.current.value = '';
+        }
+      };
+      reader.readAsDataURL(file);
+    },
+    [editor, closeImagePopover, imagePopover.alt, imagePopover.title],
+  );
+
+  const closeImageOptionsPopover = useCallback(() => {
+    setImageOptionsPopover((p) => ({ ...p, open: false }));
+  }, []);
+
+  const applyImageOptions = useCallback(() => {
+    if (!editor) return;
+    const pos = imageOptionsPopover.imagePos;
+    const attrs = {
+      alt: imageOptionsPopover.alt || null,
+      title: imageOptionsPopover.title || null,
+      caption: imageOptionsPopover.caption || null,
+      href: imageOptionsPopover.href?.trim() || null,
+    };
+    if (pos == null) {
+      closeImageOptionsPopover();
+      return;
+    }
+    // Apply synchronously before closing popover, so mode switches/onBlur
+    // don't overwrite content with stale HTML.
+    const { state, view } = editor;
+    const node = state.doc.nodeAt(pos);
+    if (!node || node.type.name !== 'image') return;
+    const tr = state.tr
+      .setSelection(NodeSelection.create(state.doc, pos))
+      .setNodeMarkup(pos, undefined, { ...node.attrs, ...attrs });
+    view.dispatch(tr);
+    // Force immediate upstream sync to avoid losing attrs on fast mode toggles
+    // where blur/update listeners can race with unmount.
+    if (onChangeRef.current) {
+      onChangeRef.current(null, createEditorAdapter(editor));
+    }
+    closeImageOptionsPopover();
+  }, [editor, imageOptionsPopover, closeImageOptionsPopover]);
+
+  /** Get the visual element for the image (img or figure), not the resize wrapper. */
+  const getImageVisualElement = useCallback((dom: Node | null): HTMLElement | null => {
+    if (!(dom instanceof HTMLElement)) return null;
+    const figure = dom.classList?.contains('image-figure') ? dom : dom.querySelector('.image-figure');
+    const img = dom.tagName === 'IMG' ? dom : dom.querySelector('img');
+    return (figure ?? img ?? dom) as HTMLElement;
+  }, []);
+
+  // Compute icon position relative to the inner content wrapper so the icon scrolls with the editor content.
+  // Icon sits slightly inside the image (bottom-right), left of the resize handle.
+  const computeRelativePos = useCallback(
+    (imageRect: DOMRect, contentWrap: HTMLDivElement) => {
+      const wrapRect = contentWrap.getBoundingClientRect();
+      const iconWidth = 28;
+      const gapFromHandle = 14;
+      return {
+        relativeTop: imageRect.bottom - wrapRect.top - 24,
+        relativeLeft: imageRect.right - wrapRect.left - iconWidth - gapFromHandle,
+      };
+    },
+    [],
+  );
+
+  const updateImageEditButtonRect = useCallback(() => {
+    const pos = imageEditPosRef.current;
+    if (!editor || pos == null || !editorContentWrapRef.current) return;
+    const dom = editor.view.nodeDOM(pos);
+    const el = getImageVisualElement(dom);
+    const contentWrap = editorContentWrapRef.current;
+    if (!el || !contentWrap) {
+      setImageEditButton(null);
+      return;
+    }
+    const rect = el.getBoundingClientRect();
+    const { relativeTop, relativeLeft } = computeRelativePos(rect, contentWrap);
+    setImageEditButton((prev) =>
+      prev
+        ? {
+            ...prev,
+            rect: { top: rect.top, right: rect.right, bottom: rect.bottom, left: rect.left },
+            relativeTop,
+            relativeLeft,
+          }
+        : null,
+    );
+  }, [editor, getImageVisualElement, computeRelativePos]);
+
+  /** Show edit icon when mouse is over an image (hover), not on selection. */
+  useEffect(() => {
+    if (!editor || !editorContentWrapRef.current || disabled) return;
+    const view = editor.view;
+    const contentWrap = editorContentWrapRef.current;
+
+    const getImageUnderCoords = (clientX: number, clientY: number) => {
+      const result = view.posAtCoords({ left: clientX, top: clientY });
+      if (!result) return null;
+      const { pos } = result;
+      const { doc } = editor.state;
+      const $pos = doc.resolve(pos);
+      const nodeAfter = $pos.nodeAfter;
+      const nodeBefore = $pos.nodeBefore;
+      if (nodeAfter?.type.name === 'image') {
+        return { node: nodeAfter, pos };
+      }
+      if (nodeBefore?.type.name === 'image') {
+        return { node: nodeBefore, pos: pos - nodeBefore.nodeSize };
+      }
+      return null;
+    };
+
+    const onMouseMove = (e: MouseEvent) => {
+      const hit = getImageUnderCoords(e.clientX, e.clientY);
+      if (!hit) {
+        setImageEditButton(null);
+        return;
+      }
+      const dom = view.nodeDOM(hit.pos);
+      const el = getImageVisualElement(dom);
+      const rect = el?.getBoundingClientRect();
+      if (!rect || !contentWrap) {
+        setImageEditButton(null);
+        return;
+      }
+      const { relativeTop, relativeLeft } = computeRelativePos(rect, contentWrap);
+      setImageEditButton({
+        pos: hit.pos,
+        attrs: hit.node.attrs,
+        rect: { top: rect.top, right: rect.right, bottom: rect.bottom, left: rect.left },
+        relativeTop,
+        relativeLeft,
+      });
+    };
+
+    const onMouseLeave = () => {
+      if (imageOptionsPopoverOpenRef.current) return;
+      setImageEditButton(null);
+    };
+
+    const el = contentWrap;
+    el.addEventListener('mousemove', onMouseMove);
+    el.addEventListener('mouseleave', onMouseLeave);
+    return () => {
+      el.removeEventListener('mousemove', onMouseMove);
+      el.removeEventListener('mouseleave', onMouseLeave);
+    };
+  }, [editor, disabled, getImageVisualElement, computeRelativePos]);
+
+  useEffect(() => {
+    if (!imageEditButton || !editorWrapRef.current) return;
+    const scrollEl = editorWrapRef.current;
+    const onScroll = () => updateImageEditButtonRect();
+    scrollEl.addEventListener('scroll', onScroll, true);
+    return () => scrollEl.removeEventListener('scroll', onScroll, true);
+  }, [imageEditButton, updateImageEditButtonRect]);
+
+  const openImageOptionsFromEditIcon = useCallback(() => {
+    if (!imageEditButton) return;
+    setImageOptionsPopover({
+      open: true,
+      position: { top: imageEditButton.rect.bottom + 4, left: imageEditButton.rect.left },
+      imagePos: imageEditButton.pos,
+      alt: String(imageEditButton.attrs.alt ?? ''),
+      title: String(imageEditButton.attrs.title ?? ''),
+      caption: String(imageEditButton.attrs.caption ?? ''),
+      href: String(imageEditButton.attrs.href ?? ''),
+    });
+  }, [imageEditButton]);
+
+  const handleTableContextMenu = useCallback(
+    (e: React.MouseEvent) => {
+      if (!editor || disabled) return;
+      if (editor.isActive('table')) {
+        e.preventDefault();
+        setTableContextMenu({
+          open: true,
+          position: { top: e.clientY, left: e.clientX },
+        });
+      }
+    },
+    [editor, disabled],
+  );
+
+  const closeTableContextMenu = useCallback(() => {
+    setTableContextMenu({ open: false, position: null });
+    // Preserve scroll position: closing the menu can trigger ProseMirror
+    // scrollIntoView which jumps the editor to the cursor.
+    const scrollEl = editorWrapRef.current;
+    if (scrollEl) {
+      const { scrollTop, scrollLeft } = scrollEl;
+      requestAnimationFrame(() => {
+        scrollEl.scrollTop = scrollTop;
+        scrollEl.scrollLeft = scrollLeft;
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    if (editor && onReady) {
+      onReady(editor);
+    }
+  }, [editor, onReady]);
+
+  useEffect(() => {
+    if (!editor || editor.isDestroyed) return;
+    if (data !== undefined && data !== editor.getHTML()) {
+      editor.commands.setContent(data || '<p></p>', { emitUpdate: false });
+    }
+  }, [data, editor]);
+
+  useEffect(() => {
+    if (editor) editor.setEditable(!disabled);
+  }, [editor, disabled]);
+
+  useEffect(() => {
+    if (!editor) return;
+    const handler = () => {
+      if (onChangeRef.current) {
+        onChangeRef.current(null, createEditorAdapter(editor));
+      }
+    };
+    editor.on('update', handler);
+    return () => {
+      editor.off('update', handler);
+    };
+  }, [editor]);
+
+  useEffect(() => {
+    if (!editor || !onBlur) return;
+    const handler = ({ event }: { event: FocusEvent }) => onBlur(event, createEditorAdapter(editor));
+    editor.on('blur', handler);
+    return () => {
+      editor.off('blur', handler);
+    };
+  }, [editor, onBlur]);
+
+  useEffect(() => {
+    if (!editor || !onFocus) return;
+    const handler = ({ event }: { event: FocusEvent }) => onFocus(event);
+    editor.on('focus', handler);
+    return () => {
+      editor.off('focus', handler);
+    };
+  }, [editor, onFocus]);
+
+  if (!editor) {
+    return null;
+  }
+
+  return (
+    <div
+      className="rich-text-editor-wrapper"
+      style={{ height: '100%', display: 'flex', flexDirection: 'column' }}
+    >
+      <TiptapEditorToolbar
+        editor={editor}
+        disabled={disabled}
+        onOpenLinkPopover={openLinkPopoverFromToolbar}
+        onOpenImagePopover={openImagePopoverFromToolbar}
+        isSourceMode={sourceMode}
+        onToggleSourceMode={toggleSourceMode}
+      />
+      <div
+        ref={editorWrapRef}
+        style={{ flex: 1, minHeight: 0, overflow: 'auto' }}
+      >
+        {sourceMode ? (
+          <textarea
+            value={sourceHtml}
+            onChange={(e) => setSourceHtml(e.target.value)}
+            style={{
+              width: '100%',
+              height: '100%',
+              minHeight: 200,
+              padding: 12,
+              fontFamily: 'monospace',
+              fontSize: 13,
+              border: 'none',
+              outline: 'none',
+              resize: 'none',
+              background: 'transparent',
+              color: 'inherit',
+              boxSizing: 'border-box',
+            }}
+            spellCheck={false}
+          />
+        ) : (
+          <div
+            ref={editorContentWrapRef}
+            onContextMenu={handleTableContextMenu}
+            style={{ position: 'relative', minHeight: '100%' }}
+          >
+            <EditorContent editor={editor} />
+            {!disabled && imageEditButton && !imageOptionsPopover.open && (
+              <IconButton
+                size="small"
+                aria-label="Edit image options"
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  openImageOptionsFromEditIcon();
+                }}
+                sx={{
+                  position: 'absolute',
+                  top: imageEditButton.relativeTop,
+                  left: imageEditButton.relativeLeft,
+                  width: 28,
+                  height: 28,
+                  backgroundColor: 'background.paper',
+                  border: '1px solid',
+                  borderColor: 'divider',
+                  boxShadow: 1,
+                  '&:hover': { backgroundColor: 'action.hover' },
+                  zIndex: 10,
+                }}
+              >
+                <EditOutlined sx={{ fontSize: 16 }} />
+              </IconButton>
+            )}
+          </div>
+        )}
+      </div>
+      <Popover
+        open={linkPopover.open}
+        onClose={closeLinkPopover}
+        anchorReference="anchorPosition"
+        anchorPosition={
+          linkPopover.position
+            ? { top: linkPopover.position.top, left: linkPopover.position.left }
+            : undefined
+        }
+        transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+        PaperProps={{
+          sx: { mt: 0.5 },
+          onKeyDownCapture: (e: React.KeyboardEvent) => {
+            if (e.key === 'Enter' || e.key === 'Escape') {
+              e.preventDefault();
+              e.stopPropagation();
+              if (e.key === 'Enter') applyLink();
+              else closeLinkPopover();
+            }
+          },
+        }}
+      >
+        <Stack sx={{ p: 2, minWidth: 280 }} spacing={1}>
+          <TextField
+            size="small"
+            label="Text"
+            placeholder="Link text"
+            value={linkPopover.text}
+            onChange={(e) => setLinkPopover((p) => ({ ...p, text: e.target.value }))}
+            fullWidth
+          />
+          <TextField
+            size="small"
+            label="URL"
+            placeholder="https://"
+            value={linkPopover.url}
+            onChange={(e) => setLinkPopover((p) => ({ ...p, url: e.target.value }))}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                e.stopPropagation();
+                applyLink();
+              }
+              if (e.key === 'Escape') {
+                e.preventDefault();
+                e.stopPropagation();
+                closeLinkPopover();
+              }
+            }}
+            autoFocus
+            fullWidth
+          />
+          <Stack direction="row" spacing={1} justifyContent="flex-end">
+            {editor.isActive('link') && (
+              <Button size="small" onClick={removeLink} color="error">
+                Remove link
+              </Button>
+            )}
+            <Button size="small" variant="contained" onClick={applyLink}>
+              Apply
+            </Button>
+          </Stack>
+        </Stack>
+      </Popover>
+      <Popover
+        open={imagePopover.open}
+        onClose={closeImagePopover}
+        anchorReference="anchorPosition"
+        anchorPosition={
+          imagePopover.position
+            ? { top: imagePopover.position.top, left: imagePopover.position.left }
+            : undefined
+        }
+        transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+        PaperProps={{
+          sx: { mt: 0.5 },
+          onKeyDownCapture: (e: React.KeyboardEvent) => {
+            if (e.key === 'Escape') {
+              e.preventDefault();
+              e.stopPropagation();
+              closeImagePopover();
+            }
+          },
+        }}
+      >
+        <Stack sx={{ p: 0, minWidth: 320 }} spacing={0}>
+          <Tabs
+            value={imagePopover.tab}
+            onChange={(_e, v: 'url' | 'upload') => setImagePopover((p) => ({ ...p, tab: v }))}
+            variant="fullWidth"
+            sx={{ borderBottom: 1, borderColor: 'divider', minHeight: 40 }}
+          >
+            <Tab label="By URL" value="url" />
+            <Tab label="Upload" value="upload" />
+          </Tabs>
+          <Box sx={{ p: 2 }}>
+            {imagePopover.tab === 'url' && (
+              <Stack spacing={1.5}>
+                <TextField
+                  size="small"
+                  label="Image URL"
+                  placeholder="https://…"
+                  value={imagePopover.url}
+                  onChange={(e) => setImagePopover((p) => ({ ...p, url: e.target.value }))}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      e.preventDefault();
+                      applyImageFromUrl();
+                    }
+                    if (e.key === 'Escape') closeImagePopover();
+                  }}
+                  autoFocus
+                  fullWidth
+                />
+                <TextField
+                  size="small"
+                  label="Alt text"
+                  placeholder="Optional description"
+                  value={imagePopover.alt}
+                  onChange={(e) => setImagePopover((p) => ({ ...p, alt: e.target.value }))}
+                  fullWidth
+                />
+                <TextField
+                  size="small"
+                  label="Tooltip"
+                  placeholder="Optional tooltip on hover"
+                  value={imagePopover.title}
+                  onChange={(e) => setImagePopover((p) => ({ ...p, title: e.target.value }))}
+                  fullWidth
+                />
+                <Stack direction="row" spacing={1} justifyContent="flex-end">
+                  <Button size="small" onClick={closeImagePopover}>
+                    Cancel
+                  </Button>
+                  <Button size="small" variant="contained" onClick={applyImageFromUrl} disabled={!imagePopover.url.trim()}>
+                    Insert
+                  </Button>
+                </Stack>
+              </Stack>
+            )}
+            {imagePopover.tab === 'upload' && (
+              <Stack spacing={1.5}>
+                <TextField
+                  size="small"
+                  label="Alt text"
+                  placeholder="Optional description"
+                  value={imagePopover.alt}
+                  onChange={(e) => setImagePopover((p) => ({ ...p, alt: e.target.value }))}
+                  fullWidth
+                />
+                <TextField
+                  size="small"
+                  label="Tooltip"
+                  placeholder="Optional tooltip on hover"
+                  value={imagePopover.title}
+                  onChange={(e) => setImagePopover((p) => ({ ...p, title: e.target.value }))}
+                  fullWidth
+                />
+                <Button
+                  size="small"
+                  variant="outlined"
+                  component="label"
+                  fullWidth
+                  sx={{ py: 1.5 }}
+                >
+                  Choose image…
+                  <input
+                    ref={imageFileInputRef}
+                    type="file"
+                    accept="image/*"
+                    onChange={handleImageFileSelect}
+                    hidden
+                  />
+                </Button>
+                <MuiTypography variant="caption" color="text.secondary" sx={{ textAlign: 'center' }}>
+                  Image will be embedded in the content.
+                </MuiTypography>
+              </Stack>
+            )}
+          </Box>
+        </Stack>
+      </Popover>
+      <Popover
+        open={imageOptionsPopover.open}
+        onClose={closeImageOptionsPopover}
+        anchorReference="anchorPosition"
+        anchorPosition={
+          imageOptionsPopover.position
+            ? { top: imageOptionsPopover.position.top, left: imageOptionsPopover.position.left }
+            : undefined
+        }
+        transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+        PaperProps={{
+          sx: { mt: 0.5 },
+          onKeyDownCapture: (e: React.KeyboardEvent) => {
+            if (e.key === 'Enter' || e.key === 'Escape') {
+              e.preventDefault();
+              e.stopPropagation();
+              if (e.key === 'Enter') applyImageOptions();
+              else closeImageOptionsPopover();
+            }
+          },
+        }}
+      >
+        <Stack sx={{ p: 2, minWidth: 320 }} spacing={1.5}>
+          <MuiTypography variant="subtitle2" color="text.secondary">
+            Image options
+          </MuiTypography>
+          <TextField
+            size="small"
+            label="Alt text"
+            placeholder="Description for accessibility"
+            value={imageOptionsPopover.alt}
+            onChange={(e) => setImageOptionsPopover((p) => ({ ...p, alt: e.target.value }))}
+            fullWidth
+          />
+          <TextField
+            size="small"
+            label="Tooltip"
+            placeholder="Tooltip on hover"
+            value={imageOptionsPopover.title}
+            onChange={(e) => setImageOptionsPopover((p) => ({ ...p, title: e.target.value }))}
+            fullWidth
+          />
+          <TextField
+            size="small"
+            label="Caption"
+            placeholder="Caption below image"
+            value={imageOptionsPopover.caption}
+            onChange={(e) => setImageOptionsPopover((p) => ({ ...p, caption: e.target.value }))}
+            fullWidth
+          />
+          <TextField
+            size="small"
+            label="Link"
+            placeholder="https://…"
+            value={imageOptionsPopover.href}
+            onChange={(e) => setImageOptionsPopover((p) => ({ ...p, href: e.target.value }))}
+            fullWidth
+          />
+          <Stack direction="row" spacing={1} justifyContent="flex-end">
+            <Button size="small" onClick={closeImageOptionsPopover}>
+              Cancel
+            </Button>
+            <Button size="small" variant="contained" onClick={applyImageOptions}>
+              Apply
+            </Button>
+          </Stack>
+        </Stack>
+      </Popover>
+      <TableContextMenu
+        editor={editor}
+        open={tableContextMenu.open}
+        position={tableContextMenu.position}
+        onClose={closeTableContextMenu}
+      />
+    </div>
+  );
+};
+
+export default RichTextEditor;

--- a/packages/filigran-rich-text-editor/src/RichTextEditor.tsx
+++ b/packages/filigran-rich-text-editor/src/RichTextEditor.tsx
@@ -38,6 +38,7 @@ import { Paragraph } from './richTextEditor/extensions/Paragraph';
 import type { Theme } from '@mui/material/styles';
 import { TaskList } from './richTextEditor/extensions/TaskList';
 import { TaskItem } from './richTextEditor/extensions/TaskListItem';
+import { Div } from './richTextEditor/extensions/Div';
 
 import './styles/TiptapEditor.css';
 
@@ -237,6 +238,7 @@ export const RichTextEditor: React.FC<RichTextEditorProps> = ({
       Placeholder.configure({ placeholder }),
       PageBreak,
       TableCellSplit,
+      Div,
     ],
     content: initialContentRef.current,
     editable: !disabled,

--- a/packages/filigran-rich-text-editor/src/index.ts
+++ b/packages/filigran-rich-text-editor/src/index.ts
@@ -1,0 +1,2 @@
+export {RichTextEditor, TIPTAP_EDITOR_SELECTOR} from './RichTextEditor'
+export type {RichTextEditorProps, RichTextEditorAdapter} from './RichTextEditor'

--- a/packages/filigran-rich-text-editor/src/richTextEditor/TableContextMenu.tsx
+++ b/packages/filigran-rich-text-editor/src/richTextEditor/TableContextMenu.tsx
@@ -1,0 +1,187 @@
+import type { Editor } from '@tiptap/react';
+import React, { useCallback } from 'react';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import Divider from '@mui/material/Divider';
+import ListSubheader from '@mui/material/ListSubheader';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import { DeleteOutline, MergeType, SplitscreenOutlined, BorderTopOutlined, BorderLeftOutlined, TableChart, AddOutlined, RemoveOutlined } from '@mui/icons-material';
+
+interface TableContextMenuProps {
+  editor: Editor | null;
+  open: boolean;
+  position: { top: number; left: number } | null;
+  onClose: () => void;
+}
+
+const subheaderSx = { lineHeight: '28px', fontSize: '0.72rem', fontWeight: 700 } as const;
+
+/**
+ * Context menu shown on right-click inside a table.
+ *
+ * Exposes all prosemirror-tables operations available via @tiptap/extension-table:
+ * row/column CRUD, header toggles, merge, split, nested table insertion, and delete table.
+ */
+export const TableContextMenu: React.FC<TableContextMenuProps> = ({
+  editor,
+  open,
+  position,
+  onClose,
+}) => {
+  const runAndClose = useCallback(
+    (command: () => void) => {
+      command();
+      onClose();
+    },
+    [onClose],
+  );
+
+  if (!editor) return null;
+
+  const canMerge = editor.can().mergeCells();
+
+  return (
+    <Menu
+      open={open}
+      onClose={onClose}
+      anchorReference="anchorPosition"
+      anchorPosition={position ? { top: position.top, left: position.left } : undefined}
+      /* Prevent MUI from restoring focus to the editor on close —
+         that would trigger ProseMirror's scrollIntoView and jump to the top. */
+      disableRestoreFocus
+      disableAutoFocus
+      slotProps={{ paper: { sx: { minWidth: 220 } } }}
+    >
+      {/* ── Row operations ── */}
+      <ListSubheader sx={subheaderSx}>Row</ListSubheader>
+      <MenuItem
+        dense
+        onClick={() => runAndClose(() => editor.chain().focus().addRowBefore().run())}
+      >
+        <ListItemIcon><AddOutlined fontSize="small" /></ListItemIcon>
+        <ListItemText>Add row above</ListItemText>
+      </MenuItem>
+      <MenuItem
+        dense
+        onClick={() => runAndClose(() => editor.chain().focus().addRowAfter().run())}
+      >
+        <ListItemIcon><AddOutlined fontSize="small" /></ListItemIcon>
+        <ListItemText>Add row below</ListItemText>
+      </MenuItem>
+      <MenuItem
+        dense
+        onClick={() => runAndClose(() => editor.chain().focus().deleteRow().run())}
+      >
+        <ListItemIcon><RemoveOutlined fontSize="small" /></ListItemIcon>
+        <ListItemText>Delete row</ListItemText>
+      </MenuItem>
+
+      <Divider />
+
+      {/* ── Column operations ── */}
+      <ListSubheader sx={subheaderSx}>Column</ListSubheader>
+      <MenuItem
+        dense
+        onClick={() => runAndClose(() => editor.chain().focus().addColumnBefore().run())}
+      >
+        <ListItemIcon><AddOutlined fontSize="small" /></ListItemIcon>
+        <ListItemText>Add column before</ListItemText>
+      </MenuItem>
+      <MenuItem
+        dense
+        onClick={() => runAndClose(() => editor.chain().focus().addColumnAfter().run())}
+      >
+        <ListItemIcon><AddOutlined fontSize="small" /></ListItemIcon>
+        <ListItemText>Add column after</ListItemText>
+      </MenuItem>
+      <MenuItem
+        dense
+        onClick={() => runAndClose(() => editor.chain().focus().deleteColumn().run())}
+      >
+        <ListItemIcon><RemoveOutlined fontSize="small" /></ListItemIcon>
+        <ListItemText>Delete column</ListItemText>
+      </MenuItem>
+
+      <Divider />
+
+      {/* ── Header toggles ── */}
+      <ListSubheader sx={subheaderSx}>Header</ListSubheader>
+      <MenuItem
+        dense
+        onClick={() => runAndClose(() => editor.chain().focus().toggleHeaderRow().run())}
+      >
+        <ListItemIcon><BorderTopOutlined fontSize="small" /></ListItemIcon>
+        <ListItemText>Toggle header row</ListItemText>
+      </MenuItem>
+      <MenuItem
+        dense
+        onClick={() => runAndClose(() => editor.chain().focus().toggleHeaderColumn().run())}
+      >
+        <ListItemIcon><BorderLeftOutlined fontSize="small" /></ListItemIcon>
+        <ListItemText>Toggle header column</ListItemText>
+      </MenuItem>
+
+      <Divider />
+
+      {/* ── Merge / Split ── */}
+      <ListSubheader sx={subheaderSx}>Cells</ListSubheader>
+      <MenuItem
+        dense
+        disabled={!canMerge}
+        onClick={() => runAndClose(() => editor.chain().focus().mergeCells().run())}
+      >
+        <ListItemIcon><MergeType fontSize="small" /></ListItemIcon>
+        <ListItemText>Merge cells</ListItemText>
+      </MenuItem>
+      <MenuItem
+        dense
+        onClick={() => runAndClose(() => editor.chain().focus().splitCellHorizontal().run())}
+      >
+        <ListItemIcon>
+          <SplitscreenOutlined fontSize="small" />
+        </ListItemIcon>
+        <ListItemText>Split cell horizontally</ListItemText>
+      </MenuItem>
+      <MenuItem
+        dense
+        onClick={() => runAndClose(() => editor.chain().focus().splitCellVertical().run())}
+      >
+        <ListItemIcon>
+          <SplitscreenOutlined fontSize="small" sx={{ transform: 'rotate(90deg)' }} />
+        </ListItemIcon>
+        <ListItemText>Split cell vertically</ListItemText>
+      </MenuItem>
+
+      <Divider />
+
+      {/* ── Nested table ── */}
+      <MenuItem
+        dense
+        onClick={() =>
+          runAndClose(() =>
+            editor
+              .chain()
+              .focus()
+              .insertTable({ rows: 2, cols: 2, withHeaderRow: true })
+              .run(),
+          )}
+      >
+        <ListItemIcon><TableChart fontSize="small" /></ListItemIcon>
+        <ListItemText>Insert nested table</ListItemText>
+      </MenuItem>
+
+      <Divider />
+
+      {/* ── Delete table ── */}
+      <MenuItem
+        dense
+        onClick={() => runAndClose(() => editor.chain().focus().deleteTable().run())}
+        sx={{ color: 'error.main' }}
+      >
+        <ListItemIcon><DeleteOutline fontSize="small" color="error" /></ListItemIcon>
+        <ListItemText>Delete table</ListItemText>
+      </MenuItem>
+    </Menu>
+  );
+};

--- a/packages/filigran-rich-text-editor/src/richTextEditor/TableGridPicker.tsx
+++ b/packages/filigran-rich-text-editor/src/richTextEditor/TableGridPicker.tsx
@@ -1,0 +1,174 @@
+import type { Editor } from '@tiptap/react';
+import React, { useState, useCallback, useRef, useEffect } from 'react';
+import Box from '@mui/material/Box';
+import Popover from '@mui/material/Popover';
+import Typography from '@mui/material/Typography';
+import Checkbox from '@mui/material/Checkbox';
+import FormControlLabel from '@mui/material/FormControlLabel';
+
+const MAX_ROWS = 10;
+const MAX_COLS = 10;
+const CELL_SIZE = 18;
+const CELL_GAP = 2;
+
+interface TableGridPickerProps {
+  anchorEl: HTMLElement | null;
+  open: boolean;
+  onClose: () => void;
+  editor: Editor;
+}
+
+/**
+ * A visual rows×cols grid picker for inserting tables.
+ *
+ * Supports full keyboard navigation:
+ * - Arrow keys move the highlighted selection
+ * - Enter inserts the table at the highlighted size
+ * - Escape closes the picker
+ */
+export const TableGridPicker: React.FC<TableGridPickerProps> = ({
+  anchorEl,
+  open,
+  onClose,
+  editor,
+}) => {
+  const [hoverRow, setHoverRow] = useState(0);
+  const [hoverCol, setHoverCol] = useState(0);
+  const [withHeaderRow, setWithHeaderRow] = useState(true);
+  const gridRef = useRef<HTMLDivElement>(null);
+
+  // Reset highlight when the picker opens
+  useEffect(() => {
+    if (open) {
+      setHoverRow(0);
+      setHoverCol(0);
+    }
+  }, [open]);
+
+  // Auto-focus the grid so keyboard works immediately
+  useEffect(() => {
+    if (open) {
+      // Small delay to let the popover render before focusing
+      const timer = setTimeout(() => gridRef.current?.focus(), 50);
+      return () => clearTimeout(timer);
+    }
+    return undefined;
+  }, [open]);
+
+  const insertTable = useCallback(
+    (rows: number, cols: number) => {
+      editor.chain().focus().insertTable({ rows, cols, withHeaderRow }).run();
+      onClose();
+    },
+    [editor, withHeaderRow, onClose],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      switch (e.key) {
+        case 'ArrowRight':
+          e.preventDefault();
+          setHoverCol((c) => Math.min(c + 1, MAX_COLS - 1));
+          break;
+        case 'ArrowLeft':
+          e.preventDefault();
+          setHoverCol((c) => Math.max(c - 1, 0));
+          break;
+        case 'ArrowDown':
+          e.preventDefault();
+          setHoverRow((r) => Math.min(r + 1, MAX_ROWS - 1));
+          break;
+        case 'ArrowUp':
+          e.preventDefault();
+          setHoverRow((r) => Math.max(r - 1, 0));
+          break;
+        case 'Enter':
+          e.preventDefault();
+          insertTable(hoverRow + 1, hoverCol + 1);
+          break;
+        case 'Escape':
+          e.preventDefault();
+          onClose();
+          break;
+        default:
+          break;
+      }
+    },
+    [hoverRow, hoverCol, insertTable, onClose],
+  );
+
+  const isHighlighted = (row: number, col: number) => row <= hoverRow && col <= hoverCol;
+
+  return (
+    <Popover
+      open={open}
+      anchorEl={anchorEl}
+      onClose={onClose}
+      anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+      transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+      slotProps={{ paper: { sx: { mt: 0.5 } } }}
+    >
+      <Box sx={{ p: 1.5, minWidth: MAX_COLS * (CELL_SIZE + CELL_GAP) + 12 }}>
+        <Box
+          ref={gridRef}
+          tabIndex={0}
+          role="grid"
+          aria-label="Table size picker"
+          onKeyDown={handleKeyDown}
+          sx={{
+            outline: 'none',
+            display: 'inline-grid',
+            gridTemplateColumns: `repeat(${MAX_COLS}, ${CELL_SIZE}px)`,
+            gap: `${CELL_GAP}px`,
+          }}
+        >
+          {Array.from({ length: MAX_ROWS }, (_, r) =>
+            Array.from({ length: MAX_COLS }, (_, c) => (
+              <Box
+                key={`${r}-${c}`}
+                role="gridcell"
+                aria-label={`${r + 1} rows × ${c + 1} columns`}
+                aria-selected={isHighlighted(r, c)}
+                onMouseEnter={() => {
+                  setHoverRow(r);
+                  setHoverCol(c);
+                }}
+                onClick={() => insertTable(r + 1, c + 1)}
+                sx={{
+                  width: CELL_SIZE,
+                  height: CELL_SIZE,
+                  border: '1px solid',
+                  borderColor: isHighlighted(r, c) ? 'primary.main' : 'divider',
+                  backgroundColor: isHighlighted(r, c) ? 'primary.main' : 'transparent',
+                  opacity: isHighlighted(r, c) ? 0.45 : 1,
+                  cursor: 'pointer',
+                  borderRadius: '2px',
+                  transition: 'background-color 0.08s, border-color 0.08s',
+                }}
+              />
+            )),
+          )}
+        </Box>
+
+        <Typography
+          variant="caption"
+          sx={{ display: 'block', textAlign: 'center', mt: 1, fontWeight: 500 }}
+        >
+          {hoverRow + 1} × {hoverCol + 1}
+        </Typography>
+
+        <FormControlLabel
+          control={(
+            <Checkbox
+              size="small"
+              checked={withHeaderRow}
+              onChange={(e) => setWithHeaderRow(e.target.checked)}
+            />
+          )}
+          label={<Typography variant="caption">Header row</Typography>}
+          sx={{ mt: 0.5, ml: 0 }}
+        />
+      </Box>
+    </Popover>
+  );
+};

--- a/packages/filigran-rich-text-editor/src/richTextEditor/TiptapEditorToolbar.tsx
+++ b/packages/filigran-rich-text-editor/src/richTextEditor/TiptapEditorToolbar.tsx
@@ -1,0 +1,593 @@
+import type { Editor } from '@tiptap/react';
+import React from 'react';
+import {
+  FormatBold,
+  FormatItalic,
+  FormatUnderlined,
+  FormatStrikethrough,
+  FormatListBulleted,
+  FormatListNumbered,
+  FormatQuote,
+  Code,
+  DataObject,
+  Html,
+  Link as LinkIcon,
+  Image as ImageIcon,
+  HorizontalRule,
+  TableChart,
+  ViewAgenda,
+  FormatAlignLeft,
+  FormatAlignCenter,
+  FormatAlignRight,
+  FormatAlignJustify,
+  Highlight,
+  Subscript as SubscriptIcon,
+  Superscript as SuperscriptIcon,
+  Undo,
+  Redo,
+  ChecklistRtl,
+  FormatColorText,
+  FormatPaint,
+  FormatSize,
+  FontDownload,
+  ArrowDropDown,
+  FormatIndentIncrease,
+  FormatIndentDecrease,
+} from '@mui/icons-material';
+import ToggleButton from '@mui/material/ToggleButton';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
+import IconButton from '@mui/material/IconButton';
+import Box from '@mui/material/Box';
+import Tooltip from '@mui/material/Tooltip';
+import Select from '@mui/material/Select';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import Popover from '@mui/material/Popover';
+import { SketchPicker } from 'react-color';
+import { TableGridPicker } from './TableGridPicker';
+
+const HEADING_OPTIONS = [
+  { value: 'paragraph', label: 'Paragraph', level: null },
+  { value: 'h1', label: 'Heading 1', level: 1 },
+  { value: 'h2', label: 'Heading 2', level: 2 },
+  { value: 'h3', label: 'Heading 3', level: 3 },
+] as const;
+
+const FONT_FAMILY_OPTIONS = [
+  { value: '', label: 'Default' },
+  { value: 'Arial', label: 'Arial' },
+  { value: 'Courier New', label: 'Courier New' },
+  { value: 'Georgia', label: 'Georgia' },
+  { value: 'Helvetica', label: 'Helvetica' },
+  { value: 'Lucida Sans Unicode', label: 'Lucida Sans Unicode' },
+  { value: 'Times New Roman', label: 'Times New Roman' },
+  { value: 'Trebuchet MS', label: 'Trebuchet MS' },
+  { value: 'Verdana', label: 'Verdana' },
+] as const;
+
+const ALIGN_OPTIONS = [
+  { value: 'left', label: 'Align Left', icon: FormatAlignLeft },
+  { value: 'center', label: 'Align Center', icon: FormatAlignCenter },
+  { value: 'right', label: 'Align Right', icon: FormatAlignRight },
+  { value: 'justify', label: 'Justify', icon: FormatAlignJustify },
+] as const;
+
+const FONT_SIZE_OPTIONS = [
+  { value: '', label: 'Default' },
+  { value: '10px', label: 'Tiny' },
+  { value: '12px', label: 'Small' },
+  { value: '14px', label: 'Normal' },
+  { value: '18px', label: 'Big' },
+  { value: '24px', label: 'Huge' },
+] as const;
+
+interface TiptapEditorToolbarProps {
+  editor: Editor;
+  disabled?: boolean;
+  onOpenLinkPopover?: () => void;
+  onOpenImagePopover?: () => void;
+  isSourceMode?: boolean;
+  onToggleSourceMode?: () => void;
+}
+
+export const TiptapEditorToolbar: React.FC<TiptapEditorToolbarProps> = ({
+  editor,
+  disabled = false,
+  onOpenLinkPopover,
+  onOpenImagePopover,
+  isSourceMode = false,
+  onToggleSourceMode,
+}) => {
+  const [, forceUpdate] = React.useReducer((x) => x + 1, 0);
+  React.useEffect(() => {
+    if (!editor) return;
+    editor.on('selectionUpdate', forceUpdate);
+    editor.on('transaction', forceUpdate);
+    return () => {
+      editor.off('selectionUpdate', forceUpdate);
+      editor.off('transaction', forceUpdate);
+    };
+  }, [editor]);
+
+  const [textColorAnchor, setTextColorAnchor] = React.useState<HTMLElement | null>(null);
+  const [bgColorAnchor, setBgColorAnchor] = React.useState<HTMLElement | null>(null);
+  const [fontFamilyAnchor, setFontFamilyAnchor] = React.useState<HTMLElement | null>(null);
+  const [fontSizeAnchor, setFontSizeAnchor] = React.useState<HTMLElement | null>(null);
+  const [alignAnchor, setAlignAnchor] = React.useState<HTMLElement | null>(null);
+  const [tableGridAnchor, setTableGridAnchor] = React.useState<HTMLElement | null>(null);
+
+  const currentHeading
+    = editor.isActive('heading', { level: 1 })
+      ? 'h1'
+      : editor.isActive('heading', { level: 2 })
+        ? 'h2'
+        : editor.isActive('heading', { level: 3 })
+          ? 'h3'
+          : 'paragraph';
+
+  const currentFontFamily = editor.getAttributes('textStyle').fontFamily ?? '';
+  const currentFontSize = editor.getAttributes('textStyle').fontSize ?? '';
+  const currentColor = editor.getAttributes('textStyle').color ?? '';
+  const currentAlign = editor.isActive({ textAlign: 'center' })
+    ? 'center'
+    : editor.isActive({ textAlign: 'right' })
+      ? 'right'
+      : editor.isActive({ textAlign: 'justify' })
+        ? 'justify'
+        : 'left';
+  const currentBgColor = editor.getAttributes('textStyle').backgroundColor ?? '';
+
+  const insertPageBreak = () => {
+    editor.chain().focus().setPageBreak().run();
+  };
+
+  const indent = () => editor.chain().focus().indent().run();
+  const outdent = () => editor.chain().focus().outdent().run();
+
+  return (
+    <Box
+      onMouseDown={(e) => e.preventDefault()}
+      sx={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        alignItems: 'center',
+        gap: 0.5,
+        p: 0.5,
+        borderBottom: 1,
+        borderColor: 'divider',
+        minHeight: 40,
+      }}
+    >
+      {/* legacy editor order: heading, fontFamily, fontSize, alignment, pageBreak */}
+      <Select
+        size="small"
+        disabled={disabled}
+        value={currentHeading}
+        onChange={(e) => {
+          const opt = HEADING_OPTIONS.find((o) => o.value === e.target.value);
+          if (!opt) return;
+          if (opt.level === null) {
+            editor.chain().focus().setParagraph().run();
+          } else {
+            editor.chain().focus().toggleHeading({ level: opt.level }).run();
+          }
+        }}
+        displayEmpty
+        sx={{ minWidth: 130, height: 32 }}
+      >
+        {HEADING_OPTIONS.map((o) => (
+          <MenuItem key={o.value} value={o.value}>
+            {o.label}
+          </MenuItem>
+        ))}
+      </Select>
+      <ToggleButtonGroup size="small" disabled={disabled}>
+        <Tooltip title="Font Family">
+          <ToggleButton
+            value="fontFamily"
+            selected={Boolean(fontFamilyAnchor)}
+            onClick={(e) => setFontFamilyAnchor(fontFamilyAnchor ? null : e.currentTarget)}
+            sx={{ pr: 0.25 }}
+          >
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+              <FontDownload fontSize="small" />
+              <ArrowDropDown sx={{ fontSize: 18 }} />
+            </Box>
+          </ToggleButton>
+        </Tooltip>
+        <Tooltip title="Font Size">
+          <ToggleButton
+            value="fontSize"
+            selected={Boolean(fontSizeAnchor)}
+            onClick={(e) => setFontSizeAnchor(fontSizeAnchor ? null : e.currentTarget)}
+            sx={{ pr: 0.25 }}
+          >
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+              <FormatSize fontSize="small" />
+              <ArrowDropDown sx={{ fontSize: 18 }} />
+            </Box>
+          </ToggleButton>
+        </Tooltip>
+        <Menu
+          anchorEl={fontFamilyAnchor}
+          open={Boolean(fontFamilyAnchor)}
+          onClose={() => setFontFamilyAnchor(null)}
+          anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+        >
+          {FONT_FAMILY_OPTIONS.map((o) => (
+            <MenuItem
+              key={o.value || 'default'}
+              selected={currentFontFamily === o.value}
+              onClick={() => {
+                if (o.value) editor.chain().focus().setFontFamily(o.value).run();
+                else editor.chain().focus().unsetFontFamily().run();
+                setFontFamilyAnchor(null);
+              }}
+              sx={{ fontFamily: o.value || 'inherit' }}
+            >
+              {o.label}
+            </MenuItem>
+          ))}
+        </Menu>
+        <Menu
+          anchorEl={fontSizeAnchor}
+          open={Boolean(fontSizeAnchor)}
+          onClose={() => setFontSizeAnchor(null)}
+          anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+        >
+          {FONT_SIZE_OPTIONS.map((o) => (
+            <MenuItem
+              key={o.value || 'default'}
+              selected={currentFontSize === o.value}
+              onClick={() => {
+                if (o.value) editor.chain().focus().setFontSize(o.value).run();
+                else editor.chain().focus().unsetFontSize().run();
+                setFontSizeAnchor(null);
+              }}
+            >
+              {o.label}
+            </MenuItem>
+          ))}
+        </Menu>
+        <Tooltip title="Bold">
+          <ToggleButton
+            value="bold"
+            selected={editor.isActive('bold')}
+            onClick={() => editor.chain().focus().toggleBold().run()}
+          >
+            <FormatBold fontSize="small" />
+          </ToggleButton>
+        </Tooltip>
+        <Tooltip title="Italic">
+          <ToggleButton
+            value="italic"
+            selected={editor.isActive('italic')}
+            onClick={() => editor.chain().focus().toggleItalic().run()}
+          >
+            <FormatItalic fontSize="small" />
+          </ToggleButton>
+        </Tooltip>
+        <Tooltip title="Underline">
+          <ToggleButton
+            value="underline"
+            selected={editor.isActive('underline')}
+            onClick={() => editor.chain().focus().toggleUnderline().run()}
+          >
+            <FormatUnderlined fontSize="small" />
+          </ToggleButton>
+        </Tooltip>
+        <Tooltip title="Strikethrough">
+          <ToggleButton
+            value="strike"
+            selected={editor.isActive('strike')}
+            onClick={() => editor.chain().focus().toggleStrike().run()}
+          >
+            <FormatStrikethrough fontSize="small" />
+          </ToggleButton>
+        </Tooltip>
+      </ToggleButtonGroup>
+      <ToggleButtonGroup size="small" disabled={disabled}>
+        <Tooltip title="Text Color">
+          <ToggleButton
+            value="textColor"
+            selected={Boolean(textColorAnchor)}
+            onClick={(e) => setTextColorAnchor(textColorAnchor ? null : e.currentTarget)}
+          >
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.25 }}>
+              <FormatColorText fontSize="small" />
+              {currentColor && (
+                <Box
+                  sx={{
+                    width: 12,
+                    height: 12,
+                    borderRadius: 0.5,
+                    border: 1,
+                    borderColor: 'divider',
+                    bgcolor: currentColor,
+                  }}
+                />
+              )}
+            </Box>
+          </ToggleButton>
+        </Tooltip>
+        <Tooltip title="Background Color">
+          <ToggleButton
+            value="bgColor"
+            selected={Boolean(bgColorAnchor)}
+            onClick={(e) => setBgColorAnchor(bgColorAnchor ? null : e.currentTarget)}
+          >
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.25 }}>
+              <FormatPaint fontSize="small" />
+              {currentBgColor && (
+                <Box
+                  sx={{
+                    width: 12,
+                    height: 12,
+                    borderRadius: 0.5,
+                    border: 1,
+                    borderColor: 'divider',
+                    bgcolor: currentBgColor,
+                  }}
+                />
+              )}
+            </Box>
+          </ToggleButton>
+        </Tooltip>
+        <Tooltip title="Highlight">
+          <ToggleButton
+            value="highlight"
+            selected={editor.isActive('highlight')}
+            onClick={() => editor.chain().focus().toggleHighlight().run()}
+          >
+            <Highlight fontSize="small" />
+          </ToggleButton>
+        </Tooltip>
+      </ToggleButtonGroup>
+      <ToggleButtonGroup size="small" disabled={disabled}>
+        <Tooltip title="Alignment">
+          <ToggleButton
+            value="align"
+            selected={Boolean(alignAnchor)}
+            onClick={(e) => setAlignAnchor(alignAnchor ? null : e.currentTarget)}
+            sx={{ pr: 0.25 }}
+          >
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+              {React.createElement(ALIGN_OPTIONS.find((o) => o.value === currentAlign)?.icon ?? FormatAlignLeft, {
+                fontSize: 'small',
+              })}
+              <ArrowDropDown sx={{ fontSize: 18 }} />
+            </Box>
+          </ToggleButton>
+        </Tooltip>
+        <Tooltip title="Bullet List">
+          <ToggleButton
+            value="bulletList"
+            selected={editor.isActive('bulletList')}
+            onClick={() => editor.chain().focus().toggleBulletList().run()}
+          >
+            <FormatListBulleted fontSize="small" />
+          </ToggleButton>
+        </Tooltip>
+        <Tooltip title="Numbered List">
+          <ToggleButton
+            value="orderedList"
+            selected={editor.isActive('orderedList')}
+            onClick={() => editor.chain().focus().toggleOrderedList().run()}
+          >
+            <FormatListNumbered fontSize="small" />
+          </ToggleButton>
+        </Tooltip>
+        <Tooltip title="Indent">
+          <ToggleButton value="indent" onClick={indent}>
+            <FormatIndentIncrease fontSize="small" />
+          </ToggleButton>
+        </Tooltip>
+        <Tooltip title="Outdent">
+          <ToggleButton value="outdent" onClick={outdent}>
+            <FormatIndentDecrease fontSize="small" />
+          </ToggleButton>
+        </Tooltip>
+        <Tooltip title="Todo List">
+          <ToggleButton
+            value="taskList"
+            selected={editor.isActive('taskList')}
+            onClick={() => editor.chain().focus().toggleTaskList().run()}
+          >
+            <ChecklistRtl fontSize="small" />
+          </ToggleButton>
+        </Tooltip>
+      </ToggleButtonGroup>
+      <Menu
+        anchorEl={alignAnchor}
+        open={Boolean(alignAnchor)}
+        onClose={() => setAlignAnchor(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+      >
+        {ALIGN_OPTIONS.map((o) => (
+          <MenuItem
+            key={o.value}
+            selected={currentAlign === o.value}
+            onClick={() => {
+              editor.chain().focus().setTextAlign(o.value).run();
+              setAlignAnchor(null);
+            }}
+          >
+            <Box component={o.icon} sx={{ mr: 1, fontSize: 20 }} />
+            {o.label}
+          </MenuItem>
+        ))}
+      </Menu>
+      {/* link, imageInsert, blockQuote, code, codeBlock, subscript, superscript, horizontalLine */}
+      <ToggleButtonGroup size="small" disabled={disabled}>
+        <Tooltip title="Link">
+          <ToggleButton
+            value="link"
+            selected={editor.isActive('link')}
+            onClick={() => onOpenLinkPopover?.()}
+          >
+            <LinkIcon fontSize="small" />
+          </ToggleButton>
+        </Tooltip>
+        <Tooltip title="Image">
+          <ToggleButton value="image" onClick={() => onOpenImagePopover?.()}>
+            <ImageIcon fontSize="small" />
+          </ToggleButton>
+        </Tooltip>
+        <Tooltip title="Blockquote">
+          <ToggleButton
+            value="blockquote"
+            selected={editor.isActive('blockquote')}
+            onClick={() => editor.chain().focus().toggleBlockquote().run()}
+          >
+            <FormatQuote fontSize="small" />
+          </ToggleButton>
+        </Tooltip>
+        <Tooltip title="Code">
+          <ToggleButton
+            value="code"
+            selected={editor.isActive('code')}
+            onClick={() => editor.chain().focus().toggleCode().run()}
+          >
+            <Code fontSize="small" />
+          </ToggleButton>
+        </Tooltip>
+        <Tooltip title="Code Block">
+          <ToggleButton
+            value="codeBlock"
+            selected={editor.isActive('codeBlock')}
+            onClick={() => editor.chain().focus().toggleCodeBlock().run()}
+          >
+            <DataObject fontSize="small" />
+          </ToggleButton>
+        </Tooltip>
+        <Tooltip title="Subscript">
+          <ToggleButton
+            value="subscript"
+            selected={editor.isActive('subscript')}
+            onClick={() => editor.chain().focus().toggleSubscript().run()}
+          >
+            <SubscriptIcon fontSize="small" />
+          </ToggleButton>
+        </Tooltip>
+        <Tooltip title="Superscript">
+          <ToggleButton
+            value="superscript"
+            selected={editor.isActive('superscript')}
+            onClick={() => editor.chain().focus().toggleSuperscript().run()}
+          >
+            <SuperscriptIcon fontSize="small" />
+          </ToggleButton>
+        </Tooltip>
+      </ToggleButtonGroup>
+      <ToggleButtonGroup size="small" disabled={disabled}>
+        <Tooltip title="Table">
+          <ToggleButton
+            value="table"
+            selected={Boolean(tableGridAnchor)}
+            onClick={(e) => setTableGridAnchor(tableGridAnchor ? null : e.currentTarget)}
+          >
+            <TableChart fontSize="small" />
+          </ToggleButton>
+        </Tooltip>
+        <Tooltip title="Page Break">
+          <ToggleButton value="pageBreak" onClick={insertPageBreak}>
+            <ViewAgenda fontSize="small" />
+          </ToggleButton>
+        </Tooltip>
+        <Tooltip title="Horizontal Rule">
+          <ToggleButton value="hr" onClick={() => editor.chain().focus().setHorizontalRule().run()}>
+            <HorizontalRule fontSize="small" />
+          </ToggleButton>
+        </Tooltip>
+      </ToggleButtonGroup>
+      {onToggleSourceMode && (
+        <ToggleButtonGroup size="small" disabled={disabled}>
+          <Tooltip title="Source HTML">
+            <ToggleButton
+              value="sourceMode"
+              selected={isSourceMode}
+              onClick={onToggleSourceMode}
+            >
+              <Html fontSize="small" />
+            </ToggleButton>
+          </Tooltip>
+        </ToggleButtonGroup>
+      )}
+      {/* undo, redo */}
+      <ToggleButtonGroup size="small" disabled={disabled} sx={{ flexWrap: 'wrap' }}>
+        <Tooltip title="Undo">
+          <IconButton
+            size="small"
+            onClick={() => editor.chain().focus().undo().run()}
+            disabled={!editor.can().undo()}
+          >
+            <Undo fontSize="small" />
+          </IconButton>
+        </Tooltip>
+        <Tooltip title="Redo">
+          <IconButton
+            size="small"
+            onClick={() => editor.chain().focus().redo().run()}
+            disabled={!editor.can().redo()}
+          >
+            <Redo fontSize="small" />
+          </IconButton>
+        </Tooltip>
+      </ToggleButtonGroup>
+      <Popover
+        open={Boolean(textColorAnchor)}
+        anchorEl={textColorAnchor}
+        onClose={() => setTextColorAnchor(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+      >
+        <Box sx={{ p: 1, borderBottom: 1, borderColor: 'divider', display: 'flex', justifyContent: 'center' }}>
+          <MenuItem
+            sx={{ borderRadius: 1, typography: 'body2', py: 0.5, flexGrow: 1, justifyContent: 'center' }}
+            onClick={() => {
+              editor.chain().focus().unsetColor().run();
+              setTextColorAnchor(null);
+            }}
+          >
+            Reset Default Color
+          </MenuItem>
+        </Box>
+        <SketchPicker
+          color={currentColor || '#000000'}
+          onChangeComplete={(color) => {
+            editor.chain().focus().setColor(color.hex).run();
+          }}
+        />
+      </Popover>
+      <Popover
+        open={Boolean(bgColorAnchor)}
+        anchorEl={bgColorAnchor}
+        onClose={() => setBgColorAnchor(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+      >
+        <Box sx={{ p: 1, borderBottom: 1, borderColor: 'divider', display: 'flex', justifyContent: 'center' }}>
+          <MenuItem
+            sx={{ borderRadius: 1, typography: 'body2', py: 0.5, flexGrow: 1, justifyContent: 'center' }}
+            onClick={() => {
+              editor.chain().focus().unsetBackgroundColor().run();
+              setBgColorAnchor(null);
+            }}
+          >
+            Reset Background Color
+          </MenuItem>
+        </Box>
+        <SketchPicker
+          color={currentBgColor || '#ffff00'}
+          onChangeComplete={(color) => {
+            editor.chain().focus().setBackgroundColor(color.hex).run();
+          }}
+        />
+      </Popover>
+      <TableGridPicker
+        anchorEl={tableGridAnchor}
+        open={Boolean(tableGridAnchor)}
+        onClose={() => setTableGridAnchor(null)}
+        editor={editor}
+      />
+    </Box>
+  );
+};

--- a/packages/filigran-rich-text-editor/src/richTextEditor/TiptapEditorToolbar.tsx
+++ b/packages/filigran-rich-text-editor/src/richTextEditor/TiptapEditorToolbar.tsx
@@ -33,6 +33,7 @@ import {
   ArrowDropDown,
   FormatIndentIncrease,
   FormatIndentDecrease,
+  MoreVert,
 } from '@mui/icons-material';
 import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
@@ -115,6 +116,7 @@ export const TiptapEditorToolbar: React.FC<TiptapEditorToolbarProps> = ({
   const [fontSizeAnchor, setFontSizeAnchor] = React.useState<HTMLElement | null>(null);
   const [alignAnchor, setAlignAnchor] = React.useState<HTMLElement | null>(null);
   const [tableGridAnchor, setTableGridAnchor] = React.useState<HTMLElement | null>(null);
+  const [moreAnchor, setMoreAnchor] = React.useState<HTMLElement | null>(null);
 
   const currentHeading
     = editor.isActive('heading', { level: 1 })
@@ -144,70 +146,241 @@ export const TiptapEditorToolbar: React.FC<TiptapEditorToolbarProps> = ({
   const indent = () => editor.chain().focus().indent().run();
   const outdent = () => editor.chain().focus().outdent().run();
 
+  // --- Overflow menu ---
+  const toolbarRef = React.useRef<HTMLDivElement>(null);
+  const [hiddenItems, setHiddenItems] = React.useState<Set<string>>(new Set());
+  const cachedWidthsRef = React.useRef<Record<string, number>>({});
+
+  const hasSourceMode = Boolean(onToggleSourceMode);
+
+  const itemGroups = React.useMemo(
+    () => [
+      ['heading-select'],
+      ['font-family', 'font-size', 'bold', 'italic', 'underline', 'strike'],
+      ['text-color', 'bg-color', 'highlight'],
+      ['align', 'bullet-list', 'ordered-list', 'indent', 'outdent', 'task-list'],
+      ['link', 'image', 'blockquote', 'code', 'code-block', 'subscript', 'superscript'],
+      ['table', 'page-break', 'hr'],
+      ...(hasSourceMode ? [['source']] : []),
+      ['undo', 'redo'],
+    ],
+    [hasSourceMode],
+  );
+
+  const itemIds = React.useMemo(
+    () => itemGroups.flat(),
+    [itemGroups],
+  );
+
+  React.useEffect(() => {
+    const container = toolbarRef.current;
+    if (!container) return;
+
+    // Phase 1: cache natural widths of all items (all visible on first render)
+    itemIds.forEach((id) => {
+      const el = container.querySelector<HTMLElement>(`[data-toolbar-item="${id}"]`);
+      if (el && el.offsetWidth > 0) {
+        cachedWidthsRef.current[id] = el.offsetWidth;
+      }
+    });
+
+    // Build lookup: item id → group index (gap is between groups, not between items)
+    const groupOf: Record<string, number> = {};
+    itemGroups.forEach((group, gi) => {
+      group.forEach((id) => {
+        groupOf[id] = gi;
+      });
+    });
+
+    const INTER_GROUP_GAP = 4; // gap: 0.5 = 4px between group Boxes
+
+    const measure = () => {
+      const containerWidth = container.clientWidth;
+
+      // Total natural width: one gap per group transition, not per item
+      let totalNatural = 0;
+      let lastGroup = -1;
+      for (const id of itemIds) {
+        const w = cachedWidthsRef.current[id] ?? 0;
+        if (w === 0) continue;
+        const gi = groupOf[id];
+        if (lastGroup !== -1 && gi !== lastGroup) totalNatural += INTER_GROUP_GAP;
+        totalNatural += w;
+        lastGroup = gi;
+      }
+
+      if (totalNatural <= containerWidth) {
+        setMoreAnchor(null);
+        setHiddenItems((prev) => (prev.size === 0 ? prev : new Set()));
+        return;
+      }
+
+      const MORE_BTN_WIDTH = 36;
+      const available = containerWidth - MORE_BTN_WIDTH;
+      let used = 0;
+      const newHidden = new Set<string>();
+      let overflowing = false;
+      let lastVisibleGroup = -1;
+
+      for (const id of itemIds) {
+        const w = cachedWidthsRef.current[id] ?? 0;
+        const gi = groupOf[id];
+        const gapCost = (lastVisibleGroup !== -1 && gi !== lastVisibleGroup) ? INTER_GROUP_GAP : 0;
+
+        if (!overflowing && used + gapCost + w <= available) {
+          used += gapCost + w;
+          lastVisibleGroup = gi;
+        } else {
+          overflowing = true;
+          newHidden.add(id);
+        }
+      }
+
+      setHiddenItems((prev) => {
+        if (prev.size === newHidden.size && Array.from(prev).every((id) => newHidden.has(id))) return prev;
+        return newHidden;
+      });
+    };
+
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(container);
+    return () => ro.disconnect();
+  }, [itemIds, itemGroups]);
+
   return (
-    <Box
-      onMouseDown={(e) => e.preventDefault()}
-      sx={{
-        display: 'flex',
-        flexWrap: 'wrap',
-        alignItems: 'center',
-        gap: 0.5,
-        p: 0.5,
-        borderBottom: 1,
-        borderColor: 'divider',
-        minHeight: 40,
-      }}
-    >
-      {/* legacy editor order: heading, fontFamily, fontSize, alignment, pageBreak */}
-      <Select
-        size="small"
-        disabled={disabled}
-        value={currentHeading}
-        onChange={(e) => {
-          const opt = HEADING_OPTIONS.find((o) => o.value === e.target.value);
-          if (!opt) return;
-          if (opt.level === null) {
-            editor.chain().focus().setParagraph().run();
-          } else {
-            editor.chain().focus().toggleHeading({ level: opt.level }).run();
-          }
+    <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+      <Box
+        ref={toolbarRef}
+        onMouseDown={(e) => e.preventDefault()}
+        sx={{
+          display: 'flex',
+          flexWrap: 'nowrap',
+          alignItems: 'center',
+          gap: 0.5,
+          p: 0.5,
+          minHeight: 40,
+          overflow: 'hidden',
         }}
-        displayEmpty
-        sx={{ minWidth: 130, height: 32 }}
       >
-        {HEADING_OPTIONS.map((o) => (
-          <MenuItem key={o.value} value={o.value}>
-            {o.label}
-          </MenuItem>
-        ))}
-      </Select>
-      <ToggleButtonGroup size="small" disabled={disabled}>
-        <Tooltip title="Font Family">
-          <ToggleButton
-            value="fontFamily"
-            selected={Boolean(fontFamilyAnchor)}
-            onClick={(e) => setFontFamilyAnchor(fontFamilyAnchor ? null : e.currentTarget)}
-            sx={{ pr: 0.25 }}
+      {/* heading */}
+      {!hiddenItems.has('heading-select') && (
+        <Box
+          data-toolbar-item="heading-select"
+          sx={{ display: 'inline-flex', alignItems: 'center' }}
+        >
+          <Select
+            size="small"
+            disabled={disabled}
+            value={currentHeading}
+            onChange={(e) => {
+              const opt = HEADING_OPTIONS.find((o) => o.value === e.target.value);
+              if (!opt) return;
+              if (opt.level === null) {
+                editor.chain().focus().setParagraph().run();
+              } else {
+                editor.chain().focus().toggleHeading({ level: opt.level }).run();
+              }
+            }}
+            displayEmpty
+            sx={{ minWidth: 130, height: 32 }}
           >
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-              <FontDownload fontSize="small" />
-              <ArrowDropDown sx={{ fontSize: 18 }} />
-            </Box>
-          </ToggleButton>
-        </Tooltip>
-        <Tooltip title="Font Size">
-          <ToggleButton
-            value="fontSize"
-            selected={Boolean(fontSizeAnchor)}
-            onClick={(e) => setFontSizeAnchor(fontSizeAnchor ? null : e.currentTarget)}
-            sx={{ pr: 0.25 }}
-          >
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-              <FormatSize fontSize="small" />
-              <ArrowDropDown sx={{ fontSize: 18 }} />
-            </Box>
-          </ToggleButton>
-        </Tooltip>
+            {HEADING_OPTIONS.map((o) => (
+              <MenuItem key={o.value} value={o.value}>
+                {o.label}
+              </MenuItem>
+            ))}
+          </Select>
+        </Box>
+      )}
+      {/* font-format: font family, font size, bold, italic, underline, strike */}
+      {!['font-family', 'font-size', 'bold', 'italic', 'underline', 'strike'].every((id) => hiddenItems.has(id)) && (
+        <Box sx={{ display: 'inline-flex', alignItems: 'center' }}>
+          <ToggleButtonGroup size="small" disabled={disabled}>
+            {!hiddenItems.has('font-family') && (
+              <Tooltip title="Font Family">
+                <ToggleButton
+                  value="fontFamily"
+                  data-toolbar-item="font-family"
+                  selected={Boolean(fontFamilyAnchor)}
+                  onClick={(e) => setFontFamilyAnchor(fontFamilyAnchor ? null : e.currentTarget)}
+                  sx={{ pr: 0.25 }}
+                >
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                    <FontDownload fontSize="small" />
+                    <ArrowDropDown sx={{ fontSize: 18 }} />
+                  </Box>
+                </ToggleButton>
+              </Tooltip>
+            )}
+            {!hiddenItems.has('font-size') && (
+              <Tooltip title="Font Size">
+                <ToggleButton
+                  value="fontSize"
+                  data-toolbar-item="font-size"
+                  selected={Boolean(fontSizeAnchor)}
+                  onClick={(e) => setFontSizeAnchor(fontSizeAnchor ? null : e.currentTarget)}
+                  sx={{ pr: 0.25 }}
+                >
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                    <FormatSize fontSize="small" />
+                    <ArrowDropDown sx={{ fontSize: 18 }} />
+                  </Box>
+                </ToggleButton>
+              </Tooltip>
+            )}
+            {!hiddenItems.has('bold') && (
+              <Tooltip title="Bold">
+                <ToggleButton
+                  value="bold"
+                  data-toolbar-item="bold"
+                  selected={editor.isActive('bold')}
+                  onClick={() => editor.chain().focus().toggleBold().run()}
+                >
+                  <FormatBold fontSize="small" />
+                </ToggleButton>
+              </Tooltip>
+            )}
+            {!hiddenItems.has('italic') && (
+              <Tooltip title="Italic">
+                <ToggleButton
+                  value="italic"
+                  data-toolbar-item="italic"
+                  selected={editor.isActive('italic')}
+                  onClick={() => editor.chain().focus().toggleItalic().run()}
+                >
+                  <FormatItalic fontSize="small" />
+                </ToggleButton>
+              </Tooltip>
+            )}
+            {!hiddenItems.has('underline') && (
+              <Tooltip title="Underline">
+                <ToggleButton
+                  value="underline"
+                  data-toolbar-item="underline"
+                  selected={editor.isActive('underline')}
+                  onClick={() => editor.chain().focus().toggleUnderline().run()}
+                >
+                  <FormatUnderlined fontSize="small" />
+                </ToggleButton>
+              </Tooltip>
+            )}
+            {!hiddenItems.has('strike') && (
+              <Tooltip title="Strikethrough">
+                <ToggleButton
+                  value="strike"
+                  data-toolbar-item="strike"
+                  selected={editor.isActive('strike')}
+                  onClick={() => editor.chain().focus().toggleStrike().run()}
+                >
+                  <FormatStrikethrough fontSize="small" />
+                </ToggleButton>
+              </Tooltip>
+            )}
+          </ToggleButtonGroup>
+        </Box>
+      )}
+      {/* Font family/size menus — always rendered (portals, don't affect layout) */}
         <Menu
           anchorEl={fontFamilyAnchor}
           open={Boolean(fontFamilyAnchor)}
@@ -249,154 +422,161 @@ export const TiptapEditorToolbar: React.FC<TiptapEditorToolbarProps> = ({
             </MenuItem>
           ))}
         </Menu>
-        <Tooltip title="Bold">
-          <ToggleButton
-            value="bold"
-            selected={editor.isActive('bold')}
-            onClick={() => editor.chain().focus().toggleBold().run()}
-          >
-            <FormatBold fontSize="small" />
-          </ToggleButton>
-        </Tooltip>
-        <Tooltip title="Italic">
-          <ToggleButton
-            value="italic"
-            selected={editor.isActive('italic')}
-            onClick={() => editor.chain().focus().toggleItalic().run()}
-          >
-            <FormatItalic fontSize="small" />
-          </ToggleButton>
-        </Tooltip>
-        <Tooltip title="Underline">
-          <ToggleButton
-            value="underline"
-            selected={editor.isActive('underline')}
-            onClick={() => editor.chain().focus().toggleUnderline().run()}
-          >
-            <FormatUnderlined fontSize="small" />
-          </ToggleButton>
-        </Tooltip>
-        <Tooltip title="Strikethrough">
-          <ToggleButton
-            value="strike"
-            selected={editor.isActive('strike')}
-            onClick={() => editor.chain().focus().toggleStrike().run()}
-          >
-            <FormatStrikethrough fontSize="small" />
-          </ToggleButton>
-        </Tooltip>
-      </ToggleButtonGroup>
-      <ToggleButtonGroup size="small" disabled={disabled}>
-        <Tooltip title="Text Color">
-          <ToggleButton
-            value="textColor"
-            selected={Boolean(textColorAnchor)}
-            onClick={(e) => setTextColorAnchor(textColorAnchor ? null : e.currentTarget)}
-          >
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.25 }}>
-              <FormatColorText fontSize="small" />
-              {currentColor && (
-                <Box
-                  sx={{
-                    width: 12,
-                    height: 12,
-                    borderRadius: 0.5,
-                    border: 1,
-                    borderColor: 'divider',
-                    bgcolor: currentColor,
-                  }}
-                />
-              )}
-            </Box>
-          </ToggleButton>
-        </Tooltip>
-        <Tooltip title="Background Color">
-          <ToggleButton
-            value="bgColor"
-            selected={Boolean(bgColorAnchor)}
-            onClick={(e) => setBgColorAnchor(bgColorAnchor ? null : e.currentTarget)}
-          >
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.25 }}>
-              <FormatPaint fontSize="small" />
-              {currentBgColor && (
-                <Box
-                  sx={{
-                    width: 12,
-                    height: 12,
-                    borderRadius: 0.5,
-                    border: 1,
-                    borderColor: 'divider',
-                    bgcolor: currentBgColor,
-                  }}
-                />
-              )}
-            </Box>
-          </ToggleButton>
-        </Tooltip>
-        <Tooltip title="Highlight">
-          <ToggleButton
-            value="highlight"
-            selected={editor.isActive('highlight')}
-            onClick={() => editor.chain().focus().toggleHighlight().run()}
-          >
-            <Highlight fontSize="small" />
-          </ToggleButton>
-        </Tooltip>
-      </ToggleButtonGroup>
-      <ToggleButtonGroup size="small" disabled={disabled}>
-        <Tooltip title="Alignment">
-          <ToggleButton
-            value="align"
-            selected={Boolean(alignAnchor)}
-            onClick={(e) => setAlignAnchor(alignAnchor ? null : e.currentTarget)}
-            sx={{ pr: 0.25 }}
-          >
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-              {React.createElement(ALIGN_OPTIONS.find((o) => o.value === currentAlign)?.icon ?? FormatAlignLeft, {
-                fontSize: 'small',
-              })}
-              <ArrowDropDown sx={{ fontSize: 18 }} />
-            </Box>
-          </ToggleButton>
-        </Tooltip>
-        <Tooltip title="Bullet List">
-          <ToggleButton
-            value="bulletList"
-            selected={editor.isActive('bulletList')}
-            onClick={() => editor.chain().focus().toggleBulletList().run()}
-          >
-            <FormatListBulleted fontSize="small" />
-          </ToggleButton>
-        </Tooltip>
-        <Tooltip title="Numbered List">
-          <ToggleButton
-            value="orderedList"
-            selected={editor.isActive('orderedList')}
-            onClick={() => editor.chain().focus().toggleOrderedList().run()}
-          >
-            <FormatListNumbered fontSize="small" />
-          </ToggleButton>
-        </Tooltip>
-        <Tooltip title="Indent">
-          <ToggleButton value="indent" onClick={indent}>
-            <FormatIndentIncrease fontSize="small" />
-          </ToggleButton>
-        </Tooltip>
-        <Tooltip title="Outdent">
-          <ToggleButton value="outdent" onClick={outdent}>
-            <FormatIndentDecrease fontSize="small" />
-          </ToggleButton>
-        </Tooltip>
-        <Tooltip title="Todo List">
-          <ToggleButton
-            value="taskList"
-            selected={editor.isActive('taskList')}
-            onClick={() => editor.chain().focus().toggleTaskList().run()}
-          >
-            <ChecklistRtl fontSize="small" />
-          </ToggleButton>
-        </Tooltip>
-      </ToggleButtonGroup>
+      {/* color: text color, background color, highlight */}
+      {!['text-color', 'bg-color', 'highlight'].every((id) => hiddenItems.has(id)) && (
+        <Box sx={{ display: 'inline-flex', alignItems: 'center' }}>
+          <ToggleButtonGroup size="small" disabled={disabled}>
+            {!hiddenItems.has('text-color') && (
+              <Tooltip title="Text Color">
+                <ToggleButton
+                  value="textColor"
+                  data-toolbar-item="text-color"
+                  selected={Boolean(textColorAnchor)}
+                  onClick={(e) => setTextColorAnchor(textColorAnchor ? null : e.currentTarget)}
+                >
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.25 }}>
+                    <FormatColorText fontSize="small" />
+                    {currentColor && (
+                      <Box
+                        sx={{
+                          width: 12,
+                          height: 12,
+                          borderRadius: 0.5,
+                          border: 1,
+                          borderColor: 'divider',
+                          bgcolor: currentColor,
+                        }}
+                      />
+                    )}
+                  </Box>
+                </ToggleButton>
+              </Tooltip>
+            )}
+            {!hiddenItems.has('bg-color') && (
+              <Tooltip title="Background Color">
+                <ToggleButton
+                  value="bgColor"
+                  data-toolbar-item="bg-color"
+                  selected={Boolean(bgColorAnchor)}
+                  onClick={(e) => setBgColorAnchor(bgColorAnchor ? null : e.currentTarget)}
+                >
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.25 }}>
+                    <FormatPaint fontSize="small" />
+                    {currentBgColor && (
+                      <Box
+                        sx={{
+                          width: 12,
+                          height: 12,
+                          borderRadius: 0.5,
+                          border: 1,
+                          borderColor: 'divider',
+                          bgcolor: currentBgColor,
+                        }}
+                      />
+                    )}
+                  </Box>
+                </ToggleButton>
+              </Tooltip>
+            )}
+            {!hiddenItems.has('highlight') && (
+              <Tooltip title="Highlight">
+                <ToggleButton
+                  value="highlight"
+                  data-toolbar-item="highlight"
+                  selected={editor.isActive('highlight')}
+                  onClick={() => editor.chain().focus().toggleHighlight().run()}
+                >
+                  <Highlight fontSize="small" />
+                </ToggleButton>
+              </Tooltip>
+            )}
+          </ToggleButtonGroup>
+        </Box>
+      )}
+      {/* align-lists: alignment, lists, indent */}
+      {!['align', 'bullet-list', 'ordered-list', 'indent', 'outdent', 'task-list'].every((id) => hiddenItems.has(id)) && (
+        <Box sx={{ display: 'inline-flex', alignItems: 'center' }}>
+          <ToggleButtonGroup size="small" disabled={disabled}>
+            {!hiddenItems.has('align') && (
+              <Tooltip title="Alignment">
+                <ToggleButton
+                  value="align"
+                  data-toolbar-item="align"
+                  selected={Boolean(alignAnchor)}
+                  onClick={(e) => setAlignAnchor(alignAnchor ? null : e.currentTarget)}
+                  sx={{ pr: 0.25 }}
+                >
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                    {React.createElement(ALIGN_OPTIONS.find((o) => o.value === currentAlign)?.icon ?? FormatAlignLeft, {
+                      fontSize: 'small',
+                    })}
+                    <ArrowDropDown sx={{ fontSize: 18 }} />
+                  </Box>
+                </ToggleButton>
+              </Tooltip>
+            )}
+            {!hiddenItems.has('bullet-list') && (
+              <Tooltip title="Bullet List">
+                <ToggleButton
+                  value="bulletList"
+                  data-toolbar-item="bullet-list"
+                  selected={editor.isActive('bulletList')}
+                  onClick={() => editor.chain().focus().toggleBulletList().run()}
+                >
+                  <FormatListBulleted fontSize="small" />
+                </ToggleButton>
+              </Tooltip>
+            )}
+            {!hiddenItems.has('ordered-list') && (
+              <Tooltip title="Numbered List">
+                <ToggleButton
+                  value="orderedList"
+                  data-toolbar-item="ordered-list"
+                  selected={editor.isActive('orderedList')}
+                  onClick={() => editor.chain().focus().toggleOrderedList().run()}
+                >
+                  <FormatListNumbered fontSize="small" />
+                </ToggleButton>
+              </Tooltip>
+            )}
+            {!hiddenItems.has('indent') && (
+              <Tooltip title="Indent">
+                <ToggleButton
+                  value="indent"
+                  data-toolbar-item="indent"
+                  onClick={indent}
+                >
+                  <FormatIndentIncrease fontSize="small" />
+                </ToggleButton>
+              </Tooltip>
+            )}
+            {!hiddenItems.has('outdent') && (
+              <Tooltip title="Outdent">
+                <ToggleButton
+                  value="outdent"
+                  data-toolbar-item="outdent"
+                  onClick={outdent}
+                >
+                  <FormatIndentDecrease fontSize="small" />
+                </ToggleButton>
+              </Tooltip>
+            )}
+            {!hiddenItems.has('task-list') && (
+              <Tooltip title="Todo List">
+                <ToggleButton
+                  value="taskList"
+                  data-toolbar-item="task-list"
+                  selected={editor.isActive('taskList')}
+                  onClick={() => editor.chain().focus().toggleTaskList().run()}
+                >
+                  <ChecklistRtl fontSize="small" />
+                </ToggleButton>
+              </Tooltip>
+            )}
+          </ToggleButtonGroup>
+        </Box>
+      )}
+      {/* Alignment dropdown menu — always rendered (uses a portal) */}
       <Menu
         anchorEl={alignAnchor}
         open={Boolean(alignAnchor)}
@@ -417,123 +597,617 @@ export const TiptapEditorToolbar: React.FC<TiptapEditorToolbarProps> = ({
           </MenuItem>
         ))}
       </Menu>
-      {/* link, imageInsert, blockQuote, code, codeBlock, subscript, superscript, horizontalLine */}
-      <ToggleButtonGroup size="small" disabled={disabled}>
-        <Tooltip title="Link">
-          <ToggleButton
-            value="link"
-            selected={editor.isActive('link')}
-            onClick={() => onOpenLinkPopover?.()}
-          >
-            <LinkIcon fontSize="small" />
-          </ToggleButton>
-        </Tooltip>
-        <Tooltip title="Image">
-          <ToggleButton value="image" onClick={() => onOpenImagePopover?.()}>
-            <ImageIcon fontSize="small" />
-          </ToggleButton>
-        </Tooltip>
-        <Tooltip title="Blockquote">
-          <ToggleButton
-            value="blockquote"
-            selected={editor.isActive('blockquote')}
-            onClick={() => editor.chain().focus().toggleBlockquote().run()}
-          >
-            <FormatQuote fontSize="small" />
-          </ToggleButton>
-        </Tooltip>
-        <Tooltip title="Code">
-          <ToggleButton
-            value="code"
-            selected={editor.isActive('code')}
-            onClick={() => editor.chain().focus().toggleCode().run()}
-          >
-            <Code fontSize="small" />
-          </ToggleButton>
-        </Tooltip>
-        <Tooltip title="Code Block">
-          <ToggleButton
-            value="codeBlock"
-            selected={editor.isActive('codeBlock')}
-            onClick={() => editor.chain().focus().toggleCodeBlock().run()}
-          >
-            <DataObject fontSize="small" />
-          </ToggleButton>
-        </Tooltip>
-        <Tooltip title="Subscript">
-          <ToggleButton
-            value="subscript"
-            selected={editor.isActive('subscript')}
-            onClick={() => editor.chain().focus().toggleSubscript().run()}
-          >
-            <SubscriptIcon fontSize="small" />
-          </ToggleButton>
-        </Tooltip>
-        <Tooltip title="Superscript">
-          <ToggleButton
-            value="superscript"
-            selected={editor.isActive('superscript')}
-            onClick={() => editor.chain().focus().toggleSuperscript().run()}
-          >
-            <SuperscriptIcon fontSize="small" />
-          </ToggleButton>
-        </Tooltip>
-      </ToggleButtonGroup>
-      <ToggleButtonGroup size="small" disabled={disabled}>
-        <Tooltip title="Table">
-          <ToggleButton
-            value="table"
-            selected={Boolean(tableGridAnchor)}
-            onClick={(e) => setTableGridAnchor(tableGridAnchor ? null : e.currentTarget)}
-          >
-            <TableChart fontSize="small" />
-          </ToggleButton>
-        </Tooltip>
-        <Tooltip title="Page Break">
-          <ToggleButton value="pageBreak" onClick={insertPageBreak}>
-            <ViewAgenda fontSize="small" />
-          </ToggleButton>
-        </Tooltip>
-        <Tooltip title="Horizontal Rule">
-          <ToggleButton value="hr" onClick={() => editor.chain().focus().setHorizontalRule().run()}>
-            <HorizontalRule fontSize="small" />
-          </ToggleButton>
-        </Tooltip>
-      </ToggleButtonGroup>
-      {onToggleSourceMode && (
-        <ToggleButtonGroup size="small" disabled={disabled}>
-          <Tooltip title="Source HTML">
-            <ToggleButton
-              value="sourceMode"
-              selected={isSourceMode}
-              onClick={onToggleSourceMode}
-            >
-              <Html fontSize="small" />
-            </ToggleButton>
-          </Tooltip>
-        </ToggleButtonGroup>
+      {/* insert: link, image, blockquote, code, subscript, superscript */}
+      {!['link', 'image', 'blockquote', 'code', 'code-block', 'subscript', 'superscript'].every((id) => hiddenItems.has(id)) && (
+        <Box sx={{ display: 'inline-flex', alignItems: 'center' }}>
+          <ToggleButtonGroup size="small" disabled={disabled}>
+            {!hiddenItems.has('link') && (
+              <Tooltip title="Link">
+                <ToggleButton
+                  value="link"
+                  data-toolbar-item="link"
+                  selected={editor.isActive('link')}
+                  onClick={() => onOpenLinkPopover?.()}
+                >
+                  <LinkIcon fontSize="small" />
+                </ToggleButton>
+              </Tooltip>
+            )}
+            {!hiddenItems.has('image') && (
+              <Tooltip title="Image">
+                <ToggleButton
+                  value="image"
+                  data-toolbar-item="image"
+                  onClick={() => onOpenImagePopover?.()}
+                >
+                  <ImageIcon fontSize="small" />
+                </ToggleButton>
+              </Tooltip>
+            )}
+            {!hiddenItems.has('blockquote') && (
+              <Tooltip title="Blockquote">
+                <ToggleButton
+                  value="blockquote"
+                  data-toolbar-item="blockquote"
+                  selected={editor.isActive('blockquote')}
+                  onClick={() => editor.chain().focus().toggleBlockquote().run()}
+                >
+                  <FormatQuote fontSize="small" />
+                </ToggleButton>
+              </Tooltip>
+            )}
+            {!hiddenItems.has('code') && (
+              <Tooltip title="Code">
+                <ToggleButton
+                  value="code"
+                  data-toolbar-item="code"
+                  selected={editor.isActive('code')}
+                  onClick={() => editor.chain().focus().toggleCode().run()}
+                >
+                  <Code fontSize="small" />
+                </ToggleButton>
+              </Tooltip>
+            )}
+            {!hiddenItems.has('code-block') && (
+              <Tooltip title="Code Block">
+                <ToggleButton
+                  value="codeBlock"
+                  data-toolbar-item="code-block"
+                  selected={editor.isActive('codeBlock')}
+                  onClick={() => editor.chain().focus().toggleCodeBlock().run()}
+                >
+                  <DataObject fontSize="small" />
+                </ToggleButton>
+              </Tooltip>
+            )}
+            {!hiddenItems.has('subscript') && (
+              <Tooltip title="Subscript">
+                <ToggleButton
+                  value="subscript"
+                  data-toolbar-item="subscript"
+                  selected={editor.isActive('subscript')}
+                  onClick={() => editor.chain().focus().toggleSubscript().run()}
+                >
+                  <SubscriptIcon fontSize="small" />
+                </ToggleButton>
+              </Tooltip>
+            )}
+            {!hiddenItems.has('superscript') && (
+              <Tooltip title="Superscript">
+                <ToggleButton
+                  value="superscript"
+                  data-toolbar-item="superscript"
+                  selected={editor.isActive('superscript')}
+                  onClick={() => editor.chain().focus().toggleSuperscript().run()}
+                >
+                  <SuperscriptIcon fontSize="small" />
+                </ToggleButton>
+              </Tooltip>
+            )}
+          </ToggleButtonGroup>
+        </Box>
       )}
-      {/* undo, redo */}
-      <ToggleButtonGroup size="small" disabled={disabled} sx={{ flexWrap: 'wrap' }}>
-        <Tooltip title="Undo">
+      {/* block: table, page break, horizontal rule */}
+      {!['table', 'page-break', 'hr'].every((id) => hiddenItems.has(id)) && (
+        <Box sx={{ display: 'inline-flex', alignItems: 'center' }}>
+          <ToggleButtonGroup size="small" disabled={disabled}>
+            {!hiddenItems.has('table') && (
+              <Tooltip title="Table">
+                <ToggleButton
+                  value="table"
+                  data-toolbar-item="table"
+                  selected={Boolean(tableGridAnchor)}
+                  onClick={(e) => setTableGridAnchor(tableGridAnchor ? null : e.currentTarget)}
+                >
+                  <TableChart fontSize="small" />
+                </ToggleButton>
+              </Tooltip>
+            )}
+            {!hiddenItems.has('page-break') && (
+              <Tooltip title="Page Break">
+                <ToggleButton
+                  value="pageBreak"
+                  data-toolbar-item="page-break"
+                  onClick={insertPageBreak}
+                >
+                  <ViewAgenda fontSize="small" />
+                </ToggleButton>
+              </Tooltip>
+            )}
+            {!hiddenItems.has('hr') && (
+              <Tooltip title="Horizontal Rule">
+                <ToggleButton
+                  value="hr"
+                  data-toolbar-item="hr"
+                  onClick={() => editor.chain().focus().setHorizontalRule().run()}
+                >
+                  <HorizontalRule fontSize="small" />
+                </ToggleButton>
+              </Tooltip>
+            )}
+          </ToggleButtonGroup>
+        </Box>
+      )}
+      {/* source: HTML source mode (optional) */}
+      {onToggleSourceMode && !hiddenItems.has('source') && (
+        <Box sx={{ display: 'inline-flex', alignItems: 'center' }}>
+          <ToggleButtonGroup size="small" disabled={disabled}>
+            <Tooltip title="Source HTML">
+              <ToggleButton
+                value="sourceMode"
+                data-toolbar-item="source"
+                selected={isSourceMode}
+                onClick={onToggleSourceMode}
+              >
+                <Html fontSize="small" />
+              </ToggleButton>
+            </Tooltip>
+          </ToggleButtonGroup>
+        </Box>
+      )}
+      {/* history: undo, redo */}
+      {!['undo', 'redo'].every((id) => hiddenItems.has(id)) && (
+        <Box sx={{ display: 'inline-flex', alignItems: 'center' }}>
+          <ToggleButtonGroup size="small" disabled={disabled}>
+            {!hiddenItems.has('undo') && (
+              <Tooltip title="Undo">
+                <span>
+                  <IconButton
+                    size="small"
+                    data-toolbar-item="undo"
+                    onClick={() => editor.chain().focus().undo().run()}
+                    disabled={!editor.can().undo()}
+                  >
+                    <Undo fontSize="small" />
+                  </IconButton>
+                </span>
+              </Tooltip>
+            )}
+            {!hiddenItems.has('redo') && (
+              <Tooltip title="Redo">
+                <span>
+                  <IconButton
+                    size="small"
+                    data-toolbar-item="redo"
+                    onClick={() => editor.chain().focus().redo().run()}
+                    disabled={!editor.can().redo()}
+                  >
+                    <Redo fontSize="small" />
+                  </IconButton>
+                </span>
+              </Tooltip>
+            )}
+          </ToggleButtonGroup>
+        </Box>
+      )}
+      {hiddenItems.size > 0 && (
+        <Tooltip title="More">
           <IconButton
             size="small"
-            onClick={() => editor.chain().focus().undo().run()}
-            disabled={!editor.can().undo()}
+            aria-label="More"
+            aria-haspopup="menu"
+            aria-expanded={Boolean(moreAnchor)}
+            onClick={(e) => setMoreAnchor(moreAnchor ? null : e.currentTarget)}
+            sx={{ ml: 0.5 }}
           >
-            <Undo fontSize="small" />
+            <MoreVert fontSize="small" />
           </IconButton>
         </Tooltip>
-        <Tooltip title="Redo">
-          <IconButton
-            size="small"
-            onClick={() => editor.chain().focus().redo().run()}
-            disabled={!editor.can().redo()}
-          >
-            <Redo fontSize="small" />
-          </IconButton>
-        </Tooltip>
-      </ToggleButtonGroup>
+      )}
+      </Box>
+      {/* === Overflow menu — horizontal icon popover === */}
+      <Popover
+        open={Boolean(moreAnchor)}
+        anchorEl={moreAnchor}
+        onClose={() => setMoreAnchor(null)}
+        disableRestoreFocus={hiddenItems.size === 0}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+        slotProps={{ paper: { sx: { p: 0.5 } } }}
+      >
+        <Box
+          onMouseDown={(e) => e.preventDefault()}
+          sx={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            alignItems: 'center',
+            gap: 0.5,
+          }}
+        >
+          {/* heading */}
+          {hiddenItems.has('heading-select') && (
+            <Select
+              size="small"
+              disabled={disabled}
+              value={currentHeading}
+              onChange={(e) => {
+                const opt = HEADING_OPTIONS.find((o) => o.value === e.target.value);
+                if (!opt) return;
+                if (opt.level === null) {
+                  editor.chain().focus().setParagraph().run();
+                } else {
+                  editor.chain().focus().toggleHeading({ level: opt.level }).run();
+                }
+              }}
+              displayEmpty
+              sx={{ minWidth: 130, height: 32 }}
+            >
+              {HEADING_OPTIONS.map((o) => (
+                <MenuItem key={o.value} value={o.value}>
+                  {o.label}
+                </MenuItem>
+              ))}
+            </Select>
+          )}
+          {/* font-format */}
+          {['font-family', 'font-size', 'bold', 'italic', 'underline', 'strike'].some((id) => hiddenItems.has(id)) && (
+            <ToggleButtonGroup size="small" disabled={disabled}>
+              {hiddenItems.has('font-family') && (
+                <Tooltip title="Font Family">
+                  <ToggleButton
+                    value="fontFamily"
+                    selected={Boolean(fontFamilyAnchor)}
+                    onClick={(e) => setFontFamilyAnchor(fontFamilyAnchor ? null : e.currentTarget)}
+                    sx={{ pr: 0.25 }}
+                  >
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                      <FontDownload fontSize="small" />
+                      <ArrowDropDown sx={{ fontSize: 18 }} />
+                    </Box>
+                  </ToggleButton>
+                </Tooltip>
+              )}
+              {hiddenItems.has('font-size') && (
+                <Tooltip title="Font Size">
+                  <ToggleButton
+                    value="fontSize"
+                    selected={Boolean(fontSizeAnchor)}
+                    onClick={(e) => setFontSizeAnchor(fontSizeAnchor ? null : e.currentTarget)}
+                    sx={{ pr: 0.25 }}
+                  >
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                      <FormatSize fontSize="small" />
+                      <ArrowDropDown sx={{ fontSize: 18 }} />
+                    </Box>
+                  </ToggleButton>
+                </Tooltip>
+              )}
+              {hiddenItems.has('bold') && (
+                <Tooltip title="Bold">
+                  <ToggleButton
+                    value="bold"
+                    selected={editor.isActive('bold')}
+                    onClick={() => editor.chain().focus().toggleBold().run()}
+                  >
+                    <FormatBold fontSize="small" />
+                  </ToggleButton>
+                </Tooltip>
+              )}
+              {hiddenItems.has('italic') && (
+                <Tooltip title="Italic">
+                  <ToggleButton
+                    value="italic"
+                    selected={editor.isActive('italic')}
+                    onClick={() => editor.chain().focus().toggleItalic().run()}
+                  >
+                    <FormatItalic fontSize="small" />
+                  </ToggleButton>
+                </Tooltip>
+              )}
+              {hiddenItems.has('underline') && (
+                <Tooltip title="Underline">
+                  <ToggleButton
+                    value="underline"
+                    selected={editor.isActive('underline')}
+                    onClick={() => editor.chain().focus().toggleUnderline().run()}
+                  >
+                    <FormatUnderlined fontSize="small" />
+                  </ToggleButton>
+                </Tooltip>
+              )}
+              {hiddenItems.has('strike') && (
+                <Tooltip title="Strikethrough">
+                  <ToggleButton
+                    value="strike"
+                    selected={editor.isActive('strike')}
+                    onClick={() => editor.chain().focus().toggleStrike().run()}
+                  >
+                    <FormatStrikethrough fontSize="small" />
+                  </ToggleButton>
+                </Tooltip>
+              )}
+            </ToggleButtonGroup>
+          )}
+          {/* color */}
+          {['text-color', 'bg-color', 'highlight'].some((id) => hiddenItems.has(id)) && (
+            <ToggleButtonGroup size="small" disabled={disabled}>
+              {hiddenItems.has('text-color') && (
+                <Tooltip title="Text Color">
+                  <ToggleButton
+                    value="textColor"
+                    selected={Boolean(textColorAnchor)}
+                    onClick={(e) => setTextColorAnchor(textColorAnchor ? null : e.currentTarget)}
+                  >
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.25 }}>
+                      <FormatColorText fontSize="small" />
+                      {currentColor && (
+                        <Box
+                          sx={{
+                            width: 12,
+                            height: 12,
+                            borderRadius: 0.5,
+                            border: 1,
+                            borderColor: 'divider',
+                            bgcolor: currentColor,
+                          }}
+                        />
+                      )}
+                    </Box>
+                  </ToggleButton>
+                </Tooltip>
+              )}
+              {hiddenItems.has('bg-color') && (
+                <Tooltip title="Background Color">
+                  <ToggleButton
+                    value="bgColor"
+                    selected={Boolean(bgColorAnchor)}
+                    onClick={(e) => setBgColorAnchor(bgColorAnchor ? null : e.currentTarget)}
+                  >
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.25 }}>
+                      <FormatPaint fontSize="small" />
+                      {currentBgColor && (
+                        <Box
+                          sx={{
+                            width: 12,
+                            height: 12,
+                            borderRadius: 0.5,
+                            border: 1,
+                            borderColor: 'divider',
+                            bgcolor: currentBgColor,
+                          }}
+                        />
+                      )}
+                    </Box>
+                  </ToggleButton>
+                </Tooltip>
+              )}
+              {hiddenItems.has('highlight') && (
+                <Tooltip title="Highlight">
+                  <ToggleButton
+                    value="highlight"
+                    selected={editor.isActive('highlight')}
+                    onClick={() => editor.chain().focus().toggleHighlight().run()}
+                  >
+                    <Highlight fontSize="small" />
+                  </ToggleButton>
+                </Tooltip>
+              )}
+            </ToggleButtonGroup>
+          )}
+          {/* align-lists */}
+          {['align', 'bullet-list', 'ordered-list', 'indent', 'outdent', 'task-list'].some((id) => hiddenItems.has(id)) && (
+            <ToggleButtonGroup size="small" disabled={disabled}>
+              {hiddenItems.has('align') && (
+                <Tooltip title="Alignment">
+                  <ToggleButton
+                    value="align"
+                    selected={Boolean(alignAnchor)}
+                    onClick={(e) => setAlignAnchor(alignAnchor ? null : e.currentTarget)}
+                    sx={{ pr: 0.25 }}
+                  >
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                      {React.createElement(ALIGN_OPTIONS.find((o) => o.value === currentAlign)?.icon ?? FormatAlignLeft, {
+                        fontSize: 'small',
+                      })}
+                      <ArrowDropDown sx={{ fontSize: 18 }} />
+                    </Box>
+                  </ToggleButton>
+                </Tooltip>
+              )}
+              {hiddenItems.has('bullet-list') && (
+                <Tooltip title="Bullet List">
+                  <ToggleButton
+                    value="bulletList"
+                    selected={editor.isActive('bulletList')}
+                    onClick={() => editor.chain().focus().toggleBulletList().run()}
+                  >
+                    <FormatListBulleted fontSize="small" />
+                  </ToggleButton>
+                </Tooltip>
+              )}
+              {hiddenItems.has('ordered-list') && (
+                <Tooltip title="Numbered List">
+                  <ToggleButton
+                    value="orderedList"
+                    selected={editor.isActive('orderedList')}
+                    onClick={() => editor.chain().focus().toggleOrderedList().run()}
+                  >
+                    <FormatListNumbered fontSize="small" />
+                  </ToggleButton>
+                </Tooltip>
+              )}
+              {hiddenItems.has('indent') && (
+                <Tooltip title="Indent">
+                  <ToggleButton value="indent" onClick={indent}>
+                    <FormatIndentIncrease fontSize="small" />
+                  </ToggleButton>
+                </Tooltip>
+              )}
+              {hiddenItems.has('outdent') && (
+                <Tooltip title="Outdent">
+                  <ToggleButton value="outdent" onClick={outdent}>
+                    <FormatIndentDecrease fontSize="small" />
+                  </ToggleButton>
+                </Tooltip>
+              )}
+              {hiddenItems.has('task-list') && (
+                <Tooltip title="Todo List">
+                  <ToggleButton
+                    value="taskList"
+                    selected={editor.isActive('taskList')}
+                    onClick={() => editor.chain().focus().toggleTaskList().run()}
+                  >
+                    <ChecklistRtl fontSize="small" />
+                  </ToggleButton>
+                </Tooltip>
+              )}
+            </ToggleButtonGroup>
+          )}
+          {/* insert */}
+          {['link', 'image', 'blockquote', 'code', 'code-block', 'subscript', 'superscript'].some((id) => hiddenItems.has(id)) && (
+            <ToggleButtonGroup size="small" disabled={disabled}>
+              {hiddenItems.has('link') && (
+                <Tooltip title="Link">
+                  <ToggleButton
+                    value="link"
+                    selected={editor.isActive('link')}
+                    onClick={() => onOpenLinkPopover?.()}
+                  >
+                    <LinkIcon fontSize="small" />
+                  </ToggleButton>
+                </Tooltip>
+              )}
+              {hiddenItems.has('image') && (
+                <Tooltip title="Image">
+                  <ToggleButton value="image" onClick={() => onOpenImagePopover?.()}>
+                    <ImageIcon fontSize="small" />
+                  </ToggleButton>
+                </Tooltip>
+              )}
+              {hiddenItems.has('blockquote') && (
+                <Tooltip title="Blockquote">
+                  <ToggleButton
+                    value="blockquote"
+                    selected={editor.isActive('blockquote')}
+                    onClick={() => editor.chain().focus().toggleBlockquote().run()}
+                  >
+                    <FormatQuote fontSize="small" />
+                  </ToggleButton>
+                </Tooltip>
+              )}
+              {hiddenItems.has('code') && (
+                <Tooltip title="Code">
+                  <ToggleButton
+                    value="code"
+                    selected={editor.isActive('code')}
+                    onClick={() => editor.chain().focus().toggleCode().run()}
+                  >
+                    <Code fontSize="small" />
+                  </ToggleButton>
+                </Tooltip>
+              )}
+              {hiddenItems.has('code-block') && (
+                <Tooltip title="Code Block">
+                  <ToggleButton
+                    value="codeBlock"
+                    selected={editor.isActive('codeBlock')}
+                    onClick={() => editor.chain().focus().toggleCodeBlock().run()}
+                  >
+                    <DataObject fontSize="small" />
+                  </ToggleButton>
+                </Tooltip>
+              )}
+              {hiddenItems.has('subscript') && (
+                <Tooltip title="Subscript">
+                  <ToggleButton
+                    value="subscript"
+                    selected={editor.isActive('subscript')}
+                    onClick={() => editor.chain().focus().toggleSubscript().run()}
+                  >
+                    <SubscriptIcon fontSize="small" />
+                  </ToggleButton>
+                </Tooltip>
+              )}
+              {hiddenItems.has('superscript') && (
+                <Tooltip title="Superscript">
+                  <ToggleButton
+                    value="superscript"
+                    selected={editor.isActive('superscript')}
+                    onClick={() => editor.chain().focus().toggleSuperscript().run()}
+                  >
+                    <SuperscriptIcon fontSize="small" />
+                  </ToggleButton>
+                </Tooltip>
+              )}
+            </ToggleButtonGroup>
+          )}
+          {/* block */}
+          {['table', 'page-break', 'hr'].some((id) => hiddenItems.has(id)) && (
+            <ToggleButtonGroup size="small" disabled={disabled}>
+              {hiddenItems.has('table') && (
+                <Tooltip title="Table">
+                  <ToggleButton
+                    value="table"
+                    selected={Boolean(tableGridAnchor)}
+                    onClick={(e) => setTableGridAnchor(tableGridAnchor ? null : e.currentTarget)}
+                  >
+                    <TableChart fontSize="small" />
+                  </ToggleButton>
+                </Tooltip>
+              )}
+              {hiddenItems.has('page-break') && (
+                <Tooltip title="Page Break">
+                  <ToggleButton value="pageBreak" onClick={insertPageBreak}>
+                    <ViewAgenda fontSize="small" />
+                  </ToggleButton>
+                </Tooltip>
+              )}
+              {hiddenItems.has('hr') && (
+                <Tooltip title="Horizontal Rule">
+                  <ToggleButton value="hr" onClick={() => editor.chain().focus().setHorizontalRule().run()}>
+                    <HorizontalRule fontSize="small" />
+                  </ToggleButton>
+                </Tooltip>
+              )}
+            </ToggleButtonGroup>
+          )}
+          {/* source */}
+          {onToggleSourceMode && hiddenItems.has('source') && (
+            <ToggleButtonGroup size="small" disabled={disabled}>
+              <Tooltip title="Source HTML">
+                <ToggleButton
+                  value="sourceMode"
+                  selected={isSourceMode}
+                  onClick={onToggleSourceMode}
+                >
+                  <Html fontSize="small" />
+                </ToggleButton>
+              </Tooltip>
+            </ToggleButtonGroup>
+          )}
+          {/* history */}
+          {['undo', 'redo'].some((id) => hiddenItems.has(id)) && (
+            <ToggleButtonGroup size="small" disabled={disabled}>
+              {hiddenItems.has('undo') && (
+                <Tooltip title="Undo">
+                  <span>
+                    <IconButton
+                      size="small"
+                      onClick={() => editor.chain().focus().undo().run()}
+                      disabled={!editor.can().undo()}
+                    >
+                      <Undo fontSize="small" />
+                    </IconButton>
+                  </span>
+                </Tooltip>
+              )}
+              {hiddenItems.has('redo') && (
+                <Tooltip title="Redo">
+                  <span>
+                    <IconButton
+                      size="small"
+                      onClick={() => editor.chain().focus().redo().run()}
+                      disabled={!editor.can().redo()}
+                    >
+                      <Redo fontSize="small" />
+                    </IconButton>
+                  </span>
+                </Tooltip>
+              )}
+            </ToggleButtonGroup>
+          )}
+        </Box>
+      </Popover>
       <Popover
         open={Boolean(textColorAnchor)}
         anchorEl={textColorAnchor}

--- a/packages/filigran-rich-text-editor/src/richTextEditor/TiptapEditorToolbar.tsx
+++ b/packages/filigran-rich-text-editor/src/richTextEditor/TiptapEditorToolbar.tsx
@@ -193,18 +193,25 @@ export const TiptapEditorToolbar: React.FC<TiptapEditorToolbarProps> = ({
     });
 
     const INTER_GROUP_GAP = 4; // gap: 0.5 = 4px between group Boxes
+    const INTRA_GROUP_GAP = 2; // gap between buttons in same group
 
     const measure = () => {
       const containerWidth = container.clientWidth;
 
-      // Total natural width: one gap per group transition, not per item
+      // Total natural width: gaps between groups + gaps between group items + item widths
       let totalNatural = 0;
       let lastGroup = -1;
       for (const id of itemIds) {
         const w = cachedWidthsRef.current[id] ?? 0;
         if (w === 0) continue;
         const gi = groupOf[id];
-        if (lastGroup !== -1 && gi !== lastGroup) totalNatural += INTER_GROUP_GAP;
+        if (lastGroup !== -1) {
+          if (gi !== lastGroup) {
+            totalNatural += INTER_GROUP_GAP;
+          } else {
+            totalNatural += INTRA_GROUP_GAP;
+          }
+        }
         totalNatural += w;
         lastGroup = gi;
       }
@@ -215,7 +222,7 @@ export const TiptapEditorToolbar: React.FC<TiptapEditorToolbarProps> = ({
         return;
       }
 
-      const MORE_BTN_WIDTH = 36;
+      const MORE_BTN_WIDTH = 40; // 36px estimated size + 4px safety buffer
       const available = containerWidth - MORE_BTN_WIDTH;
       let used = 0;
       const newHidden = new Set<string>();
@@ -225,7 +232,15 @@ export const TiptapEditorToolbar: React.FC<TiptapEditorToolbarProps> = ({
       for (const id of itemIds) {
         const w = cachedWidthsRef.current[id] ?? 0;
         const gi = groupOf[id];
-        const gapCost = (lastVisibleGroup !== -1 && gi !== lastVisibleGroup) ? INTER_GROUP_GAP : 0;
+
+        let gapCost = 0;
+        if (lastVisibleGroup !== -1) {
+          if (gi !== lastVisibleGroup) {
+            gapCost = INTER_GROUP_GAP;
+          } else {
+            gapCost = INTRA_GROUP_GAP;
+          }
+        }
 
         if (!overflowing && used + gapCost + w <= available) {
           used += gapCost + w;
@@ -248,6 +263,45 @@ export const TiptapEditorToolbar: React.FC<TiptapEditorToolbarProps> = ({
     return () => ro.disconnect();
   }, [itemIds, itemGroups]);
 
+  const toolbarItemStyles = {
+    '& .MuiToggleButtonGroup-root': {
+      border: 'none',
+      gap: '2px',
+      '& .MuiToggleButton-root': {
+        border: 'none',
+        '&:not(:first-of-type)': {
+          borderLeft: 'none',
+          marginLeft: 0,
+        },
+      },
+    },
+    '& .MuiToggleButton-root, & .MuiIconButton-root': {
+      border: 'none',
+      color: 'text.primary',
+      backgroundColor: 'transparent',
+      '&.Mui-disabled': {
+        color: 'text.disabled',
+      },
+      '&:hover': {
+        backgroundColor: 'transparent',
+      },
+      '&:hover:not(.Mui-selected)': {
+        backgroundColor: 'transparent',
+      },
+      '&.Mui-selected': {
+        backgroundColor: 'action.selected',
+        color: 'primary.main',
+        '&.Mui-disabled': {
+          backgroundColor: 'action.selected',
+          color: 'text.disabled',
+        },
+        '&:hover': {
+          backgroundColor: 'action.selected',
+        },
+      },
+    },
+  };
+
   return (
     <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
       <Box
@@ -261,6 +315,7 @@ export const TiptapEditorToolbar: React.FC<TiptapEditorToolbarProps> = ({
           p: 0.5,
           minHeight: 40,
           overflow: 'hidden',
+          ...toolbarItemStyles,
         }}
       >
       {/* heading */}
@@ -812,6 +867,7 @@ export const TiptapEditorToolbar: React.FC<TiptapEditorToolbarProps> = ({
             flexWrap: 'wrap',
             alignItems: 'center',
             gap: 0.5,
+            ...toolbarItemStyles,
           }}
         >
           {/* heading */}

--- a/packages/filigran-rich-text-editor/src/richTextEditor/extensions/Div.ts
+++ b/packages/filigran-rich-text-editor/src/richTextEditor/extensions/Div.ts
@@ -1,0 +1,44 @@
+import {Node, mergeAttributes} from '@tiptap/core'
+
+/**
+ * TipTap node extension that preserves <div> elements from externally-created HTML.
+ *
+ * Without this extension TipTap (ProseMirror) has no schema node for <div>, so it
+ * silently unwraps every <div> and discards its inline style / class attributes.
+ * This means font-size, color and layout styles defined on parent divs are lost.
+ */
+export const Div = Node.create({
+  name: 'div',
+  group: 'block',
+  content: 'block+',
+  defining: true,
+
+  addAttributes() {
+    return {
+      style: {
+        default: null,
+        parseHTML: (element: HTMLElement) => element.getAttribute('style') || null,
+        renderHTML: (attrs: Record<string, string | null>) => {
+          if (!attrs.style) return {}
+          return {style: attrs.style}
+        },
+      },
+      class: {
+        default: null,
+        parseHTML: (element: HTMLElement) => element.getAttribute('class') || null,
+        renderHTML: (attrs: Record<string, string | null>) => {
+          if (!attrs.class) return {}
+          return {class: attrs.class}
+        },
+      },
+    }
+  },
+
+  parseHTML() {
+    return [{tag: 'div'}]
+  },
+
+  renderHTML({HTMLAttributes}) {
+    return ['div', mergeAttributes(HTMLAttributes), 0]
+  },
+})

--- a/packages/filigran-rich-text-editor/src/richTextEditor/extensions/FontSize.ts
+++ b/packages/filigran-rich-text-editor/src/richTextEditor/extensions/FontSize.ts
@@ -1,0 +1,32 @@
+import { FontSize as FontSizeBase } from '@tiptap/extension-text-style/font-size';
+import { LEGACY_FONT_SIZE_MAP } from './TextStyle';
+
+/**
+ * Extends TipTap's FontSize to read font size from legacy editor classes when no
+ * inline style is present. Must be used together with the extended TextStyle
+ * (TextStyle.ts) which allows those spans to be parsed at all.
+ */
+export const FontSize = FontSizeBase.extend({
+  addGlobalAttributes() {
+    return [
+      {
+        types: ['textStyle'],
+        attributes: {
+          fontSize: {
+            default: null,
+            parseHTML: (element: HTMLElement) => {
+              for (const [cls, size] of Object.entries(LEGACY_FONT_SIZE_MAP)) {
+                if (element.classList.contains(cls)) return size;
+              }
+              return element.style.fontSize || null;
+            },
+            renderHTML: (attrs: Record<string, string>) => {
+              if (!attrs.fontSize) return {};
+              return { style: `font-size: ${attrs.fontSize}` };
+            },
+          },
+        },
+      },
+    ];
+  },
+});

--- a/packages/filigran-rich-text-editor/src/richTextEditor/extensions/Highlight.ts
+++ b/packages/filigran-rich-text-editor/src/richTextEditor/extensions/Highlight.ts
@@ -1,0 +1,68 @@
+import HighlightBase from '@tiptap/extension-highlight';
+
+/**
+ * Legacy editor highlight class → color mapping.
+ * Markers set background color, pens set text color (handled via CSS
+ * for backward compat; not converted by this extension).
+ */
+export const LEGACY_HIGHLIGHT_MAP: Record<string, string> = {
+  'marker-yellow': 'rgb(255, 255, 0)',
+  'marker-green': 'rgb(98, 249, 98)',
+  'marker-pink': 'rgb(252, 120, 153)',
+  'marker-blue': 'rgb(15, 188, 255)',
+};
+
+export const LEGACY_PEN_MAP: Record<string, string> = {
+  'pen-red': 'rgb(231, 19, 19)',
+  'pen-green': 'rgb(18, 138, 0)',
+};
+
+/**
+ * Extends TipTap's Highlight extension to parse legacy editor marker classes
+ * (e.g. <mark class="marker-yellow">) and map them to a background color.
+ * multicolor is always enabled.
+ */
+export const Highlight = HighlightBase.extend({
+  addAttributes() {
+    return {
+      ...this.parent?.(),
+      class: {
+        default: null,
+        parseHTML: (element) => element.getAttribute('class') ?? null,
+        renderHTML: (attributes) => {
+          if (!attributes.class) {
+            return {};
+          }
+          return { class: attributes.class };
+        },
+      },
+    };
+  },
+  parseHTML() {
+    return [
+      ...(this.parent?.() ?? []),
+      // Accept legacy editor marker class marks
+      ...Object.keys(LEGACY_HIGHLIGHT_MAP).map((cls) => ({
+        tag: `mark.${cls}`,
+        getAttrs: (node: HTMLElement | string) => {
+          const classAttr = typeof node === 'string' ? '' : node.getAttribute('class');
+          return {
+            color: LEGACY_HIGHLIGHT_MAP[cls] ?? null,
+            class: classAttr,
+          };
+        },
+      })),
+      // Accept legacy editor pen class marks
+      ...Object.keys(LEGACY_PEN_MAP).map((cls) => ({
+        tag: `mark.${cls}`,
+        getAttrs: (node: HTMLElement | string) => {
+          const classAttr = typeof node === 'string' ? '' : node.getAttribute('class');
+          return {
+            color: 'transparent',
+            class: classAttr,
+          };
+        },
+      })),
+    ];
+  },
+}).configure({ multicolor: true });

--- a/packages/filigran-rich-text-editor/src/richTextEditor/extensions/ImageWithOptions.ts
+++ b/packages/filigran-rich-text-editor/src/richTextEditor/extensions/ImageWithOptions.ts
@@ -1,0 +1,373 @@
+import Image from '@tiptap/extension-image';
+import { mergeAttributes, ResizableNodeView } from '@tiptap/core';
+
+export interface ImageWithOptionsOptions {
+  inline: boolean;
+  allowBase64: boolean;
+  resize?: {
+    enabled: boolean;
+    directions: string[];
+    minWidth: number;
+    minHeight: number;
+    alwaysPreserveAspectRatio: boolean;
+  };
+  HTMLAttributes: Record<string, unknown>;
+}
+
+/**
+ * Extends Tiptap Image with: alt, title, caption, and optional link (href).
+ * Renders as <figure class="image-figure">(<a href?>)<img>(<figcaption>)</figure>
+ * for caption and link support. Resize (poignées) is configured on the base Image.
+ */
+export const ImageWithOptions = Image.extend<ImageWithOptionsOptions>({
+  addAttributes() {
+    return {
+      ...this.parent?.(),
+      alt: {
+        default: null,
+        renderHTML: (attrs) => (attrs.alt != null && attrs.alt !== '' ? { alt: String(attrs.alt) } : {}),
+      },
+      title: {
+        default: null,
+        renderHTML: (attrs) => (attrs.title != null && attrs.title !== '' ? { title: String(attrs.title) } : {}),
+      },
+      caption: {
+        default: null,
+        renderHTML: () => ({}),
+      },
+      href: {
+        default: null,
+        renderHTML: () => ({}),
+      },
+      figureStyle: {
+        default: null,
+        renderHTML: () => ({}),
+      },
+      figureClass: {
+        default: null,
+        renderHTML: () => ({}),
+      },
+      imgStyle: {
+        default: null,
+        renderHTML: () => ({}),
+      },
+    };
+  },
+
+  parseHTML() {
+    const parseDimension = (styleStr: string | null | undefined, dimension: 'width' | 'height'): number | null => {
+      if (!styleStr) return null;
+      const regex = new RegExp(`${dimension}\\s*:\\s*([0-9.]+)(px|%)?`, 'i');
+      const match = styleStr.match(regex);
+      return match && match[1] ? parseInt(match[1], 10) : null;
+    };
+
+    const extractDimensions = (figStyle: string | null | undefined, imgStyle: string | null | undefined, attrWidth: number | null, attrHeight: number | null) => {
+      const styleWidth = parseDimension(figStyle, 'width') ?? parseDimension(imgStyle, 'width');
+      const styleHeight = parseDimension(figStyle, 'height') ?? parseDimension(imgStyle, 'height');
+
+      let finalWidth = styleWidth ?? attrWidth;
+      let finalHeight = styleHeight ?? attrHeight;
+
+      // Si le style surcharge la largeur mais pas la hauteur (ou inversement),
+      // il faut recalculer l'autre dimension pour respecter le ratio d'origine
+      if (styleWidth && !styleHeight && attrWidth && attrHeight) {
+        finalHeight = Math.round(styleWidth * (attrHeight / attrWidth));
+      } else if (styleHeight && !styleWidth && attrWidth && attrHeight) {
+        finalWidth = Math.round(styleHeight * (attrWidth / attrHeight));
+      } else if (styleWidth && !styleHeight && !attrHeight) {
+        finalHeight = null;
+      } else if (styleHeight && !styleWidth && !attrWidth) {
+        finalWidth = null;
+      }
+
+      return { finalWidth, finalHeight };
+    };
+
+    const getFigureAttrs = (node: HTMLElement) => {
+      const img = node.querySelector('img');
+      if (!img) return false;
+      const a = img.closest('a');
+      const cap = node.querySelector('figcaption');
+      const figStyle = node.getAttribute('style');
+      const imgStyle = img.getAttribute('style');
+
+      const attrWidth = img.getAttribute('width') ? parseInt(img.getAttribute('width') ?? '', 10) : null;
+      const attrHeight = img.getAttribute('height') ? parseInt(img.getAttribute('height') ?? '', 10) : null;
+
+      const { finalWidth, finalHeight } = extractDimensions(figStyle, imgStyle, attrWidth, attrHeight);
+
+      return {
+        src: img.getAttribute('src'),
+        alt: img.getAttribute('alt'),
+        title: img.getAttribute('title') ?? img.getAttribute('data-title'),
+        width: finalWidth,
+        height: finalHeight,
+        href: a?.getAttribute('href') ?? img.getAttribute('data-href') ?? null,
+        caption: cap?.textContent?.trim() ?? img.getAttribute('data-caption') ?? null,
+        figureStyle: figStyle ? figStyle.replace(/(width|height)\s*:\s*[^;]+;?/gi, '').trim() : null,
+        figureClass: node.getAttribute('class') ?? null,
+        imgStyle: imgStyle ? imgStyle.replace(/(width|height)\s*:\s*[^;]+;?/gi, '').trim() : null,
+      };
+    };
+    return [
+      { tag: 'figure.image-figure', getAttrs: (node) => (typeof node === 'object' && node instanceof HTMLElement ? getFigureAttrs(node) : false) },
+      { tag: 'figure.image', getAttrs: (node) => (typeof node === 'object' && node instanceof HTMLElement ? getFigureAttrs(node) : false) },
+      {
+        tag: 'img[src]',
+        getAttrs: (node) => {
+          if (typeof node !== 'object' || !(node instanceof HTMLElement)) return false;
+          const fig = node.closest('figure');
+          const figStyle = fig?.getAttribute('style');
+          const imgStyle = node.getAttribute('style');
+          const attrWidth = node.getAttribute('width') ? parseInt(node.getAttribute('width') ?? '', 10) : null;
+          const attrHeight = node.getAttribute('height') ? parseInt(node.getAttribute('height') ?? '', 10) : null;
+
+          const { finalWidth, finalHeight } = extractDimensions(figStyle, imgStyle, attrWidth, attrHeight);
+
+          return {
+            src: node.getAttribute('src'),
+            alt: node.getAttribute('alt'),
+            title: node.getAttribute('title') ?? node.getAttribute('data-title'),
+            width: finalWidth,
+            height: finalHeight,
+            href: node.getAttribute('data-href') ?? null,
+            caption: node.getAttribute('data-caption') ?? null,
+            figureStyle: figStyle ? figStyle.replace(/(width|height)\s*:\s*[^;]+;?/gi, '').trim() : null,
+            figureClass: fig?.getAttribute('class') ?? null,
+            imgStyle: imgStyle ? imgStyle.replace(/(width|height)\s*:\s*[^;]+;?/gi, '').trim() : null,
+          };
+        },
+      },
+    ];
+  },
+
+  renderHTML({ node, HTMLAttributes }) {
+    const { caption, href, figureStyle, figureClass, imgStyle, ...rest } = node.attrs;
+    const merged = mergeAttributes(this.options.HTMLAttributes ?? {}, rest, HTMLAttributes);
+    // ProseMirror renderSpec requires attribute values to be strings; omit null/undefined
+    const imgAttrs: Record<string, string> = {};
+    Object.entries(merged).forEach(([key, value]) => {
+      if (value != null && value !== '') {
+        imgAttrs[key] = String(value);
+      }
+    });
+
+    const hasCaption = typeof caption === 'string' && caption.trim() !== '';
+    const hasLink = href && String(href).trim() !== '';
+    const captionText = hasCaption ? String(caption).trim() : '';
+    const titleText = typeof node.attrs.title === 'string' && node.attrs.title.trim() !== '' ? node.attrs.title.trim() : '';
+
+    // Redundant data-* attributes for resilience across sanitization pipelines.
+    if (captionText) {
+      imgAttrs['data-caption'] = captionText;
+    }
+    if (hasLink) {
+      imgAttrs['data-href'] = String(href).trim();
+    }
+    if (titleText) {
+      imgAttrs['data-title'] = titleText;
+    }
+    if (imgStyle && String(imgStyle).trim() !== '') {
+      imgAttrs['style'] = String(imgStyle).trim();
+    }
+
+    // Always wrap in figure.image-figure for CKEditor compatibility (centering, margins)
+    const imgTag: [string, Record<string, string>] = ['img', imgAttrs];
+    const wrappedImg = hasLink
+      ? ['a', { href: String(href).trim(), target: '_blank', rel: 'noopener noreferrer' }, imgTag]
+      : imgTag;
+
+    const figAttrs: Record<string, string> = {};
+    if (figureClass && String(figureClass).trim() !== '') {
+      figAttrs['class'] = `image-figure ${String(figureClass).trim().replace('image-figure', '')}`.replace(/\s+/g, ' ').trim();
+    } else {
+      figAttrs['class'] = 'image-figure';
+    }
+    if (figureStyle && String(figureStyle).trim() !== '') {
+      figAttrs['style'] = String(figureStyle).trim();
+    }
+
+    if (hasCaption) {
+      return ['figure', figAttrs, wrappedImg, ['figcaption', {}, captionText]];
+    }
+    return ['figure', figAttrs, wrappedImg];
+  },
+
+  addNodeView() {
+    if (typeof document === 'undefined') return null;
+    const resizeOpts = this.options.resize;
+    const resizeEnabled = resizeOpts?.enabled && resizeOpts?.directions?.length;
+
+    return ({ node, getPos, HTMLAttributes, editor }) => {
+      const { caption, href, width, height, figureStyle, figureClass, imgStyle, ...imgRest } = node.attrs as Record<string, unknown>;
+      const hasCaption = caption && typeof caption === 'string';
+      const hasLink = href && String(href).trim() !== '';
+
+      const img = document.createElement('img');
+      img.src = HTMLAttributes.src ?? '';
+
+      if (imgStyle && String(imgStyle).trim() !== '') {
+        img.setAttribute('style', String(imgStyle).trim());
+      }
+      Object.entries(imgRest).forEach(([key, value]) => {
+        if (value != null && value !== '') img.setAttribute(key, String(value));
+      });
+      if (width != null) img.setAttribute('width', String(width));
+      if (height != null) img.setAttribute('height', String(height));
+
+      const showWhenLoaded = (dom: HTMLElement) => {
+        dom.style.visibility = 'hidden';
+        dom.style.pointerEvents = 'none';
+        img.onload = () => {
+          dom.style.visibility = '';
+          dom.style.pointerEvents = '';
+        };
+      };
+
+      if (resizeEnabled && resizeOpts) {
+        const { directions, minWidth, minHeight, alwaysPreserveAspectRatio } = resizeOpts;
+        const nodeView = new ResizableNodeView({
+          element: img,
+          editor,
+          node,
+          getPos,
+          onResize: (w, h) => {
+            img.style.width = `${w}px`;
+            img.style.height = `${h}px`;
+          },
+          onCommit: (w, h) => {
+            const pos = getPos();
+            if (pos === undefined) return;
+            editor.chain().setNodeSelection(pos).updateAttributes(this.name, { width: w, height: h }).run();
+          },
+          onUpdate: (updatedNode: typeof node) => {
+            if (updatedNode.type !== node.type) return false;
+            return true;
+          },
+          options: {
+            directions: directions as ('top' | 'right' | 'bottom' | 'left' | 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left')[],
+            min: { width: minWidth, height: minHeight },
+            preserveAspectRatio: alwaysPreserveAspectRatio === true,
+          },
+        });
+
+        /* Always use figure wrapper when resize is on so we can show/update caption in update() */
+        const figure = document.createElement('figure');
+
+        let nodeFigureClass = 'image-figure';
+        if (figureClass && String(figureClass).trim() !== '') {
+          nodeFigureClass = `image-figure ${String(figureClass).trim().replace('image-figure', '')}`.replace(/\s+/g, ' ').trim();
+        }
+        figure.className = nodeFigureClass;
+
+        if (figureStyle && String(figureStyle).trim() !== '') {
+          figure.setAttribute('style', String(figureStyle).trim());
+        }
+
+        if (hasLink) {
+          const a = document.createElement('a');
+          a.href = String(href).trim();
+          a.target = '_blank';
+          a.rel = 'noopener noreferrer';
+          a.addEventListener('click', (event) => event.preventDefault());
+          a.appendChild(nodeView.dom);
+          figure.appendChild(a);
+        } else {
+          figure.appendChild(nodeView.dom);
+        }
+        if (hasCaption) {
+          const figcap = document.createElement('figcaption');
+          figcap.textContent = caption;
+          figure.appendChild(figcap);
+        }
+
+        showWhenLoaded(figure);
+
+        return {
+          dom: figure,
+          update: (updatedNode: typeof node, decorations: readonly unknown[], innerDecorations: unknown) => {
+            if (updatedNode.type !== node.type) return false;
+            const ok = nodeView.update(updatedNode, decorations as never, innerDecorations as never);
+            if (!ok) return false;
+            const cap = updatedNode.attrs.caption;
+            const capEl = figure.querySelector('figcaption');
+            if (cap != null && typeof cap === 'string' && cap !== '') {
+              if (capEl) capEl.textContent = cap;
+              else {
+                const fc = document.createElement('figcaption');
+                fc.textContent = cap;
+                figure.appendChild(fc);
+              }
+            } else if (capEl) capEl.remove();
+            const innerImg = figure.querySelector('img');
+            if (innerImg) {
+              innerImg.src = updatedNode.attrs.src ?? '';
+              ['alt', 'title'].forEach((k) => {
+                const v = updatedNode.attrs[k];
+                if (v != null) innerImg.setAttribute(k, String(v));
+                else innerImg.removeAttribute(k);
+              });
+            }
+            return true;
+          },
+          destroy: () => nodeView.destroy(),
+        };
+      }
+
+      const figure = document.createElement('figure');
+      let nodeFigureClass = 'image-figure';
+      if (figureClass && String(figureClass).trim() !== '') {
+        nodeFigureClass = `image-figure ${String(figureClass).trim().replace('image-figure', '')}`.replace(/\s+/g, ' ').trim();
+      }
+      figure.className = nodeFigureClass;
+
+      if (figureStyle && String(figureStyle).trim() !== '') {
+        figure.setAttribute('style', String(figureStyle).trim());
+      }
+      if (hasLink) {
+        const a = document.createElement('a');
+        a.href = String(href).trim();
+        a.target = '_blank';
+        a.rel = 'noopener noreferrer';
+        a.addEventListener('click', (event) => event.preventDefault());
+        a.appendChild(img);
+        figure.appendChild(a);
+      } else {
+        figure.appendChild(img);
+      }
+      if (hasCaption) {
+        const figcap = document.createElement('figcaption');
+        figcap.textContent = caption;
+        figure.appendChild(figcap);
+      }
+
+      return {
+        dom: figure,
+        update: (updatedNode: typeof node) => {
+          if (updatedNode.type !== node.type) return false;
+          const cap = updatedNode.attrs.caption;
+          const capEl = figure.querySelector('figcaption');
+          if (cap && typeof cap === 'string') {
+            if (!capEl) {
+              const fc = document.createElement('figcaption');
+              fc.textContent = cap;
+              figure.appendChild(fc);
+            } else capEl.textContent = cap;
+          } else if (capEl) capEl.remove();
+          const innerImg = figure.querySelector('img');
+          if (innerImg) {
+            innerImg.src = updatedNode.attrs.src ?? '';
+            ['alt', 'title'].forEach((k) => {
+              const v = updatedNode.attrs[k];
+              if (v != null) innerImg.setAttribute(k, String(v));
+              else innerImg.removeAttribute(k);
+            });
+          }
+          return true;
+        },
+        destroy: () => {},
+      };
+    };
+  },
+});

--- a/packages/filigran-rich-text-editor/src/richTextEditor/extensions/ImageWithOptions.ts
+++ b/packages/filigran-rich-text-editor/src/richTextEditor/extensions/ImageWithOptions.ts
@@ -172,7 +172,7 @@ export const ImageWithOptions = Image.extend<ImageWithOptionsOptions>({
       imgAttrs['style'] = String(imgStyle).trim();
     }
 
-    // Always wrap in figure.image-figure for CKEditor compatibility (centering, margins)
+    // Always wrap in figure.image-figure for layout compatibility (centering, margins)
     const imgTag: [string, Record<string, string>] = ['img', imgAttrs];
     const wrappedImg = hasLink
       ? ['a', { href: String(href).trim(), target: '_blank', rel: 'noopener noreferrer' }, imgTag]

--- a/packages/filigran-rich-text-editor/src/richTextEditor/extensions/PageBreak.ts
+++ b/packages/filigran-rich-text-editor/src/richTextEditor/extensions/PageBreak.ts
@@ -1,0 +1,93 @@
+import { Node, mergeAttributes, canInsertNode, isNodeSelection, nodeInputRule } from '@tiptap/core';
+import { TextSelection, NodeSelection } from '@tiptap/pm/state';
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    pageBreak: {
+      setPageBreak: () => ReturnType;
+    };
+  }
+}
+
+/**
+ * Page break extension for PDF export compatibility.
+ * Renders <div class="page-break"></div> for pdfPageBreaks utility.
+ */
+export const PageBreak = Node.create({
+  name: 'pageBreak',
+
+  addOptions() {
+    return {
+      HTMLAttributes: {
+        class: 'page-break',
+      },
+    };
+  },
+
+  group: 'block',
+
+  parseHTML() {
+    return [
+      { tag: 'div.page-break' },
+    ];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['div', mergeAttributes(this.options.HTMLAttributes, HTMLAttributes)];
+  },
+
+  addCommands() {
+    return {
+      setPageBreak:
+        () =>
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          ({ chain, state }: { chain: any; state: any }) => {
+            if (!canInsertNode(state, state.schema.nodes[this.name])) {
+              return false;
+            }
+            const { selection } = state;
+            const { $from: $originFrom, $to: $originTo } = selection;
+            const currentChain = chain();
+
+            if ($originFrom.parentOffset === 0) {
+              currentChain.insertContentAt(
+                { from: Math.max($originFrom.pos - 1, 0), to: $originTo.pos },
+                { type: this.name },
+              );
+            } else if (isNodeSelection(selection)) {
+              currentChain.insertContentAt($originTo.pos, { type: this.name });
+            } else {
+              currentChain.insertContent({ type: this.name });
+            }
+
+            return currentChain
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              .command(({ tr, dispatch }: { tr: any; dispatch?: any }) => {
+                if (dispatch) {
+                  const { $to } = tr.selection;
+                  const nodeAfter = $to.nodeAfter;
+                  if (nodeAfter?.isTextblock) {
+                    tr.setSelection(TextSelection.create(tr.doc, $to.pos + 1));
+                  } else if (nodeAfter?.isBlock) {
+                    tr.setSelection(NodeSelection.create(tr.doc, $to.pos));
+                  } else {
+                    tr.setSelection(TextSelection.create(tr.doc, $to.pos));
+                  }
+                  tr.scrollIntoView();
+                }
+                return true;
+              })
+              .run();
+          },
+    };
+  },
+
+  addInputRules() {
+    return [
+      nodeInputRule({
+        find: /^\/pagebreak$/,
+        type: this.type,
+      }),
+    ];
+  },
+});

--- a/packages/filigran-rich-text-editor/src/richTextEditor/extensions/Paragraph.ts
+++ b/packages/filigran-rich-text-editor/src/richTextEditor/extensions/Paragraph.ts
@@ -1,0 +1,58 @@
+import { Paragraph as ParagraphBase } from '@tiptap/extension-paragraph';
+import { mergeAttributes } from '@tiptap/core';
+
+const INDENT_STEP = 40; // px, matches CKEditor default
+const INDENT_MAX = 400; // px
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    indentation: {
+      indent: () => ReturnType;
+      outdent: () => ReturnType;
+    };
+  }
+}
+
+/**
+ * Extends TipTap's Paragraph node to preserve margin-left inline style,
+ * used by legacy editor to implement text indentation.
+ * Also adds indent/outdent commands that increment/decrement margin-left by 40px.
+ */
+export const Paragraph = ParagraphBase.extend({
+  addAttributes() {
+    return {
+      ...this.parent?.(),
+      marginLeft: {
+        default: null,
+        parseHTML: (element: HTMLElement) => element.style.marginLeft || null,
+        renderHTML: (attrs: Record<string, string>) => {
+          if (!attrs.marginLeft) return {};
+          return { style: `margin-left: ${attrs.marginLeft}` };
+        },
+      },
+    };
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['p', mergeAttributes(this.options.HTMLAttributes, HTMLAttributes), 0];
+  },
+
+  addCommands() {
+    return {
+      indent:
+        () =>
+          ({ commands, editor }) => {
+            const current = parseInt(editor.getAttributes('paragraph').marginLeft ?? '0', 10);
+            const next = Math.min(current + INDENT_STEP, INDENT_MAX);
+            return commands.updateAttributes('paragraph', { marginLeft: next > 0 ? `${next}px` : null });
+          },
+      outdent:
+        () =>
+          ({ commands, editor }) => {
+            const current = parseInt(editor.getAttributes('paragraph').marginLeft ?? '0', 10);
+            const next = Math.max(current - INDENT_STEP, 0);
+            return commands.updateAttributes('paragraph', { marginLeft: next > 0 ? `${next}px` : null });
+          },
+    };
+  },
+});

--- a/packages/filigran-rich-text-editor/src/richTextEditor/extensions/Paragraph.ts
+++ b/packages/filigran-rich-text-editor/src/richTextEditor/extensions/Paragraph.ts
@@ -1,7 +1,7 @@
 import { Paragraph as ParagraphBase } from '@tiptap/extension-paragraph';
 import { mergeAttributes } from '@tiptap/core';
 
-const INDENT_STEP = 40; // px, matches CKEditor default
+const INDENT_STEP = 40; // px
 const INDENT_MAX = 400; // px
 
 declare module '@tiptap/core' {

--- a/packages/filigran-rich-text-editor/src/richTextEditor/extensions/Table.ts
+++ b/packages/filigran-rich-text-editor/src/richTextEditor/extensions/Table.ts
@@ -1,0 +1,154 @@
+import { mergeAttributes } from '@tiptap/core';
+import type { Node as ProseMirrorNode } from '@tiptap/pm/model';
+import { Table as TiptapTable, TableView, updateColumns, TableOptions } from '@tiptap/extension-table';
+
+/**
+ * Custom TableView that re-applies percentage-based column widths stored in
+ * node.attrs.colWidths and node.attrs.tableWidth after TipTap's own updateColumns
+ * (which is pixel-only) runs.
+ */
+class CustomTableView extends TableView {
+  constructor(node: ProseMirrorNode, cellMinWidth: number) {
+    super(node, cellMinWidth);
+    this.applyCustomWidths(node);
+  }
+
+  update(node: ProseMirrorNode): boolean {
+    if (node.type !== this.node.type) return false;
+    this.node = node;
+    updateColumns(node, this.colgroup, this.table, this.cellMinWidth);
+    this.applyCustomWidths(node);
+    return true;
+  }
+
+  private applyCustomWidths(node: ProseMirrorNode) {
+    const colWidths: string[] | null = node.attrs.colWidths;
+    const tableWidth: string | null = node.attrs.tableWidth;
+
+    if (colWidths?.length) {
+      const cols = Array.from(this.colgroup.children) as HTMLTableColElement[];
+      colWidths.forEach((w, i) => {
+        if (cols[i] && w) {
+          cols[i].style.removeProperty('min-width');
+          cols[i].style.width = w;
+        }
+      });
+      this.table.style.tableLayout = 'fixed';
+    }
+
+    if (tableWidth) {
+      this.table.style.width = tableWidth;
+      this.table.style.minWidth = '';
+    }
+  }
+}
+
+/**
+ * Extended Table that preserves legacy editor column widths (in %) and table width (in %).
+ *
+ * Legacy editor stores column widths as <col style="width:X%"> inside a <colgroup>,
+ * and wraps the table in <figure class="table" style="width:Y%">.
+ * TipTap's built-in Table only handles px-based colwidths stored on cells.
+ *
+ * This extension adds:
+ * - `colWidths`: array of percentage strings parsed from <col style="width:X%">
+ * - `tableWidth`: percentage string parsed from <figure class="table" style="width:Y%">
+ *   or from <table style="width:Y%">
+ *
+ * When rendering HTML, if colWidths are present they are re-injected as-is into
+ * the colgroup, bypassing TipTap's px-based createColGroup utility.
+ */
+export const Table = TiptapTable.extend({
+  addOptions(): TableOptions {
+    const parentOptions = (this.parent?.() || {}) as TableOptions;
+    return {
+      ...parentOptions,
+      HTMLAttributes: parentOptions.HTMLAttributes || {},
+      View: CustomTableView,
+    } as TableOptions;
+  },
+
+  addAttributes() {
+    return {
+      ...this.parent?.(),
+      colWidths: {
+        default: null,
+        parseHTML: (element: HTMLElement) => {
+          const cols = element.querySelectorAll(':scope > colgroup > col');
+          if (!cols.length) return null;
+          const widths = Array.from(cols).map(
+            (col) => (col as HTMLElement).style.width || (col as HTMLElement).getAttribute('width') || '',
+          );
+          // Only store if at least one column has a meaningful width
+          return widths.some((w) => w) ? widths : null;
+        },
+        renderHTML: () => ({}), // handled manually in renderHTML
+      },
+      tableWidth: {
+        default: null,
+        parseHTML: (element: HTMLElement) => {
+          // Try inline style on the <table> itself first
+          if (element.style.width && !element.style.width.startsWith('min-')) {
+            return element.style.width;
+          }
+          // Fall back to the wrapping <figure class="table"> if present
+          const figure = element.closest('figure.table') as HTMLElement | null;
+          if (figure?.style.width) return figure.style.width;
+          return null;
+        },
+        renderHTML: () => ({}), // handled manually in renderHTML
+      },
+    };
+  },
+
+  renderHTML({ node, HTMLAttributes }: { node: ProseMirrorNode; HTMLAttributes: Record<string, unknown> }) {
+    const colWidths: string[] | null = node.attrs.colWidths;
+    const tableWidth: string | null = node.attrs.tableWidth;
+
+    // Build colgroup: prefer stored % widths, otherwise fall back to TipTap default
+    let colgroup;
+    if (colWidths?.length) {
+      colgroup = [
+        'colgroup',
+        {},
+        ...colWidths.map((w) => ['col', { style: w ? `width: ${w}` : '' }]),
+      ];
+    } else {
+      // Re-use TipTap's createColGroup via parent renderHTML — but we need the colgroup only.
+      // Easiest: call parent and extract its colgroup by letting it run, then override style.
+      // Since we can't easily extract it, we build a simple fallback.
+      const cellMinWidth = this.options.cellMinWidth ?? 25;
+      const row = node.firstChild;
+      const cols = [];
+      if (row) {
+        for (let i = 0; i < row.childCount; i += 1) {
+          const cell = row.child(i);
+          const { colspan, colwidth } = cell.attrs;
+          for (let j = 0; j < colspan; j += 1) {
+            const w = colwidth?.[j];
+            cols.push(['col', { style: w ? `width: ${w}px` : `min-width: ${cellMinWidth}px` }]);
+          }
+        }
+      }
+      colgroup = ['colgroup', {}, ...cols];
+    }
+
+    const styleAttr = tableWidth
+      ? `width: ${tableWidth}; table-layout: fixed`
+      : colWidths?.length ? 'table-layout: fixed' : undefined;
+
+    const tableNode = [
+      'table',
+      mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, styleAttr ? { style: styleAttr } : {}),
+      colgroup,
+      ['tbody', 0],
+    ];
+
+    // the legacy editor wraps tables in <figure class="table">
+    return [
+      'figure',
+      { class: 'table' },
+      tableNode,
+    ];
+  },
+});

--- a/packages/filigran-rich-text-editor/src/richTextEditor/extensions/TableCell.ts
+++ b/packages/filigran-rich-text-editor/src/richTextEditor/extensions/TableCell.ts
@@ -1,0 +1,29 @@
+import { TableCell as TiptapTableCell } from '@tiptap/extension-table';
+
+/**
+ * Extended TableCell that allows any block content including nested tables.
+ * No nesting depth limit — the schema permits table > tableCell > table recursively.
+ * Also preserves inline width styles from migration.
+ */
+export const NestedTableCell = TiptapTableCell.extend({
+  content: 'block+',
+  addAttributes() {
+    return {
+      ...this.parent?.(),
+      width: {
+        default: null,
+        parseHTML: (element: HTMLElement) => {
+          return element.style.width || element.getAttribute('width') || null;
+        },
+        renderHTML: (attributes) => {
+          if (!attributes.width) {
+            return {};
+          }
+          return {
+            style: `width: ${attributes.width}`,
+          };
+        },
+      },
+    };
+  },
+});

--- a/packages/filigran-rich-text-editor/src/richTextEditor/extensions/TableCellSplit.ts
+++ b/packages/filigran-rich-text-editor/src/richTextEditor/extensions/TableCellSplit.ts
@@ -1,0 +1,291 @@
+import { Extension } from '@tiptap/core';
+import { TableMap, selectedRect, CellSelection, cellAround, tableNodeTypes } from '@tiptap/pm/tables';
+import type { EditorState, Transaction } from '@tiptap/pm/state';
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    tableCellSplit: {
+      /**
+       * Split the current cell horizontally (into two stacked rows).
+       * Works on any cell, including 1×1.
+       */
+      splitCellHorizontal: () => ReturnType;
+      /**
+       * Split the current cell vertically (into two side-by-side columns).
+       * Works on any cell, including 1×1.
+       */
+      splitCellVertical: () => ReturnType;
+    };
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                           */
+/* ------------------------------------------------------------------ */
+
+/** Resolve the cell node + absolute position from the current selection. */
+function resolveCell(state: EditorState) {
+  const sel = state.selection;
+  if (sel instanceof CellSelection) {
+    if (sel.$anchorCell.pos !== sel.$headCell.pos) return null;
+    return { cellPos: sel.$anchorCell.pos, cellNode: sel.$anchorCell.nodeAfter! };
+  }
+  const $cell = cellAround(sel.$from);
+  if (!$cell) return null;
+  return { cellPos: $cell.pos, cellNode: $cell.nodeAfter! };
+}
+
+/** Determine the correct cell type (td vs th) for the target cell. */
+function getCellNodeType(state: EditorState, node: { type: { spec: Record<string, unknown> } }) {
+  const types = tableNodeTypes(state.schema);
+  return node.type.spec.tableRole === 'header_cell' ? types.header_cell : types.cell;
+}
+
+/** Safely extract the colwidth attribute as a number array, or null. */
+function getColwidth(attrs: Record<string, unknown>): number[] | null {
+  const cw = attrs.colwidth;
+  return Array.isArray(cw) && cw.length > 0 ? (cw as number[]) : null;
+}
+
+/**
+ * Split a colwidth array in two at `splitAt`.
+ * E.g. [100, 200, 150] split at 2 → left=[100,200], right=[150].
+ */
+function splitColwidthArray(cw: number[] | null, splitAt: number) {
+  if (!cw) return { left: null, right: null };
+  return { left: cw.slice(0, splitAt), right: cw.slice(splitAt) };
+}
+
+/**
+ * Halve a single-column colwidth.
+ * [200] → first=[100], second=[100].
+ * Returns nulls when there's no colwidth to halve.
+ */
+function halveColwidth(cw: number[] | null) {
+  if (!cw || cw.length === 0) return { first: null, second: null };
+  const w = cw[0];
+  return { first: [Math.ceil(w / 2)], second: [w - Math.ceil(w / 2)] };
+}
+
+/**
+ * Given a sibling cell's colwidth array and the index (within that array)
+ * of the column being split, return a new colwidth with that entry halved
+ * into two consecutive entries, keeping the total width unchanged.
+ */
+function spliceColwidthForSibling(
+  cw: number[] | null,
+  colIndexInCell: number,
+): number[] | null {
+  if (!cw || colIndexInCell < 0 || colIndexInCell >= cw.length) return cw;
+  const w = cw[colIndexInCell];
+  const result = [...cw];
+  result.splice(colIndexInCell, 1, Math.ceil(w / 2), w - Math.ceil(w / 2));
+  return result;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Split Horizontal                                                  */
+/*  Splits the cell so it occupies two rows.                          */
+/*  Strategy:                                                         */
+/*    1. Bump rowspan of every OTHER cell in the target row.          */
+/*    2. Insert a new <tr> containing only one empty cell (the split  */
+/*       target's bottom half) right below the target row.            */
+/* ------------------------------------------------------------------ */
+
+function splitCellHorizontalCommand(
+  state: EditorState,
+  dispatch?: (tr: Transaction) => void,
+): boolean {
+  const cell = resolveCell(state);
+  if (!cell) return false;
+  if (!dispatch) return true;
+
+  const { cellNode, cellPos } = cell;
+  const cellAttrs = cellNode.attrs as Record<string, unknown>;
+  const colspan = (cellAttrs.colspan as number) || 1;
+  const rowspan = (cellAttrs.rowspan as number) || 1;
+
+  const rect = selectedRect(state);
+  const map = rect.map as TableMap;
+  const tableStart = rect.tableStart;
+  const table = rect.table;
+  const cellRect = map.findCell(cellPos - tableStart);
+  const targetRow = cellRect.top;
+
+  const tr = state.tr;
+  const types = tableNodeTypes(state.schema);
+  const newCellNodeType = getCellNodeType(state, cellNode);
+
+  if (rowspan > 1) {
+    // Cell already spans multiple rows — halve the rowspan and insert a
+    // new cell into the row where the bottom half starts.
+    const topSpan = Math.ceil(rowspan / 2);
+    const bottomSpan = rowspan - topSpan;
+    tr.setNodeMarkup(cellPos, undefined, { ...cellAttrs, rowspan: topSpan });
+    const insertRow = cellRect.top + topSpan;
+    const insertPos = map.positionAt(insertRow, cellRect.left, table);
+    tr.insert(
+      tr.mapping.map(insertPos + tableStart),
+      newCellNodeType.createAndFill({ ...cellAttrs, rowspan: bottomSpan, colspan })!,
+    );
+    dispatch(tr);
+    return true;
+  }
+
+  // rowspan === 1 — need to insert a whole new <tr>.
+  // 1. For every OTHER cell visible in `targetRow`, bump its rowspan.
+  const visited = new Set<number>();
+  for (let col = 0; col < map.width; col++) {
+    if (col >= cellRect.left && col < cellRect.right) continue; // skip target
+    const offset = map.map[targetRow * map.width + col];
+    if (visited.has(offset)) continue;
+    visited.add(offset);
+    const pos = tableStart + offset;
+    const node = state.doc.nodeAt(pos);
+    if (!node) continue;
+    const rs = ((node.attrs as Record<string, unknown>).rowspan as number) || 1;
+    tr.setNodeMarkup(tr.mapping.map(pos), undefined, { ...node.attrs, rowspan: rs + 1 });
+  }
+
+  // 2. Build a new <tr> with a single empty cell for the target column.
+  //    Carry over colwidth so column widths don't shift.
+  const newCell = newCellNodeType.createAndFill({
+    colspan,
+    colwidth: cellAttrs.colwidth ?? null,
+  })!;
+  const newRow = types.row.create(null, [newCell]);
+
+  // Insert the new row right after `targetRow` ends.
+  let insertPos = tableStart;
+  for (let r = 0; r <= targetRow; r++) {
+    insertPos += table.child(r).nodeSize;
+  }
+  tr.insert(tr.mapping.map(insertPos), newRow);
+
+  dispatch(tr);
+  return true;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Split Vertical                                                    */
+/*  Splits the cell so it occupies two columns.                       */
+/*  Strategy:                                                         */
+/*    1. Bump colspan of every OTHER cell in the target column.       */
+/*    2. Insert a new empty cell right after the target cell.         */
+/* ------------------------------------------------------------------ */
+
+function splitCellVerticalCommand(
+  state: EditorState,
+  dispatch?: (tr: Transaction) => void,
+): boolean {
+  const cell = resolveCell(state);
+  if (!cell) return false;
+  if (!dispatch) return true;
+
+  const { cellNode, cellPos } = cell;
+  const cellAttrs = cellNode.attrs as Record<string, unknown>;
+  const colspan = (cellAttrs.colspan as number) || 1;
+  const rowspan = (cellAttrs.rowspan as number) || 1;
+
+  const rect = selectedRect(state);
+  const map = rect.map as TableMap;
+  const tableStart = rect.tableStart;
+  const cellRect = map.findCell(cellPos - tableStart);
+
+  const tr = state.tr;
+  const newCellNodeType = getCellNodeType(state, cellNode);
+
+  if (colspan > 1) {
+    // Cell already spans multiple cols — halve the colspan and insert a
+    // new cell right after the current one in the DOM.
+    // Split the colwidth array so each half keeps its original column widths.
+    const leftSpan = Math.ceil(colspan / 2);
+    const rightSpan = colspan - leftSpan;
+    const { left: leftCw, right: rightCw } = splitColwidthArray(
+      getColwidth(cellAttrs),
+      leftSpan,
+    );
+    tr.setNodeMarkup(cellPos, undefined, {
+      ...cellAttrs,
+      colspan: leftSpan,
+      colwidth: leftCw,
+    });
+    const insertPos = cellPos + cellNode.nodeSize;
+    tr.insert(
+      tr.mapping.map(insertPos),
+      newCellNodeType.createAndFill({
+        ...cellAttrs,
+        colspan: rightSpan,
+        rowspan,
+        colwidth: rightCw,
+      })!,
+    );
+    dispatch(tr);
+    return true;
+  }
+
+  // colspan === 1 — need to add a column logically.
+  // Compute the half-widths of the column being split so sizes are preserved.
+  const origCw = getColwidth(cellAttrs);
+  const { first: cwFirst, second: cwSecond } = halveColwidth(origCw);
+
+  // 0. Update the target cell's colwidth to the first half.
+  if (cwFirst) {
+    tr.setNodeMarkup(cellPos, undefined, { ...cellAttrs, colwidth: cwFirst });
+  }
+
+  // 1. For every OTHER cell in the target column, bump its colspan
+  //    and splice the halved column width into its colwidth array.
+  const visited = new Set<number>();
+  for (let row = 0; row < map.height; row++) {
+    if (row >= cellRect.top && row < cellRect.bottom) continue; // skip target
+    const offset = map.map[row * map.width + cellRect.left];
+    if (visited.has(offset)) continue;
+    visited.add(offset);
+    const pos = tableStart + offset;
+    const node = state.doc.nodeAt(pos);
+    if (!node) continue;
+    const nodeAttrs = node.attrs as Record<string, unknown>;
+    const cs = (nodeAttrs.colspan as number) || 1;
+    // Find the index of the target column within this sibling cell's span.
+    const siblingStartCol = map.colCount(offset);
+    const colIndexInCell = cellRect.left - siblingStartCol;
+    const newCw = spliceColwidthForSibling(getColwidth(nodeAttrs), colIndexInCell);
+    tr.setNodeMarkup(tr.mapping.map(pos), undefined, {
+      ...nodeAttrs,
+      colspan: cs + 1,
+      colwidth: newCw,
+    });
+  }
+
+  // 2. Insert a new empty cell right after the target cell in the DOM.
+  const insertPos = cellPos + cellNode.nodeSize;
+  tr.insert(
+    tr.mapping.map(insertPos),
+    newCellNodeType.createAndFill({ rowspan, colwidth: cwSecond })!,
+  );
+
+  dispatch(tr);
+  return true;
+}
+
+/* ------------------------------------------------------------------ */
+/*  TipTap Extension                                                  */
+/* ------------------------------------------------------------------ */
+
+export const TableCellSplit = Extension.create({
+  name: 'tableCellSplit',
+
+  addCommands() {
+    return {
+      splitCellHorizontal:
+        () =>
+          ({ state, dispatch }) =>
+            splitCellHorizontalCommand(state, dispatch),
+      splitCellVertical:
+        () =>
+          ({ state, dispatch }) =>
+            splitCellVerticalCommand(state, dispatch),
+    };
+  },
+});

--- a/packages/filigran-rich-text-editor/src/richTextEditor/extensions/TableHeader.ts
+++ b/packages/filigran-rich-text-editor/src/richTextEditor/extensions/TableHeader.ts
@@ -1,0 +1,27 @@
+import { TableHeader as TiptapTableHeader } from '@tiptap/extension-table';
+
+/**
+ * Extended TableHeader that allows any block content and preserves inline width styles.
+ */
+export const NestedTableHeader = TiptapTableHeader.extend({
+  content: 'block+',
+  addAttributes() {
+    return {
+      ...this.parent?.(),
+      width: {
+        default: null,
+        parseHTML: (element: HTMLElement) => {
+          return element.style.width || element.getAttribute('width') || null;
+        },
+        renderHTML: (attributes) => {
+          if (!attributes.width) {
+            return {};
+          }
+          return {
+            style: `width: ${attributes.width}`,
+          };
+        },
+      },
+    };
+  },
+});

--- a/packages/filigran-rich-text-editor/src/richTextEditor/extensions/TaskList.ts
+++ b/packages/filigran-rich-text-editor/src/richTextEditor/extensions/TaskList.ts
@@ -1,0 +1,18 @@
+import { TaskList as TaskListBase } from '@tiptap/extension-task-list';
+
+export const TaskList = TaskListBase.extend({
+  parseHTML() {
+    return [
+      // Default Tiptap
+      {
+        tag: `ul[data-type="${this.name}"]`,
+        priority: 51,
+      },
+      // Legacy editor
+      {
+        tag: 'ul.todo-list',
+        priority: 52,
+      },
+    ];
+  },
+});

--- a/packages/filigran-rich-text-editor/src/richTextEditor/extensions/TaskListItem.ts
+++ b/packages/filigran-rich-text-editor/src/richTextEditor/extensions/TaskListItem.ts
@@ -1,0 +1,18 @@
+import { TaskItem as TaskItemBase } from '@tiptap/extension-task-item';
+
+export const TaskItem = TaskItemBase.extend({
+  parseHTML() {
+    return [
+      // Default Tiptap
+      {
+        tag: `li[data-type="${this.name}"]`,
+        priority: 51,
+      },
+      // Legacy editor
+      {
+        tag: 'ul.todo-list > li',
+        priority: 52,
+      },
+    ];
+  },
+});

--- a/packages/filigran-rich-text-editor/src/richTextEditor/extensions/TextStyle.ts
+++ b/packages/filigran-rich-text-editor/src/richTextEditor/extensions/TextStyle.ts
@@ -1,0 +1,32 @@
+import { TextStyle as TextStyleBase } from '@tiptap/extension-text-style';
+
+/**
+ * Legacy editor font-size class → pixel value mapping.
+ * Shared with FontSize.ts to keep the two extensions in sync.
+ */
+export const LEGACY_FONT_SIZE_MAP: Record<string, string> = {
+  'text-tiny': '0.7em',
+  'text-small': '0.85em',
+  'text-big': '1.4em',
+  'text-huge': '1.8em',
+};
+
+/**
+ * Extends TipTap's TextStyle mark to also accept legacy editor font-size class
+ * spans (e.g. <span class="text-big">). Without this, TextStyle rejects any
+ * span that has no style attribute, so FontSize's addGlobalAttributes is
+ * never reached for legacy editor class-only spans.
+ */
+export const TextStyle = TextStyleBase.extend({
+  parseHTML() {
+    return [
+      ...(this.parent?.() ?? []),
+      // Accept legacy editor font-size class spans (no inline style)
+      ...Object.keys(LEGACY_FONT_SIZE_MAP).map((cls) => ({
+        tag: `span.${cls}`,
+        consuming: false,
+        getAttrs: () => ({}),
+      })),
+    ];
+  },
+});

--- a/packages/filigran-rich-text-editor/src/richTextEditor/tiptap-commands.d.ts
+++ b/packages/filigran-rich-text-editor/src/richTextEditor/tiptap-commands.d.ts
@@ -1,0 +1,55 @@
+/**
+ * Module augmentation for @tiptap/core Commands interface.
+ *
+ * TipTap StarterKit bundles sub-extensions (bold, italic, heading, …) as nested
+ * dependencies. Their `declare module '@tiptap/core'` augmentations are invisible
+ * to TypeScript because they live under starter-kit/node_modules/. We replicate
+ * the relevant command signatures here so that ChainedCommands, SingleCommands,
+ * and editor.can() are fully typed without `as any` casts.
+ */
+
+import '@tiptap/core';
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    bold: {
+      setBold: () => ReturnType;
+      toggleBold: () => ReturnType;
+      unsetBold: () => ReturnType;
+    };
+    italic: {
+      setItalic: () => ReturnType;
+      toggleItalic: () => ReturnType;
+      unsetItalic: () => ReturnType;
+    };
+    strike: {
+      setStrike: () => ReturnType;
+      toggleStrike: () => ReturnType;
+      unsetStrike: () => ReturnType;
+    };
+    code: {
+      setCode: () => ReturnType;
+      toggleCode: () => ReturnType;
+      unsetCode: () => ReturnType;
+    };
+    codeBlock: {
+      setCodeBlock: (attributes?: { language: string }) => ReturnType;
+      toggleCodeBlock: (attributes?: { language: string }) => ReturnType;
+    };
+    heading: {
+      setHeading: (attributes: { level: 1 | 2 | 3 | 4 | 5 | 6 }) => ReturnType;
+      toggleHeading: (attributes: { level: 1 | 2 | 3 | 4 | 5 | 6 }) => ReturnType;
+    };
+    paragraph: {
+      setParagraph: () => ReturnType;
+    };
+    blockQuote: {
+      setBlockquote: () => ReturnType;
+      toggleBlockquote: () => ReturnType;
+      unsetBlockquote: () => ReturnType;
+    };
+    horizontalRule: {
+      setHorizontalRule: () => ReturnType;
+    };
+  }
+}

--- a/packages/filigran-rich-text-editor/src/richTextEditor/tiptap-commands.d.ts
+++ b/packages/filigran-rich-text-editor/src/richTextEditor/tiptap-commands.d.ts
@@ -51,5 +51,10 @@ declare module '@tiptap/core' {
     horizontalRule: {
       setHorizontalRule: () => ReturnType;
     };
+    link: {
+      setLink: (attributes: { href: string; target?: string | null; rel?: string | null; class?: string | null }) => ReturnType;
+      toggleLink: (attributes: { href: string; target?: string | null; rel?: string | null; class?: string | null }) => ReturnType;
+      unsetLink: () => ReturnType;
+    };
   }
 }

--- a/packages/filigran-rich-text-editor/src/styles/TiptapEditor.css
+++ b/packages/filigran-rich-text-editor/src/styles/TiptapEditor.css
@@ -1,0 +1,566 @@
+/* Tiptap editor styles - compatible with OpenCTI theme */
+
+.rich-text-editor-wrapper {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.rich-text-editor-wrapper .ProseMirror {
+  min-height: 100px;
+  padding: 12px;
+  outline: none;
+  font-size: 14px;
+}
+
+.rich-text-editor-wrapper .ProseMirror p {
+  margin: 1em 0;
+}
+
+.rich-text-editor-wrapper .ProseMirror blockquote {
+  overflow: hidden;
+  padding-right: 1.5em;
+  padding-left: 1.5em;
+  margin-left: 0;
+  margin-right: 0;
+  font-style: italic;
+  border-left: solid 5px hsl(0, 0%, 80%);
+  color: inherit;
+}
+
+.rich-text-editor-wrapper .ProseMirror pre {
+  padding: 1em;
+  color: #353535;
+  background: rgba(199, 199, 199, 0.3);
+  border: 1px solid hsl(0, 0%, 77%);
+  border-radius: 2px;
+  text-align: left;
+  direction: ltr;
+  tab-size: 4;
+  white-space: pre-wrap;
+  font-style: normal;
+  min-width: 200px;
+  overflow-x: auto;
+}
+
+html[data-theme="dark"] .rich-text-editor-wrapper .ProseMirror pre,
+body[data-theme="dark"] .rich-text-editor-wrapper .ProseMirror pre {
+  color: inherit;
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(196,196,196);
+}
+
+.rich-text-editor-wrapper .ProseMirror code {
+  font-family: monospace;
+  font-size: 0.9em;
+  padding: .15em;
+  border-radius: 2px;
+}
+
+.rich-text-editor-wrapper .ProseMirror ul,
+.rich-text-editor-wrapper .ProseMirror ol {
+  padding-left: 1.5em;
+}
+
+/* Task list - no bullets, checkbox and text on same line */
+.rich-text-editor-wrapper .ProseMirror ul[data-type="taskList"],
+.rich-text-content ul[data-type="taskList"],
+.rich-text-content ul.todo-list {
+  list-style: none !important;
+  padding-left: 0;
+}
+
+.rich-text-editor-wrapper .ProseMirror li.tiptap-task-item,
+.rich-text-editor-wrapper .ProseMirror li[data-type="taskItem"],
+.rich-text-content li.tiptap-task-item,
+.rich-text-content li[data-type="taskItem"],
+.rich-text-content ul.todo-list > li {
+  display: flex !important;
+  flex-direction: row !important;
+  flex-wrap: nowrap !important;
+  align-items: flex-start !important;
+  gap: 0.5em;
+  margin: 0.25em 0;
+  list-style: none !important;
+}
+
+.rich-text-editor-wrapper .ProseMirror li.tiptap-task-item > label,
+.rich-text-editor-wrapper .ProseMirror li[data-type="taskItem"] > label,
+.rich-text-content li.tiptap-task-item > label,
+.rich-text-content li[data-type="taskItem"] > label,
+.rich-text-content ul.todo-list > li > label {
+  flex-shrink: 0;
+  margin: 0;
+  padding: 0;
+  padding-top: 3px; /* align checkbox with first line of text */
+  display: flex;
+  align-items: flex-start;
+  cursor: pointer;
+  line-height: 1;
+}
+.rich-text-content ul.todo-list > li > label.todo-list__label {
+  gap: 0.5rem
+}
+
+/* Task list checkbox - unchecked: transparent, checked: green with white check */
+.rich-text-editor-wrapper .ProseMirror li[data-type="taskItem"] input[type="checkbox"],
+.rich-text-editor-wrapper .ProseMirror li.tiptap-task-item input[type="checkbox"],
+.rich-text-content li[data-type="taskItem"] input[type="checkbox"],
+.rich-text-content li.tiptap-task-item input[type="checkbox"],
+.rich-text-content ul.todo-list > li input[type="checkbox"] {
+  appearance: none !important;
+  -webkit-appearance: none !important;
+  width: 16px !important;
+  height: 16px !important;
+  min-width: 16px !important;
+  margin: 0 !important;
+  padding: 0 !important;
+  border: 1px solid rgba(128, 128, 128, 0.6) !important;
+  background: transparent !important;
+  background-color: transparent !important;
+  cursor: pointer !important;
+  flex-shrink: 0 !important;
+  border-radius: 2px !important;
+}
+
+.rich-text-editor-wrapper .ProseMirror li[data-type="taskItem"] input[type="checkbox"]:checked,
+.rich-text-editor-wrapper .ProseMirror li.tiptap-task-item input[type="checkbox"]:checked,
+.rich-text-content li[data-type="taskItem"] input[type="checkbox"]:checked,
+.rich-text-content li.tiptap-task-item input[type="checkbox"]:checked,
+.rich-text-content ul.todo-list > li input[type="checkbox"]:checked {
+  background: #22c55e !important;
+  background-color: #22c55e !important;
+  border-color: #22c55e !important;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath fill='none' stroke='white' stroke-width='2' stroke-linecap='round' stroke-linejoin='round' d='M3 8l3 3 7-7'/%3E%3C/svg%3E") !important;
+  background-size: contain !important;
+}
+
+/* data-checked for readonly/display mode when :checked may not apply */
+.rich-text-editor-wrapper .ProseMirror li[data-type="taskItem"][data-checked="true"] input[type="checkbox"],
+.rich-text-content li[data-type="taskItem"][data-checked="true"] input[type="checkbox"],
+.rich-text-content ul.todo-list > li[data-checked="true"] input[type="checkbox"] {
+  background: #22c55e !important;
+  background-color: #22c55e !important;
+  border-color: #22c55e !important;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath fill='none' stroke='white' stroke-width='2' stroke-linecap='round' stroke-linejoin='round' d='M3 8l3 3 7-7'/%3E%3C/svg%3E") !important;
+  background-size: contain !important;
+}
+
+/* content div - use display:contents so its children become flex items of li */
+.rich-text-editor-wrapper .ProseMirror li.tiptap-task-item > div,
+.rich-text-editor-wrapper .ProseMirror li[data-type="taskItem"] > div,
+.rich-text-content li.tiptap-task-item > div,
+.rich-text-content li[data-type="taskItem"] > div,
+.rich-text-content ul.todo-list > li > div {
+  flex: 1;
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+  display: contents; /* children (p) become direct flex items - keeps checkbox and text on same line */
+}
+
+.rich-text-editor-wrapper .ProseMirror li.tiptap-task-item p,
+.rich-text-editor-wrapper .ProseMirror li[data-type="taskItem"] p,
+.rich-text-content li.tiptap-task-item p,
+.rich-text-content li[data-type="taskItem"] p,
+.rich-text-content ul.todo-list > li p {
+  margin: 0;
+  flex: 1;
+  min-width: 0;
+}
+
+.rich-text-editor-wrapper .ProseMirror table {
+  border-collapse: collapse;
+  max-width: 100%;
+  table-layout: auto;
+  overflow: hidden;
+  margin: 0.9em auto;
+}
+
+.rich-text-editor-wrapper .ProseMirror th,
+.rich-text-editor-wrapper .ProseMirror td,
+.rich-text-content th,
+.rich-text-content td {
+  border: 1px solid #b2b2b2;
+  padding: 0.4em;
+  position: relative;
+}
+
+/* Header cells — distinct background */
+.rich-text-editor-wrapper .ProseMirror th {
+  background-color: rgba(128, 128, 128, 0.12);
+  font-weight: 600;
+}
+
+html[data-theme="dark"] .rich-text-editor-wrapper .ProseMirror th,
+body[data-theme="dark"] .rich-text-editor-wrapper .ProseMirror th {
+  background-color: rgba(0, 0, 0, 0.05);
+}
+
+/* Selected cells highlight (prosemirror-tables adds .selectedCell) */
+.rich-text-editor-wrapper .ProseMirror .selectedCell::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: rgba(25, 118, 210, 0.18);
+  pointer-events: none;
+  z-index: 2;
+}
+
+html[data-theme="dark"] .rich-text-editor-wrapper .ProseMirror .selectedCell::after,
+body[data-theme="dark"] .rich-text-editor-wrapper .ProseMirror .selectedCell::after {
+  background: rgba(66, 165, 245, 0.22);
+}
+
+/* Column resize handle */
+.rich-text-editor-wrapper .ProseMirror .column-resize-handle {
+  position: absolute;
+  right: -2px;
+  top: 0;
+  bottom: -2px;
+  width: 4px;
+  background-color: rgba(25, 118, 210, 0.5);
+  pointer-events: none;
+  z-index: 20;
+}
+
+.rich-text-editor-wrapper .ProseMirror.resize-cursor {
+  cursor: col-resize;
+}
+
+/* Remove paragraph margin inside table cells and list items */
+.rich-text-editor-wrapper .ProseMirror td p,
+.rich-text-editor-wrapper .ProseMirror th p,
+.rich-text-editor-wrapper .ProseMirror li p {
+  margin: 0;
+}
+
+/* Nested tables: slightly smaller, with spacing */
+.rich-text-editor-wrapper .ProseMirror td table,
+.rich-text-editor-wrapper .ProseMirror th table {
+  margin: 0.9em 0;
+}
+
+.rich-text-editor-wrapper .ProseMirror td td,
+.rich-text-editor-wrapper .ProseMirror td th,
+.rich-text-editor-wrapper .ProseMirror th td,
+.rich-text-editor-wrapper .ProseMirror th th {
+  padding: 4px 8px;
+}
+
+.rich-text-editor-wrapper .ProseMirror img {
+  max-width: 100%;
+  height: auto;
+}
+
+.rich-text-editor-wrapper .ProseMirror hr {
+  margin: 15px 0;
+  height: 4px;
+  background: #dedede;
+  border: 0;
+}
+
+.rich-text-editor-wrapper .ProseMirror a {
+  color: #00b1ff;
+  text-decoration: none;
+  cursor: text;
+}
+
+.rich-text-editor-wrapper .ProseMirror a img {
+  cursor: default;
+}
+
+html[data-theme="light"] .rich-text-editor-wrapper .ProseMirror a,
+body[data-theme="light"] .rich-text-editor-wrapper .ProseMirror a {
+  color: #0066cc;
+}
+
+.rich-text-editor-wrapper .ProseMirror .page-break {
+  position: relative;
+  clear: both;
+  padding: 5px 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  page-break-after: always;
+}
+
+.rich-text-editor-wrapper .ProseMirror .page-break::after {
+  content: '';
+  position: absolute;
+  border-bottom: 2px dashed #c4c4c4;
+  width: 100%;
+}
+
+.rich-text-editor-wrapper .ProseMirror .mention {
+  background-color: rgba(0, 177, 255, 0.2);
+  border-radius: 4px;
+  padding: 0 2px;
+}
+
+.rich-text-editor-wrapper .ProseMirror p.is-editor-empty:first-child::before {
+  content: attr(data-placeholder);
+  float: left;
+  color: #999;
+  pointer-events: none;
+  height: 0;
+}
+
+.rich-text-editor-wrapper .ProseMirror.ProseMirror-focused {
+  outline: none;
+}
+
+/* HtmlDisplay - shared styles for rendered HTML content */
+.rich-text-content {
+  font-size: 14px;
+}
+
+.rich-text-content p {
+  margin: 1em 0;
+}
+
+
+.rich-text-content .page-break {
+  position: relative;
+  clear: both;
+  padding: 5px 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  page-break-after: always;
+}
+
+.rich-text-content .page-break::after {
+  content: '';
+  position: absolute;
+  border-bottom: 2px dashed #c4c4c4;
+  width: 100%;
+}
+
+/* Legacy Editor font-size classes — kept for backward compatibility with stored content */
+.rich-text-content .text-tiny  { font-size: 0.7em; }
+.rich-text-content .text-small { font-size: 0.85em; }
+.rich-text-content .text-big   { font-size: 1.4em; }
+.rich-text-content .text-huge  { font-size: 1.8em; }
+
+/* Legacy Editor highlight classes — kept for backward compatibility with stored content */
+/* General marks */
+.rich-text-content mark,
+.rich-text-editor-wrapper .ProseMirror mark { color: #000000; }
+
+/* Markers: background color */
+.rich-text-content mark.marker-yellow,
+.rich-text-editor-wrapper .ProseMirror mark.marker-yellow { background-color: rgb(255, 255, 0); color: #000000; }
+.rich-text-content mark.marker-green,
+.rich-text-editor-wrapper .ProseMirror mark.marker-green  { background-color: rgb(98, 249, 98); color: #000000; }
+.rich-text-content mark.marker-pink,
+.rich-text-editor-wrapper .ProseMirror mark.marker-pink   { background-color: rgb(252, 120, 153); color: #000000; }
+.rich-text-content mark.marker-blue,
+.rich-text-editor-wrapper .ProseMirror mark.marker-blue   { background-color: rgb(15, 188, 255); color: #000000; }
+/* Pens: text color, transparent background */
+.rich-text-content mark.pen-red,
+.rich-text-editor-wrapper .ProseMirror mark.pen-red   { background-color: transparent !important; color: rgb(231, 19, 19) !important; }
+.rich-text-content mark.pen-green,
+.rich-text-editor-wrapper .ProseMirror mark.pen-green { background-color: transparent !important; color: rgb(18, 138, 0) !important; }
+
+/* Legacy Editor image figure — kept for backward compatibility with stored content */
+.rich-text-content figure.image,
+.rich-text-content figure.image-figure,
+.rich-text-editor-wrapper .ProseMirror figure.image,
+.rich-text-editor-wrapper .ProseMirror figure.image-figure {
+  display: table;
+  clear: both;
+  text-align: center;
+  margin: 0.9em auto;
+  min-width: 50px;
+}
+.rich-text-content figure.image img,
+.rich-text-content figure.image-figure img,
+.rich-text-editor-wrapper .ProseMirror figure.image img,
+.rich-text-editor-wrapper .ProseMirror figure.image-figure img {
+  display: block;
+  max-width: 100%;
+}
+
+/* Legacy Editor support for right-aligned image figures */
+.rich-text-content figure.image-style-side,
+.rich-text-editor-wrapper .ProseMirror figure.image-style-side {
+  float: right !important;
+  clear: none !important;
+  margin: 0.9em 0 0.9em 1.5em !important;
+}
+
+.rich-text-content blockquote {
+  overflow: hidden;
+  padding-right: 1.5em;
+  padding-left: 1.5em;
+  margin-left: 0;
+  margin-right: 0;
+  font-style: italic;
+  border-left: solid 5px hsl(0, 0%, 80%);
+}
+
+.rich-text-content pre {
+  padding: 1em;
+  color: #353535;
+  background: rgba(199, 199, 199, 0.3);
+  border: 1px solid hsl(0, 0%, 77%);
+  border-radius: 2px;
+  text-align: left;
+  direction: ltr;
+  tab-size: 4;
+  white-space: pre-wrap;
+  font-style: normal;
+  min-width: 200px;
+  overflow-x: auto;
+}
+
+html[data-theme="dark"] .rich-text-content pre,
+body[data-theme="dark"] .rich-text-content pre {
+  color: inherit;
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(196,196,196);
+}
+
+.rich-text-content code {
+  padding: .15em;
+  border-radius: 2px;
+}
+
+.rich-text-content table {
+  border-collapse: collapse;
+  max-width: 100%;
+  table-layout: auto;
+  overflow: hidden;
+  margin: 0.9em auto;
+}
+
+.rich-text-content th,
+.rich-text-content td {
+  border: 1px solid #b2b2b2;
+  padding: 0.4em;
+}
+
+/* Header cells — display mode */
+.rich-text-content th {
+  background-color: rgba(128, 128, 128, 0.12);
+  font-weight: 600;
+}
+
+html[data-theme="dark"] .rich-text-content th,
+body[data-theme="dark"] .rich-text-content th {
+  background-color: rgba(0, 0, 0, 0.05);
+}
+
+/* Remove paragraph margin inside table cells and list items — display mode */
+.rich-text-content td p,
+.rich-text-content th p,
+.rich-text-content li p {
+  margin: 0;
+}
+
+/* Legacy Editor figure.table wrapper */
+.rich-text-content figure.table {
+  margin: 0.9em auto;
+}
+
+/* Nested tables — display mode */
+.rich-text-content td table,
+.rich-text-content th table {
+  margin: 0;
+}
+
+.rich-text-content td td,
+.rich-text-content td th,
+.rich-text-content th td,
+.rich-text-content th th {
+  padding: 4px 8px;
+}
+
+.rich-text-content img {
+  max-width: 100%;
+  height: auto;
+}
+
+.rich-text-content hr {
+  margin: 15px 0;
+  height: 4px;
+  background: #dedede;
+  border: 0;
+}
+
+.rich-text-content a {
+  color: #00b1ff;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+html[data-theme="light"] .rich-text-content a,
+body[data-theme="light"] .rich-text-content a {
+  color: #0066cc;
+}
+
+/* Image resize handles (poignées) - editor only */
+.rich-text-editor-wrapper .ProseMirror [data-resize-handle] {
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  background: rgba(0, 120, 215, 0.8);
+  border: 1px solid #fff;
+  border-radius: 2px;
+  z-index: 10;
+  cursor: nwse-resize;
+}
+.rich-text-editor-wrapper .ProseMirror [data-resize-handle="bottom-right"] {
+  bottom: -4px;
+  right: -4px;
+  cursor: nwse-resize;
+}
+.rich-text-editor-wrapper .ProseMirror [data-resize-handle="bottom-left"] {
+  bottom: -4px;
+  left: -4px;
+  cursor: nesw-resize;
+}
+.rich-text-editor-wrapper .ProseMirror [data-resize-handle="top-right"] {
+  top: -4px;
+  right: -4px;
+  cursor: nesw-resize;
+}
+.rich-text-editor-wrapper .ProseMirror [data-resize-handle="top-left"] {
+  top: -4px;
+  left: -4px;
+  cursor: nwse-resize;
+}
+.rich-text-editor-wrapper .ProseMirror [data-resize-state="resizing"] {
+  user-select: none;
+}
+/* Ensure resize handles aren't clipped and reduce works (top/left handles) */
+.rich-text-editor-wrapper .ProseMirror figure.image-figure,
+.rich-text-editor-wrapper .ProseMirror [data-resize-container] {
+  overflow: visible;
+}
+.rich-text-editor-wrapper .ProseMirror [data-resize-wrapper] {
+  overflow: visible;
+}
+.rich-text-editor-wrapper .ProseMirror figure.image-figure {
+  padding: 4px;
+  box-sizing: content-box;
+}
+/* Image figure + caption (display) */
+.rich-text-content figure.image-figure,
+.rich-text-editor-wrapper .ProseMirror figure.image-figure {
+  display: table;
+  clear: both;
+  text-align: center;
+  margin: 0.9em auto;
+  min-width: 50px;
+}
+.rich-text-content figure.image-figure figcaption,
+.rich-text-editor-wrapper .ProseMirror figure.image-figure figcaption {
+  display: block;
+  font-size: 0.9em;
+  color: inherit;
+  opacity: 0.85;
+  margin-top: 0.25em;
+  text-align: center;
+}

--- a/packages/filigran-rich-text-editor/tsconfig.json
+++ b/packages/filigran-rich-text-editor/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./base.json",
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["dist", "node_modules"],
+  "compilerOptions": {
+    "resolveJsonModule": true,
+    "baseUrl": ".",
+    "jsx": "react-jsx",
+    "module": "ESNext",
+    "target": "ESNext",
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "emitDeclarationOnly": true
+  }
+}

--- a/packages/filigran-rich-text-editor/tsup.config.ts
+++ b/packages/filigran-rich-text-editor/tsup.config.ts
@@ -1,4 +1,3 @@
-import {copyFile, mkdir} from 'fs/promises'
 import {defineConfig} from 'tsup'
 
 export default defineConfig({
@@ -15,28 +14,5 @@ export default defineConfig({
     '@mui/material',
     '@mui/icons-material',
     '@mui/styles',
-    '@tiptap/core',
-    '@tiptap/react',
-    '@tiptap/starter-kit',
-    '@tiptap/extension-color',
-    '@tiptap/extension-highlight',
-    '@tiptap/extension-image',
-    '@tiptap/extension-mention',
-    '@tiptap/extension-paragraph',
-    '@tiptap/extension-placeholder',
-    '@tiptap/extension-subscript',
-    '@tiptap/extension-superscript',
-    '@tiptap/extension-table',
-    '@tiptap/extension-task-item',
-    '@tiptap/extension-task-list',
-    '@tiptap/extension-text-align',
-    '@tiptap/extension-text-style',
-    '@tiptap/extension-typography',
-    '@tiptap/pm',
-    'react-color',
   ],
-  async onSuccess() {
-    await mkdir('dist', {recursive: true})
-    await copyFile('src/styles/TiptapEditor.css', 'dist/styles.css')
-  },
 })

--- a/packages/filigran-rich-text-editor/tsup.config.ts
+++ b/packages/filigran-rich-text-editor/tsup.config.ts
@@ -1,0 +1,42 @@
+import {copyFile, mkdir} from 'fs/promises'
+import {defineConfig} from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+  treeshake: true,
+  external: [
+    'react',
+    'react-dom',
+    '@mui/material',
+    '@mui/icons-material',
+    '@mui/styles',
+    '@tiptap/core',
+    '@tiptap/react',
+    '@tiptap/starter-kit',
+    '@tiptap/extension-color',
+    '@tiptap/extension-highlight',
+    '@tiptap/extension-image',
+    '@tiptap/extension-mention',
+    '@tiptap/extension-paragraph',
+    '@tiptap/extension-placeholder',
+    '@tiptap/extension-subscript',
+    '@tiptap/extension-superscript',
+    '@tiptap/extension-table',
+    '@tiptap/extension-task-item',
+    '@tiptap/extension-task-list',
+    '@tiptap/extension-text-align',
+    '@tiptap/extension-text-style',
+    '@tiptap/extension-typography',
+    '@tiptap/pm',
+    'react-color',
+  ],
+  async onSuccess() {
+    await mkdir('dist', {recursive: true})
+    await copyFile('src/styles/TiptapEditor.css', 'dist/styles.css')
+  },
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1209,6 +1209,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:^7.26.0, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.8.3, @babel/runtime@npm:^7.8.7":
+  version: 7.29.7
+  resolution: "@babel/runtime@npm:7.29.7"
+  checksum: 10c0/ca11572f7146b21e0bde6a9ed4bb6a89eafbee5f0944c7eb54d0d8a2dac962c33638a1d611e14faa71dfbb92b4b5f9236232208568a6b7d5c6f3f39ddb91771e
+  languageName: node
+  linkType: hard
+
 "@babel/template@npm:^7.28.6":
   version: 7.28.6
   resolution: "@babel/template@npm:7.28.6"
@@ -1624,10 +1631,92 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emotion/cache@npm:^11.13.5":
+  version: 11.14.0
+  resolution: "@emotion/cache@npm:11.14.0"
+  dependencies:
+    "@emotion/memoize": "npm:^0.9.0"
+    "@emotion/sheet": "npm:^1.4.0"
+    "@emotion/utils": "npm:^1.4.2"
+    "@emotion/weak-memoize": "npm:^0.4.0"
+    stylis: "npm:4.2.0"
+  checksum: 10c0/3fa3e7a431ab6f8a47c67132a00ac8358f428c1b6c8421d4b20de9df7c18e95eec04a5a6ff5a68908f98d3280044f247b4965ac63df8302d2c94dba718769724
+  languageName: node
+  linkType: hard
+
+"@emotion/hash@npm:^0.9.2":
+  version: 0.9.2
+  resolution: "@emotion/hash@npm:0.9.2"
+  checksum: 10c0/0dc254561a3cc0a06a10bbce7f6a997883fd240c8c1928b93713f803a2e9153a257a488537012efe89dbe1246f2abfe2add62cdb3471a13d67137fcb808e81c2
+  languageName: node
+  linkType: hard
+
+"@emotion/memoize@npm:^0.9.0":
+  version: 0.9.0
+  resolution: "@emotion/memoize@npm:0.9.0"
+  checksum: 10c0/13f474a9201c7f88b543e6ea42f55c04fb2fdc05e6c5a3108aced2f7e7aa7eda7794c56bba02985a46d8aaa914fcdde238727a98341a96e2aec750d372dadd15
+  languageName: node
+  linkType: hard
+
+"@emotion/serialize@npm:^1.3.3":
+  version: 1.3.3
+  resolution: "@emotion/serialize@npm:1.3.3"
+  dependencies:
+    "@emotion/hash": "npm:^0.9.2"
+    "@emotion/memoize": "npm:^0.9.0"
+    "@emotion/unitless": "npm:^0.10.0"
+    "@emotion/utils": "npm:^1.4.2"
+    csstype: "npm:^3.0.2"
+  checksum: 10c0/b28cb7de59de382021de2b26c0c94ebbfb16967a1b969a56fdb6408465a8993df243bfbd66430badaa6800e1834724e84895f5a6a9d97d0d224de3d77852acb4
+  languageName: node
+  linkType: hard
+
+"@emotion/sheet@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "@emotion/sheet@npm:1.4.0"
+  checksum: 10c0/3ca72d1650a07d2fbb7e382761b130b4a887dcd04e6574b2d51ce578791240150d7072a9bcb4161933abbcd1e38b243a6fb4464a7fe991d700c17aa66bb5acc7
+  languageName: node
+  linkType: hard
+
+"@emotion/unitless@npm:^0.10.0":
+  version: 0.10.0
+  resolution: "@emotion/unitless@npm:0.10.0"
+  checksum: 10c0/150943192727b7650eb9a6851a98034ddb58a8b6958b37546080f794696141c3760966ac695ab9af97efe10178690987aee4791f9f0ad1ff76783cdca83c1d49
+  languageName: node
+  linkType: hard
+
+"@emotion/utils@npm:^1.4.2":
+  version: 1.4.2
+  resolution: "@emotion/utils@npm:1.4.2"
+  checksum: 10c0/7d0010bf60a2a8c1a033b6431469de4c80e47aeb8fd856a17c1d1f76bbc3a03161a34aeaa78803566e29681ca551e7bf9994b68e9c5f5c796159923e44f78d9a
+  languageName: node
+  linkType: hard
+
+"@emotion/weak-memoize@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "@emotion/weak-memoize@npm:0.4.0"
+  checksum: 10c0/64376af11f1266042d03b3305c30b7502e6084868e33327e944b539091a472f089db307af69240f7188f8bc6b319276fd7b141a36613f1160d73d12a60f6ca1a
+  languageName: node
+  linkType: hard
+
+"@esbuild/aix-ppc64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/aix-ppc64@npm:0.25.12"
+  conditions: os=aix & cpu=ppc64
+  languageName: node
+  linkType: hard
+
 "@esbuild/aix-ppc64@npm:0.27.4":
   version: 0.27.4
   resolution: "@esbuild/aix-ppc64@npm:0.27.4"
   conditions: os=aix & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/android-arm64@npm:0.25.12"
+  conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -1638,10 +1727,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/android-arm@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/android-arm@npm:0.25.12"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
 "@esbuild/android-arm@npm:0.27.4":
   version: 0.27.4
   resolution: "@esbuild/android-arm@npm:0.27.4"
   conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-x64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/android-x64@npm:0.25.12"
+  conditions: os=android & cpu=x64
   languageName: node
   linkType: hard
 
@@ -1652,10 +1755,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/darwin-arm64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/darwin-arm64@npm:0.25.12"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/darwin-arm64@npm:0.27.4":
   version: 0.27.4
   resolution: "@esbuild/darwin-arm64@npm:0.27.4"
   conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-x64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/darwin-x64@npm:0.25.12"
+  conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
@@ -1666,10 +1783,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/freebsd-arm64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/freebsd-arm64@npm:0.25.12"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/freebsd-arm64@npm:0.27.4":
   version: 0.27.4
   resolution: "@esbuild/freebsd-arm64@npm:0.27.4"
   conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-x64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/freebsd-x64@npm:0.25.12"
+  conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
@@ -1680,10 +1811,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-arm64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/linux-arm64@npm:0.25.12"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-arm64@npm:0.27.4":
   version: 0.27.4
   resolution: "@esbuild/linux-arm64@npm:0.27.4"
   conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/linux-arm@npm:0.25.12"
+  conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
@@ -1694,10 +1839,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-ia32@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/linux-ia32@npm:0.25.12"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-ia32@npm:0.27.4":
   version: 0.27.4
   resolution: "@esbuild/linux-ia32@npm:0.27.4"
   conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-loong64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/linux-loong64@npm:0.25.12"
+  conditions: os=linux & cpu=loong64
   languageName: node
   linkType: hard
 
@@ -1708,10 +1867,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-mips64el@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/linux-mips64el@npm:0.25.12"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-mips64el@npm:0.27.4":
   version: 0.27.4
   resolution: "@esbuild/linux-mips64el@npm:0.27.4"
   conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ppc64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/linux-ppc64@npm:0.25.12"
+  conditions: os=linux & cpu=ppc64
   languageName: node
   linkType: hard
 
@@ -1722,10 +1895,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-riscv64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/linux-riscv64@npm:0.25.12"
+  conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-riscv64@npm:0.27.4":
   version: 0.27.4
   resolution: "@esbuild/linux-riscv64@npm:0.27.4"
   conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-s390x@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/linux-s390x@npm:0.25.12"
+  conditions: os=linux & cpu=s390x
   languageName: node
   linkType: hard
 
@@ -1736,10 +1923,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-x64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/linux-x64@npm:0.25.12"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-x64@npm:0.27.4":
   version: 0.27.4
   resolution: "@esbuild/linux-x64@npm:0.27.4"
   conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/netbsd-arm64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/netbsd-arm64@npm:0.25.12"
+  conditions: os=netbsd & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -1750,10 +1951,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/netbsd-x64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/netbsd-x64@npm:0.25.12"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/netbsd-x64@npm:0.27.4":
   version: 0.27.4
   resolution: "@esbuild/netbsd-x64@npm:0.27.4"
   conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-arm64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/openbsd-arm64@npm:0.25.12"
+  conditions: os=openbsd & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -1764,10 +1979,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/openbsd-x64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/openbsd-x64@npm:0.25.12"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/openbsd-x64@npm:0.27.4":
   version: 0.27.4
   resolution: "@esbuild/openbsd-x64@npm:0.27.4"
   conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openharmony-arm64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/openharmony-arm64@npm:0.25.12"
+  conditions: os=openharmony & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -1778,10 +2007,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/sunos-x64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/sunos-x64@npm:0.25.12"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/sunos-x64@npm:0.27.4":
   version: 0.27.4
   resolution: "@esbuild/sunos-x64@npm:0.27.4"
   conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-arm64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/win32-arm64@npm:0.25.12"
+  conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -1792,10 +2035,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/win32-ia32@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/win32-ia32@npm:0.25.12"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@esbuild/win32-ia32@npm:0.27.4":
   version: 0.27.4
   resolution: "@esbuild/win32-ia32@npm:0.27.4"
   conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-x64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/win32-x64@npm:0.25.12"
+  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -1964,6 +2221,67 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@filigran/rich-text-editor@workspace:packages/filigran-rich-text-editor":
+  version: 0.0.0-use.local
+  resolution: "@filigran/rich-text-editor@workspace:packages/filigran-rich-text-editor"
+  dependencies:
+    "@mui/icons-material": "npm:6.5.0"
+    "@mui/material": "npm:6.5.0"
+    "@mui/styles": "npm:6.5.0"
+    "@tiptap/core": "npm:3.23.1"
+    "@tiptap/extension-color": "npm:3.23.1"
+    "@tiptap/extension-highlight": "npm:3.23.1"
+    "@tiptap/extension-image": "npm:3.23.1"
+    "@tiptap/extension-mention": "npm:3.23.1"
+    "@tiptap/extension-paragraph": "npm:3.23.1"
+    "@tiptap/extension-placeholder": "npm:3.23.1"
+    "@tiptap/extension-subscript": "npm:3.23.1"
+    "@tiptap/extension-superscript": "npm:3.23.1"
+    "@tiptap/extension-table": "npm:3.23.1"
+    "@tiptap/extension-task-item": "npm:3.23.1"
+    "@tiptap/extension-task-list": "npm:3.23.1"
+    "@tiptap/extension-text-align": "npm:3.23.1"
+    "@tiptap/extension-text-style": "npm:3.23.1"
+    "@tiptap/extension-typography": "npm:3.23.1"
+    "@tiptap/pm": "npm:3.23.1"
+    "@tiptap/react": "npm:3.23.1"
+    "@tiptap/starter-kit": "npm:3.23.1"
+    "@types/react": "npm:19.2.14"
+    "@types/react-color": "npm:3.0.13"
+    react: "npm:19.2.4"
+    react-color: "npm:2.19.3"
+    react-dom: "npm:19.2.4"
+    rimraf: "npm:6.0.1"
+    tsup: "npm:8.5.0"
+    typescript: "npm:5.9.3"
+  peerDependencies:
+    "@mui/icons-material": ">=5"
+    "@mui/material": ">=5"
+    "@mui/styles": ">=5"
+    "@tiptap/core": ">=3"
+    "@tiptap/extension-color": ">=3"
+    "@tiptap/extension-highlight": ">=3"
+    "@tiptap/extension-image": ">=3"
+    "@tiptap/extension-mention": ">=3"
+    "@tiptap/extension-paragraph": ">=3"
+    "@tiptap/extension-placeholder": ">=3"
+    "@tiptap/extension-subscript": ">=3"
+    "@tiptap/extension-superscript": ">=3"
+    "@tiptap/extension-table": ">=3"
+    "@tiptap/extension-task-item": ">=3"
+    "@tiptap/extension-task-list": ">=3"
+    "@tiptap/extension-text-align": ">=3"
+    "@tiptap/extension-text-style": ">=3"
+    "@tiptap/extension-typography": ">=3"
+    "@tiptap/pm": ">=3"
+    "@tiptap/react": ">=3"
+    "@tiptap/starter-kit": ">=3"
+    react: ">=18"
+    react-color: ">=2"
+    react-dom: ">=18"
+  languageName: unknown
+  linkType: soft
+
 "@filigran/ui@workspace:packages/filigran-ui":
   version: 0.0.0-use.local
   resolution: "@filigran/ui@workspace:packages/filigran-ui"
@@ -2079,7 +2397,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@floating-ui/dom@npm:^1.7.6":
+"@floating-ui/dom@npm:^1.0.0, @floating-ui/dom@npm:^1.7.6":
   version: 1.7.6
   resolution: "@floating-ui/dom@npm:1.7.6"
   dependencies:
@@ -2407,6 +2725,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@isaacs/cliui@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "@isaacs/cliui@npm:9.0.0"
+  checksum: 10c0/971063b7296419f85053dacd0a0285dcadaa3dfc139228b23e016c1a9848121ad4aa5e7fcca7522062014e1eb6239a7424188b9f2cba893a79c90aae5710319c
+  languageName: node
+  linkType: hard
+
 "@isaacs/fs-minipass@npm:^4.0.0":
   version: 4.0.1
   resolution: "@isaacs/fs-minipass@npm:4.0.1"
@@ -2653,6 +2978,196 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mui/core-downloads-tracker@npm:^6.5.0":
+  version: 6.5.0
+  resolution: "@mui/core-downloads-tracker@npm:6.5.0"
+  checksum: 10c0/dea763c8d4b4f9415d6c6ac3a04115d04c249461ce5635f0012a75b91c38f43c0d0411201664a77c7ff10ff11ea12a0bfeea6562ec22ceec6bac82478b6384c3
+  languageName: node
+  linkType: hard
+
+"@mui/icons-material@npm:6.5.0":
+  version: 6.5.0
+  resolution: "@mui/icons-material@npm:6.5.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.26.0"
+  peerDependencies:
+    "@mui/material": ^6.5.0
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/0afec2280e8dde4ff34686481497c4b3ced8193f0038bf8984fd502808c053ba8464c35409def0380424cade1d282f647fac1db7c55046b2b232b0d2c52a589d
+  languageName: node
+  linkType: hard
+
+"@mui/material@npm:6.5.0":
+  version: 6.5.0
+  resolution: "@mui/material@npm:6.5.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.26.0"
+    "@mui/core-downloads-tracker": "npm:^6.5.0"
+    "@mui/system": "npm:^6.5.0"
+    "@mui/types": "npm:~7.2.24"
+    "@mui/utils": "npm:^6.4.9"
+    "@popperjs/core": "npm:^2.11.8"
+    "@types/react-transition-group": "npm:^4.4.12"
+    clsx: "npm:^2.1.1"
+    csstype: "npm:^3.1.3"
+    prop-types: "npm:^15.8.1"
+    react-is: "npm:^19.0.0"
+    react-transition-group: "npm:^4.4.5"
+  peerDependencies:
+    "@emotion/react": ^11.5.0
+    "@emotion/styled": ^11.3.0
+    "@mui/material-pigment-css": ^6.5.0
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@emotion/react":
+      optional: true
+    "@emotion/styled":
+      optional: true
+    "@mui/material-pigment-css":
+      optional: true
+    "@types/react":
+      optional: true
+  checksum: 10c0/24dfb582fe4655cc8e15476637d60d17cc1be6326be36d7fbc8c9a99f044ba10e5b68841f292e2cd1ce7e1ca26bc1006e37e7bba1e6979992850c907aa4c17b4
+  languageName: node
+  linkType: hard
+
+"@mui/private-theming@npm:^6.4.9":
+  version: 6.4.9
+  resolution: "@mui/private-theming@npm:6.4.9"
+  dependencies:
+    "@babel/runtime": "npm:^7.26.0"
+    "@mui/utils": "npm:^6.4.9"
+    prop-types: "npm:^15.8.1"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/3b198fad085b9ce5092cb2ad2aceee5f6a643f68f4fb1469d0748615490b8b9228179a6564be9c6784aa6f1f42a9afe61f1ad5ce0af56858e9bb58d36472e339
+  languageName: node
+  linkType: hard
+
+"@mui/styled-engine@npm:^6.5.0":
+  version: 6.5.0
+  resolution: "@mui/styled-engine@npm:6.5.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.26.0"
+    "@emotion/cache": "npm:^11.13.5"
+    "@emotion/serialize": "npm:^1.3.3"
+    "@emotion/sheet": "npm:^1.4.0"
+    csstype: "npm:^3.1.3"
+    prop-types: "npm:^15.8.1"
+  peerDependencies:
+    "@emotion/react": ^11.4.1
+    "@emotion/styled": ^11.3.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@emotion/react":
+      optional: true
+    "@emotion/styled":
+      optional: true
+  checksum: 10c0/aa44806d2cdd1b65c756a97927edcd7907cc5649d206382b5b5b8c27f899552a002e713fb167aa0e5aa980542bd309166113830dc550672d7598ad5993e7ff66
+  languageName: node
+  linkType: hard
+
+"@mui/styles@npm:6.5.0":
+  version: 6.5.0
+  resolution: "@mui/styles@npm:6.5.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.26.0"
+    "@emotion/hash": "npm:^0.9.2"
+    "@mui/private-theming": "npm:^6.4.9"
+    "@mui/types": "npm:~7.2.24"
+    "@mui/utils": "npm:^6.4.9"
+    clsx: "npm:^2.1.1"
+    csstype: "npm:^3.1.3"
+    hoist-non-react-statics: "npm:^3.3.2"
+    jss: "npm:^10.10.0"
+    jss-plugin-camel-case: "npm:^10.10.0"
+    jss-plugin-default-unit: "npm:^10.10.0"
+    jss-plugin-global: "npm:^10.10.0"
+    jss-plugin-nested: "npm:^10.10.0"
+    jss-plugin-props-sort: "npm:^10.10.0"
+    jss-plugin-rule-value-function: "npm:^10.10.0"
+    jss-plugin-vendor-prefixer: "npm:^10.10.0"
+    prop-types: "npm:^15.8.1"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/0673cfa28acc298eae843ac918c5df575d1c5bad7bbbf44030b3e148787da1365ca0edbc112d7ac49fe1486a34d14f4db7be72c718d596bafc9d4fad22de9353
+  languageName: node
+  linkType: hard
+
+"@mui/system@npm:^6.5.0":
+  version: 6.5.0
+  resolution: "@mui/system@npm:6.5.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.26.0"
+    "@mui/private-theming": "npm:^6.4.9"
+    "@mui/styled-engine": "npm:^6.5.0"
+    "@mui/types": "npm:~7.2.24"
+    "@mui/utils": "npm:^6.4.9"
+    clsx: "npm:^2.1.1"
+    csstype: "npm:^3.1.3"
+    prop-types: "npm:^15.8.1"
+  peerDependencies:
+    "@emotion/react": ^11.5.0
+    "@emotion/styled": ^11.3.0
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@emotion/react":
+      optional: true
+    "@emotion/styled":
+      optional: true
+    "@types/react":
+      optional: true
+  checksum: 10c0/2603ca8997625924e867504a53a20f81ad2dd7f3abb314709175341e4d2143bb22e2a9b4e8a008c92bf12e0333775dec651e8b9c237c4848650aabb60d8dab06
+  languageName: node
+  linkType: hard
+
+"@mui/types@npm:~7.2.24":
+  version: 7.2.24
+  resolution: "@mui/types@npm:7.2.24"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/7756339cae70e9b684c4311924e4e3882f908552b69c434b4d13faf2f5908ce72fe889a31890257c5ad42a085207be7c1661981dfc683293e90ac6dfac3759d0
+  languageName: node
+  linkType: hard
+
+"@mui/utils@npm:^6.4.9":
+  version: 6.4.9
+  resolution: "@mui/utils@npm:6.4.9"
+  dependencies:
+    "@babel/runtime": "npm:^7.26.0"
+    "@mui/types": "npm:~7.2.24"
+    "@types/prop-types": "npm:^15.7.14"
+    clsx: "npm:^2.1.1"
+    prop-types: "npm:^15.8.1"
+    react-is: "npm:^19.0.0"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/27122262bc24d31e8906e3133f3f6e6c858733802019e0e9ec6dedf632ca46287ab3735c9da6be7a7e0b4f043ced9b8f36b5b21bfef1d96ecfa5d150ea458508
+  languageName: node
+  linkType: hard
+
 "@napi-rs/wasm-runtime@npm:^0.2.11":
   version: 0.2.12
   resolution: "@napi-rs/wasm-runtime@npm:0.2.12"
@@ -2835,6 +3350,13 @@ __metadata:
   version: 0.11.0
   resolution: "@pkgjs/parseargs@npm:0.11.0"
   checksum: 10c0/5bd7576bb1b38a47a7fc7b51ac9f38748e772beebc56200450c4a817d712232b8f1d3ef70532c80840243c657d491cf6a6be1e3a214cff907645819fdc34aadd
+  languageName: node
+  linkType: hard
+
+"@popperjs/core@npm:^2.11.8":
+  version: 2.11.8
+  resolution: "@popperjs/core@npm:2.11.8"
+  checksum: 10c0/4681e682abc006d25eb380d0cf3efc7557043f53b6aea7a5057d0d1e7df849a00e281cd8ea79c902a35a414d7919621fc2ba293ecec05f413598e0b23d5a1e63
   languageName: node
   linkType: hard
 
@@ -4683,6 +5205,480 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tiptap/core@npm:3.23.1":
+  version: 3.23.1
+  resolution: "@tiptap/core@npm:3.23.1"
+  peerDependencies:
+    "@tiptap/pm": 3.23.1
+  checksum: 10c0/f5a6c8518004fd266f12b86ec692803d1f5493a54a446605d90b96433c76b8c85efb87295febf2adfeabce9566f4395514801e9e15c25c6abc2334b469335ce0
+  languageName: node
+  linkType: hard
+
+"@tiptap/core@npm:^3.23.1":
+  version: 3.23.6
+  resolution: "@tiptap/core@npm:3.23.6"
+  peerDependencies:
+    "@tiptap/pm": 3.23.6
+  checksum: 10c0/5a04e3879a6c4ceff3244ed5d1253c7448a04f8445c66441f8874a35becc290f93127f48fb77acd91c57c2bab62c742c97db74f1a795d9d30a51f080273eafe6
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-blockquote@npm:^3.23.1":
+  version: 3.23.6
+  resolution: "@tiptap/extension-blockquote@npm:3.23.6"
+  peerDependencies:
+    "@tiptap/core": 3.23.6
+  checksum: 10c0/65e2403b7e3701ba729650a4f452449e5a62b7d8ded03477033dc849a9dea7d1b46eb48b2c52020ba8e0b8d2286d06cf82aa95379ef0d5dd5e8950efb77bbbd0
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-bold@npm:^3.23.1":
+  version: 3.23.6
+  resolution: "@tiptap/extension-bold@npm:3.23.6"
+  peerDependencies:
+    "@tiptap/core": 3.23.6
+  checksum: 10c0/f0f1769326840841f53d8a0ae8d2ba1ae2f088c8333c15a9e6a83cafb5ff49ac48128d82762fcc4bd3eaabae495774e13c53ac7ccbcb3fe9c7006e9f254d8632
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-bubble-menu@npm:^3.23.1":
+  version: 3.23.6
+  resolution: "@tiptap/extension-bubble-menu@npm:3.23.6"
+  dependencies:
+    "@floating-ui/dom": "npm:^1.0.0"
+  peerDependencies:
+    "@tiptap/core": 3.23.6
+    "@tiptap/pm": 3.23.6
+  checksum: 10c0/f96dedbc5d9a21f57fa538f9aa0eb55fa511cdb9efc5782b3ec85d5697842f63cf5ce5fc77c33714ccf8bb5529a683086894183f37e5cf77d940c172093c6783
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-bullet-list@npm:^3.23.1":
+  version: 3.23.6
+  resolution: "@tiptap/extension-bullet-list@npm:3.23.6"
+  peerDependencies:
+    "@tiptap/extension-list": 3.23.6
+  checksum: 10c0/65e9278143deec77711ed9ef132892a55e374c68abbe4c013587976d426ee2aecb5fb372df4b287b39dc7078c35b488ae3946fc991abdd282807ba5c38d7187d
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-code-block@npm:^3.23.1":
+  version: 3.23.6
+  resolution: "@tiptap/extension-code-block@npm:3.23.6"
+  peerDependencies:
+    "@tiptap/core": 3.23.6
+    "@tiptap/pm": 3.23.6
+  checksum: 10c0/7ffdc7daa9416b021a61d6c967d65296ebb1aa8375fc96dcff69a5091ebba1f094b7d17fe1c0167e9d1f0f5fc96ecf631a07f2fcafecb72619b020b2d1a17cef
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-code@npm:^3.23.1":
+  version: 3.23.6
+  resolution: "@tiptap/extension-code@npm:3.23.6"
+  peerDependencies:
+    "@tiptap/core": 3.23.6
+  checksum: 10c0/6e066bd9370fa5a4607fde7733d9588174399d3060ebb2d2bac706ba7d8ed92b42d2f769daafb57439309b32163e79b6828bc51b53c5bf667cb290787c4decad
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-color@npm:3.23.1":
+  version: 3.23.1
+  resolution: "@tiptap/extension-color@npm:3.23.1"
+  peerDependencies:
+    "@tiptap/extension-text-style": 3.23.1
+  checksum: 10c0/ebe8622f5050dfd28fe829d7a7519a909c493a4d52d766b3279b07ef323d2414f6901632ffabd718c62867ac7bd36a1482768844335244b3aea68fa6d62b654d
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-document@npm:^3.23.1":
+  version: 3.23.6
+  resolution: "@tiptap/extension-document@npm:3.23.6"
+  peerDependencies:
+    "@tiptap/core": 3.23.6
+  checksum: 10c0/e2f6769de7f59e37535099f573c7d434c23cd891de9bdfe612710bf7fff14fc08d341a0497898150f86c3e42dadee0b2a156363309007fb9a87fc2578ac704ca
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-dropcursor@npm:^3.23.1":
+  version: 3.23.6
+  resolution: "@tiptap/extension-dropcursor@npm:3.23.6"
+  peerDependencies:
+    "@tiptap/extensions": 3.23.6
+  checksum: 10c0/3b603cbf9876220443030a87310a9299b1b6baf17cf1ed5c36831ddbc81e8bc85b4d9018d837ec404a1c22f344cd432f00c9f2c8e500d214d516921307f9a20e
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-floating-menu@npm:^3.23.1":
+  version: 3.23.6
+  resolution: "@tiptap/extension-floating-menu@npm:3.23.6"
+  peerDependencies:
+    "@floating-ui/dom": ^1.0.0
+    "@tiptap/core": 3.23.6
+    "@tiptap/pm": 3.23.6
+  checksum: 10c0/2f8824446c135593c9cee59e5cb823d986f0bad39e96cfffd74f1d0dd2e7c10c3d31d95323fce69cab7a45e7d19248e26ba3198fb76c0ee609248bc362461469
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-gapcursor@npm:^3.23.1":
+  version: 3.23.6
+  resolution: "@tiptap/extension-gapcursor@npm:3.23.6"
+  peerDependencies:
+    "@tiptap/extensions": 3.23.6
+  checksum: 10c0/ce0a3f0939f063fde252be5e9920fac7ce0b8f40cde27ca49fbfbc58ff0ad0606e5d95c1b0ad4c041e77d50515b1755efbcc063ac6b59601e104c06445a8dcc7
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-hard-break@npm:^3.23.1":
+  version: 3.23.6
+  resolution: "@tiptap/extension-hard-break@npm:3.23.6"
+  peerDependencies:
+    "@tiptap/core": 3.23.6
+  checksum: 10c0/10c4d0f98b7e234edee00fe3f82d2c3240fef89d397c8cd1eaecb5be690bc88e9e52f476d27b437d413b9544c609a0523c5f83f3334f14ca042ff34f1ef9376e
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-heading@npm:^3.23.1":
+  version: 3.23.6
+  resolution: "@tiptap/extension-heading@npm:3.23.6"
+  peerDependencies:
+    "@tiptap/core": 3.23.6
+  checksum: 10c0/9434c63ed86091e767ef3e2b15520d6416f1f7c768b237df817cb2a1c878ce80ce2677a5de0e3441f237a99e74ce0ee6aeffb686df953daf8ecb76c0163f1404
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-highlight@npm:3.23.1":
+  version: 3.23.1
+  resolution: "@tiptap/extension-highlight@npm:3.23.1"
+  peerDependencies:
+    "@tiptap/core": 3.23.1
+  checksum: 10c0/2bb7f4199f227d7ba4c781328bd19871b752aedde58397a3d2346cc5af9c7a4bd57e3c369b644e08f466cbb8e6bf94cafe64efb1b9e36072114042d448b7d3e1
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-horizontal-rule@npm:^3.23.1":
+  version: 3.23.6
+  resolution: "@tiptap/extension-horizontal-rule@npm:3.23.6"
+  peerDependencies:
+    "@tiptap/core": 3.23.6
+    "@tiptap/pm": 3.23.6
+  checksum: 10c0/74525e696d650d74f014a40687a152e4e4140ff01f59bba0e49e7914ac0dc78718a136f348e8a50b378962139c28ba7eb59426ed310a069974c3af8584975e4a
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-image@npm:3.23.1":
+  version: 3.23.1
+  resolution: "@tiptap/extension-image@npm:3.23.1"
+  peerDependencies:
+    "@tiptap/core": 3.23.1
+  checksum: 10c0/11ba41407d84bbc70d0e192f490fbc3a81a59a1567ad35f37efb1b00b2a2073875ad65e2158bf101a6441b161f0661cb97893e8e55bf47f64f52b93cad7e3050
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-italic@npm:^3.23.1":
+  version: 3.23.6
+  resolution: "@tiptap/extension-italic@npm:3.23.6"
+  peerDependencies:
+    "@tiptap/core": 3.23.6
+  checksum: 10c0/a911e50369c5045c93a6e2e7a6814f21c42eb33c315def0a295e38f06bfd165e04dfe47b096628c8236d5b9b75cc95af3a452816970ee89659f8fada541fad3e
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-link@npm:^3.23.1":
+  version: 3.23.6
+  resolution: "@tiptap/extension-link@npm:3.23.6"
+  dependencies:
+    linkifyjs: "npm:^4.3.3"
+  peerDependencies:
+    "@tiptap/core": 3.23.6
+    "@tiptap/pm": 3.23.6
+  checksum: 10c0/7587bb9dc3d02426a85413e018d5585cc66d3d14251b76d81003e5261c797c16ef14012e8100a99bed50a22b59ec1d62583d6f657ce19ba82eb03258fef9083d
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-list-item@npm:^3.23.1":
+  version: 3.23.6
+  resolution: "@tiptap/extension-list-item@npm:3.23.6"
+  peerDependencies:
+    "@tiptap/extension-list": 3.23.6
+  checksum: 10c0/9c806400455d605b424cf4aa17c67f8f817b2d8257d1d87eaa4eb321fa59565ff33f4707c6bc3e2c0d0f853b60d83b783c7577f594373e7940593d15e30fb94c
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-list-keymap@npm:^3.23.1":
+  version: 3.23.6
+  resolution: "@tiptap/extension-list-keymap@npm:3.23.6"
+  peerDependencies:
+    "@tiptap/extension-list": 3.23.6
+  checksum: 10c0/eec4e46510fca28ef6c99e2c5f69ea6e7915e40ee9c76ebf264280d521aae290580398cffa56685a318a220b14b7d3b30e91560412d81b854486ec0afa124236
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-list@npm:^3.23.1":
+  version: 3.23.6
+  resolution: "@tiptap/extension-list@npm:3.23.6"
+  peerDependencies:
+    "@tiptap/core": 3.23.6
+    "@tiptap/pm": 3.23.6
+  checksum: 10c0/1372d3371ba3d5c8b679b0cd05e69f4912aa8f27d593f63b7900390beb1147a86440a8af91f64e1fa3150d4e278de46b5e3d5febc970bac014cd01216e9f5cad
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-mention@npm:3.23.1":
+  version: 3.23.1
+  resolution: "@tiptap/extension-mention@npm:3.23.1"
+  peerDependencies:
+    "@tiptap/core": 3.23.1
+    "@tiptap/pm": 3.23.1
+    "@tiptap/suggestion": 3.23.1
+  checksum: 10c0/04b270d4b49acd723792292ce4f8343ed8ec8564bc5917c6959179d49ad4fd0f5b636a00269732694d8e9a43f7b61877e9f688321649a7555915ccca60d1b5c3
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-ordered-list@npm:^3.23.1":
+  version: 3.23.6
+  resolution: "@tiptap/extension-ordered-list@npm:3.23.6"
+  peerDependencies:
+    "@tiptap/extension-list": 3.23.6
+  checksum: 10c0/7b0147e3b0e1e6531cc721942924c9ee6ef536f6e99f99c2c66eaa908641fc6f25104786271ea40b9e5e7dff178254b8ca69574e50168f9ef819ff5699f41b54
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-paragraph@npm:3.23.1":
+  version: 3.23.1
+  resolution: "@tiptap/extension-paragraph@npm:3.23.1"
+  peerDependencies:
+    "@tiptap/core": 3.23.1
+  checksum: 10c0/d73311e2d8b84ee91fee1acb7f0883f62c3ceed9fd32db4c4b1f5d64ff19881ea0a2a7892814d3a1af57288c52da8dd0a32897e3beff9e7095ba7e0ab9abe6b1
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-paragraph@npm:^3.23.1":
+  version: 3.23.6
+  resolution: "@tiptap/extension-paragraph@npm:3.23.6"
+  peerDependencies:
+    "@tiptap/core": 3.23.6
+  checksum: 10c0/9f990d18effc6348e0b65133c464059ed05da935c52d46c1597f957a02faf072579bfc552e537b6c5eaebefcf8adde691a2210cba7c5034f44f3b81545cf6dc9
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-placeholder@npm:3.23.1":
+  version: 3.23.1
+  resolution: "@tiptap/extension-placeholder@npm:3.23.1"
+  peerDependencies:
+    "@tiptap/extensions": 3.23.1
+  checksum: 10c0/dfe7f979ecd98cdcbb330c6cf937af5575390d85d9a5e9904c13918938507148ed79e7f4217b0231decd20877fafbad90c6d6b8d84c2e23919fbd0faed8db91e
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-strike@npm:^3.23.1":
+  version: 3.23.6
+  resolution: "@tiptap/extension-strike@npm:3.23.6"
+  peerDependencies:
+    "@tiptap/core": 3.23.6
+  checksum: 10c0/8ad41c611f46973836377f92bab2a958dd74b134b0c983c865b81f14f30b2a6c6fef398e9e869b13bb5e66c65dd0a2cb11de1d80ef182c0b81ecc0e4eaeac378
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-subscript@npm:3.23.1":
+  version: 3.23.1
+  resolution: "@tiptap/extension-subscript@npm:3.23.1"
+  peerDependencies:
+    "@tiptap/core": 3.23.1
+    "@tiptap/pm": 3.23.1
+  checksum: 10c0/d709e523075d003b2a69f82bdf61f24d198d406d0f282433b956f71283404dc8b0b455641a6bd42b32e73b246f37452833d3bed92dc679414bd4b0d1965474c3
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-superscript@npm:3.23.1":
+  version: 3.23.1
+  resolution: "@tiptap/extension-superscript@npm:3.23.1"
+  peerDependencies:
+    "@tiptap/core": 3.23.1
+    "@tiptap/pm": 3.23.1
+  checksum: 10c0/3ee2c795fa61c01ad3ebd5bb9c999ef45cf1f934033cfd6912ae11fa56864bf8de6019f7e88043abe49138cf3d2069ed6e3eb42606119bfbb612489b2aee212d
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-table@npm:3.23.1":
+  version: 3.23.1
+  resolution: "@tiptap/extension-table@npm:3.23.1"
+  peerDependencies:
+    "@tiptap/core": 3.23.1
+    "@tiptap/pm": 3.23.1
+  checksum: 10c0/6d1ddc862c4f452f5be1ed45d38bfb4399f3f44def5480fcb0329c4931d8556721bfe60571066f0d5caca220432798159e41cddaa1146bbc87e12833182426c1
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-task-item@npm:3.23.1":
+  version: 3.23.1
+  resolution: "@tiptap/extension-task-item@npm:3.23.1"
+  peerDependencies:
+    "@tiptap/extension-list": 3.23.1
+  checksum: 10c0/01bfa28024e192d02d2a6063d0de5a64f483722ae71cf07ba34e304605b61cbf892403652aaf9e6cf4bf448f666656326d65293328df7f50e6c96a202824d8ab
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-task-list@npm:3.23.1":
+  version: 3.23.1
+  resolution: "@tiptap/extension-task-list@npm:3.23.1"
+  peerDependencies:
+    "@tiptap/extension-list": 3.23.1
+  checksum: 10c0/ec1495679d67485914a5ac3298d0808cef1e1f0ea591917a4fa4c7db4c9b0c1730bfed31c30507a425c2b448e56323d88974f1c2d3652f3d806c8e6ca391d8c1
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-text-align@npm:3.23.1":
+  version: 3.23.1
+  resolution: "@tiptap/extension-text-align@npm:3.23.1"
+  peerDependencies:
+    "@tiptap/core": 3.23.1
+  checksum: 10c0/98ada3b8d2d366b3169bf35d8482c108b9635d134246c4c4dd285fcbf12576c9f9f664b2236fc5f4ffb0e0c6bbf52e50453c4b7ef2ee4de584ee84dbd36e055b
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-text-style@npm:3.23.1":
+  version: 3.23.1
+  resolution: "@tiptap/extension-text-style@npm:3.23.1"
+  peerDependencies:
+    "@tiptap/core": 3.23.1
+  checksum: 10c0/83755da630732112c7c5d25be0ec96f7392e3726869cbf45e07d730819dc58128fd87c813e0226d8723f518a4c207f7d9da9546ff01f9b989d0dcc6054569274
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-text@npm:^3.23.1":
+  version: 3.23.6
+  resolution: "@tiptap/extension-text@npm:3.23.6"
+  peerDependencies:
+    "@tiptap/core": 3.23.6
+  checksum: 10c0/4e3e23b7397504aabcc4d307d1748db6c759d18406f99adc0ae33474fe02ea8676add53e5dc706c849d15be62f7f9aa399a9b4b2d2b2daa67daf30ed0125ef30
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-typography@npm:3.23.1":
+  version: 3.23.1
+  resolution: "@tiptap/extension-typography@npm:3.23.1"
+  peerDependencies:
+    "@tiptap/core": 3.23.1
+  checksum: 10c0/6f42d090935aa36830a897a196ee5ff4689a520b49405bf13010b8df9c7bba75d21376207abc734e88ff39a64169eca659f16e36c610e8e210ed9cab18eac328
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-underline@npm:^3.23.1":
+  version: 3.23.6
+  resolution: "@tiptap/extension-underline@npm:3.23.6"
+  peerDependencies:
+    "@tiptap/core": 3.23.6
+  checksum: 10c0/3314e7501a3c725bfe6e5e522d3a24610edc462c1da3c395b7b5239eb83962fbb15b4d569d4c8baef2e69f45c2c508861990be922451323b37703c5e198b9643
+  languageName: node
+  linkType: hard
+
+"@tiptap/extensions@npm:^3.23.1":
+  version: 3.23.6
+  resolution: "@tiptap/extensions@npm:3.23.6"
+  peerDependencies:
+    "@tiptap/core": 3.23.6
+    "@tiptap/pm": 3.23.6
+  checksum: 10c0/b85ea3e502244c0c152dcbc5dc89b5c778aa37da7579e9d7a41b06309e8f510b16deef59a40e2483a0bef77938c4c1652548068bf33a3868b906ad37bdd41abd
+  languageName: node
+  linkType: hard
+
+"@tiptap/pm@npm:3.23.1":
+  version: 3.23.1
+  resolution: "@tiptap/pm@npm:3.23.1"
+  dependencies:
+    prosemirror-changeset: "npm:^2.3.0"
+    prosemirror-commands: "npm:^1.6.2"
+    prosemirror-dropcursor: "npm:^1.8.1"
+    prosemirror-gapcursor: "npm:^1.3.2"
+    prosemirror-history: "npm:^1.4.1"
+    prosemirror-keymap: "npm:^1.2.2"
+    prosemirror-model: "npm:^1.24.1"
+    prosemirror-schema-list: "npm:^1.5.0"
+    prosemirror-state: "npm:^1.4.3"
+    prosemirror-tables: "npm:^1.6.4"
+    prosemirror-transform: "npm:^1.10.2"
+    prosemirror-view: "npm:^1.38.1"
+  checksum: 10c0/e3e798dfdf488e5d5e919bc39d734ccdb8ebc34683417eafd7cbc733765100da6d9c920c73b3bd17d3fafe6f6055a2a2f374e9b3785b70c61a88f011cb260c1c
+  languageName: node
+  linkType: hard
+
+"@tiptap/pm@npm:^3.23.1":
+  version: 3.23.6
+  resolution: "@tiptap/pm@npm:3.23.6"
+  dependencies:
+    prosemirror-changeset: "npm:^2.3.0"
+    prosemirror-commands: "npm:^1.6.2"
+    prosemirror-dropcursor: "npm:^1.8.1"
+    prosemirror-gapcursor: "npm:^1.3.2"
+    prosemirror-history: "npm:^1.4.1"
+    prosemirror-keymap: "npm:^1.2.2"
+    prosemirror-model: "npm:^1.24.1"
+    prosemirror-schema-list: "npm:^1.5.0"
+    prosemirror-state: "npm:^1.4.3"
+    prosemirror-tables: "npm:^1.6.4"
+    prosemirror-transform: "npm:^1.10.2"
+    prosemirror-view: "npm:^1.38.1"
+  checksum: 10c0/7ce4cd0d440ec557545821cfb0a222f85200856bf4f28cfaa20e7913111af7d6f4764a55ca35f0cf0d3ea5f8df5e8d0a9f607c0d6dc7f5ccdcde22704b1533dc
+  languageName: node
+  linkType: hard
+
+"@tiptap/react@npm:3.23.1":
+  version: 3.23.1
+  resolution: "@tiptap/react@npm:3.23.1"
+  dependencies:
+    "@tiptap/extension-bubble-menu": "npm:^3.23.1"
+    "@tiptap/extension-floating-menu": "npm:^3.23.1"
+    "@types/use-sync-external-store": "npm:^0.0.6"
+    fast-equals: "npm:^5.3.3"
+    use-sync-external-store: "npm:^1.4.0"
+  peerDependencies:
+    "@tiptap/core": 3.23.1
+    "@tiptap/pm": 3.23.1
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    "@types/react-dom": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+  dependenciesMeta:
+    "@tiptap/extension-bubble-menu":
+      optional: true
+    "@tiptap/extension-floating-menu":
+      optional: true
+  checksum: 10c0/208f2013179d05c8b150f8fff8712494caf1b4ef915f43f9d225877e7cdccb88891f7a38351359fe030e8b9cb4a256f1de73a5331ce0ead24afd9ff9c0005031
+  languageName: node
+  linkType: hard
+
+"@tiptap/starter-kit@npm:3.23.1":
+  version: 3.23.1
+  resolution: "@tiptap/starter-kit@npm:3.23.1"
+  dependencies:
+    "@tiptap/core": "npm:^3.23.1"
+    "@tiptap/extension-blockquote": "npm:^3.23.1"
+    "@tiptap/extension-bold": "npm:^3.23.1"
+    "@tiptap/extension-bullet-list": "npm:^3.23.1"
+    "@tiptap/extension-code": "npm:^3.23.1"
+    "@tiptap/extension-code-block": "npm:^3.23.1"
+    "@tiptap/extension-document": "npm:^3.23.1"
+    "@tiptap/extension-dropcursor": "npm:^3.23.1"
+    "@tiptap/extension-gapcursor": "npm:^3.23.1"
+    "@tiptap/extension-hard-break": "npm:^3.23.1"
+    "@tiptap/extension-heading": "npm:^3.23.1"
+    "@tiptap/extension-horizontal-rule": "npm:^3.23.1"
+    "@tiptap/extension-italic": "npm:^3.23.1"
+    "@tiptap/extension-link": "npm:^3.23.1"
+    "@tiptap/extension-list": "npm:^3.23.1"
+    "@tiptap/extension-list-item": "npm:^3.23.1"
+    "@tiptap/extension-list-keymap": "npm:^3.23.1"
+    "@tiptap/extension-ordered-list": "npm:^3.23.1"
+    "@tiptap/extension-paragraph": "npm:^3.23.1"
+    "@tiptap/extension-strike": "npm:^3.23.1"
+    "@tiptap/extension-text": "npm:^3.23.1"
+    "@tiptap/extension-underline": "npm:^3.23.1"
+    "@tiptap/extensions": "npm:^3.23.1"
+    "@tiptap/pm": "npm:^3.23.1"
+  checksum: 10c0/7ec4ef089553c8a2abbd9371a7cf665bfb7a4e94cba247cff00664f6f96de48c0435235e2b9e1fb086026741065572a4eb0b03ee577486b72b1b9075bdbb7501
+  languageName: node
+  linkType: hard
+
 "@tybys/wasm-util@npm:^0.10.0, @tybys/wasm-util@npm:^0.10.1":
   version: 0.10.1
   resolution: "@tybys/wasm-util@npm:0.10.1"
@@ -4811,6 +5807,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/prop-types@npm:^15.7.14":
+  version: 15.7.15
+  resolution: "@types/prop-types@npm:15.7.15"
+  checksum: 10c0/b59aad1ad19bf1733cf524fd4e618196c6c7690f48ee70a327eb450a42aab8e8a063fbe59ca0a5701aebe2d92d582292c0fb845ea57474f6a15f6994b0e260b2
+  languageName: node
+  linkType: hard
+
+"@types/react-color@npm:3.0.13":
+  version: 3.0.13
+  resolution: "@types/react-color@npm:3.0.13"
+  dependencies:
+    "@types/reactcss": "npm:*"
+  peerDependencies:
+    "@types/react": "*"
+  checksum: 10c0/a26a2a628dc98d2186743a52e18fc1a4622ba9ec69989be1e51614084fd90a52c139ea6689aa9706fcea94356d277c87d69f11a5c1f66c19b45e6b0132db40bb
+  languageName: node
+  linkType: hard
+
 "@types/react-color@npm:^2":
   version: 2.17.12
   resolution: "@types/react-color@npm:2.17.12"
@@ -4828,6 +5842,15 @@ __metadata:
   peerDependencies:
     "@types/react": ^19.2.0
   checksum: 10c0/b486ebe0f4e2fb35e2e108df1d8fc0927ca5d6002d5771e8a739de11239fe62d0e207c50886185253c99eb9dedfeeb956ea7429e5ba17f6693c7acb4c02f8cd1
+  languageName: node
+  linkType: hard
+
+"@types/react-transition-group@npm:^4.4.12":
+  version: 4.4.12
+  resolution: "@types/react-transition-group@npm:4.4.12"
+  peerDependencies:
+    "@types/react": "*"
+  checksum: 10c0/0441b8b47c69312c89ec0760ba477ba1a0808a10ceef8dc1c64b1013ed78517332c30f18681b0ec0b53542731f1ed015169fed1d127cc91222638ed955478ec7
   languageName: node
   linkType: hard
 
@@ -4867,6 +5890,13 @@ __metadata:
   version: 2.0.11
   resolution: "@types/unist@npm:2.0.11"
   checksum: 10c0/24dcdf25a168f453bb70298145eb043cfdbb82472db0bc0b56d6d51cd2e484b9ed8271d4ac93000a80da568f2402e9339723db262d0869e2bf13bc58e081768d
+  languageName: node
+  linkType: hard
+
+"@types/use-sync-external-store@npm:^0.0.6":
+  version: 0.0.6
+  resolution: "@types/use-sync-external-store@npm:0.0.6"
+  checksum: 10c0/77c045a98f57488201f678b181cccd042279aff3da34540ad242f893acc52b358bd0a8207a321b8ac09adbcef36e3236944390e2df4fcedb556ce7bb2a88f2a8
   languageName: node
   linkType: hard
 
@@ -6357,6 +7387,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"css-vendor@npm:^2.0.8":
+  version: 2.0.8
+  resolution: "css-vendor@npm:2.0.8"
+  dependencies:
+    "@babel/runtime": "npm:^7.8.3"
+    is-in-browser: "npm:^1.0.2"
+  checksum: 10c0/2538bc37adf72eb79781929dbb8c48e12c6a4b926594ad4134408b3000249f1a50d25be374f0e63f688c863368814aa6cc2e9ea11ea22a7309a7d966b281244c
+  languageName: node
+  linkType: hard
+
 "css-what@npm:^6.1.0":
   version: 6.2.2
   resolution: "css-what@npm:6.2.2"
@@ -6450,7 +7490,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"csstype@npm:^3.0.5, csstype@npm:^3.2.2":
+"csstype@npm:^3.0.2, csstype@npm:^3.0.5, csstype@npm:^3.1.3, csstype@npm:^3.2.2":
   version: 3.2.3
   resolution: "csstype@npm:3.2.3"
   checksum: 10c0/cd29c51e70fa822f1cecd8641a1445bed7063697469d35633b516e60fe8c1bde04b08f6c5b6022136bb669b64c63d4173af54864510fbb4ee23281801841a3ce
@@ -6706,6 +7746,16 @@ __metadata:
   dependencies:
     esutils: "npm:^2.0.2"
   checksum: 10c0/b6416aaff1f380bf56c3b552f31fdf7a69b45689368deca72d28636f41c16bb28ec3ebc40ace97db4c1afc0ceeb8120e8492fe0046841c94c2933b2e30a7d5ac
+  languageName: node
+  linkType: hard
+
+"dom-helpers@npm:^5.0.1":
+  version: 5.2.1
+  resolution: "dom-helpers@npm:5.2.1"
+  dependencies:
+    "@babel/runtime": "npm:^7.8.7"
+    csstype: "npm:^3.0.2"
+  checksum: 10c0/f735074d66dd759b36b158fa26e9d00c9388ee0e8c9b16af941c38f014a37fc80782de83afefd621681b19ac0501034b4f1c4a3bff5caa1b8667f0212b5e124c
   languageName: node
   linkType: hard
 
@@ -7193,6 +8243,95 @@ __metadata:
     esast-util-from-estree: "npm:^2.0.0"
     vfile-message: "npm:^4.0.0"
   checksum: 10c0/3a446fb0b0d7bcd7e0157aa44b3b692802a08c93edbea81cc0f7fe4437bfdfb4b72e4563fe63b4e36d390086b71185dba4ac921f4180cc6349985c263cc74421
+  languageName: node
+  linkType: hard
+
+"esbuild@npm:^0.25.0":
+  version: 0.25.12
+  resolution: "esbuild@npm:0.25.12"
+  dependencies:
+    "@esbuild/aix-ppc64": "npm:0.25.12"
+    "@esbuild/android-arm": "npm:0.25.12"
+    "@esbuild/android-arm64": "npm:0.25.12"
+    "@esbuild/android-x64": "npm:0.25.12"
+    "@esbuild/darwin-arm64": "npm:0.25.12"
+    "@esbuild/darwin-x64": "npm:0.25.12"
+    "@esbuild/freebsd-arm64": "npm:0.25.12"
+    "@esbuild/freebsd-x64": "npm:0.25.12"
+    "@esbuild/linux-arm": "npm:0.25.12"
+    "@esbuild/linux-arm64": "npm:0.25.12"
+    "@esbuild/linux-ia32": "npm:0.25.12"
+    "@esbuild/linux-loong64": "npm:0.25.12"
+    "@esbuild/linux-mips64el": "npm:0.25.12"
+    "@esbuild/linux-ppc64": "npm:0.25.12"
+    "@esbuild/linux-riscv64": "npm:0.25.12"
+    "@esbuild/linux-s390x": "npm:0.25.12"
+    "@esbuild/linux-x64": "npm:0.25.12"
+    "@esbuild/netbsd-arm64": "npm:0.25.12"
+    "@esbuild/netbsd-x64": "npm:0.25.12"
+    "@esbuild/openbsd-arm64": "npm:0.25.12"
+    "@esbuild/openbsd-x64": "npm:0.25.12"
+    "@esbuild/openharmony-arm64": "npm:0.25.12"
+    "@esbuild/sunos-x64": "npm:0.25.12"
+    "@esbuild/win32-arm64": "npm:0.25.12"
+    "@esbuild/win32-ia32": "npm:0.25.12"
+    "@esbuild/win32-x64": "npm:0.25.12"
+  dependenciesMeta:
+    "@esbuild/aix-ppc64":
+      optional: true
+    "@esbuild/android-arm":
+      optional: true
+    "@esbuild/android-arm64":
+      optional: true
+    "@esbuild/android-x64":
+      optional: true
+    "@esbuild/darwin-arm64":
+      optional: true
+    "@esbuild/darwin-x64":
+      optional: true
+    "@esbuild/freebsd-arm64":
+      optional: true
+    "@esbuild/freebsd-x64":
+      optional: true
+    "@esbuild/linux-arm":
+      optional: true
+    "@esbuild/linux-arm64":
+      optional: true
+    "@esbuild/linux-ia32":
+      optional: true
+    "@esbuild/linux-loong64":
+      optional: true
+    "@esbuild/linux-mips64el":
+      optional: true
+    "@esbuild/linux-ppc64":
+      optional: true
+    "@esbuild/linux-riscv64":
+      optional: true
+    "@esbuild/linux-s390x":
+      optional: true
+    "@esbuild/linux-x64":
+      optional: true
+    "@esbuild/netbsd-arm64":
+      optional: true
+    "@esbuild/netbsd-x64":
+      optional: true
+    "@esbuild/openbsd-arm64":
+      optional: true
+    "@esbuild/openbsd-x64":
+      optional: true
+    "@esbuild/openharmony-arm64":
+      optional: true
+    "@esbuild/sunos-x64":
+      optional: true
+    "@esbuild/win32-arm64":
+      optional: true
+    "@esbuild/win32-ia32":
+      optional: true
+    "@esbuild/win32-x64":
+      optional: true
+  bin:
+    esbuild: bin/esbuild
+  checksum: 10c0/c205357531423220a9de8e1e6c6514242bc9b1666e762cd67ccdf8fdfdc3f1d0bd76f8d9383958b97ad4c953efdb7b6e8c1f9ca5951cd2b7c5235e8755b34a6b
   languageName: node
   linkType: hard
 
@@ -7832,6 +8971,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-equals@npm:^5.3.3":
+  version: 5.4.0
+  resolution: "fast-equals@npm:5.4.0"
+  checksum: 10c0/4fdce3a8f814e78af7296ca4ebe82f4765074a6dfe557ee98c18f5d2958c3de59025fbff7556d65f250165ccef424d37f9952ee159400f8ebe5f2edb704ec80e
+  languageName: node
+  linkType: hard
+
 "fast-glob@npm:3.3.1":
   version: 3.3.1
   resolution: "fast-glob@npm:3.3.1"
@@ -7987,7 +9133,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"foreground-child@npm:^3.1.0":
+"foreground-child@npm:^3.1.0, foreground-child@npm:^3.3.1":
   version: 3.3.1
   resolution: "foreground-child@npm:3.3.1"
   dependencies:
@@ -8207,6 +9353,22 @@ __metadata:
   bin:
     glob: dist/esm/bin.mjs
   checksum: 10c0/100705eddbde6323e7b35e1d1ac28bcb58322095bd8e63a7d0bef1a2cdafe0d0f7922a981b2b48369a4f8c1b077be5c171804534c3509dfe950dde15fbe6d828
+  languageName: node
+  linkType: hard
+
+"glob@npm:^11.0.0":
+  version: 11.1.0
+  resolution: "glob@npm:11.1.0"
+  dependencies:
+    foreground-child: "npm:^3.3.1"
+    jackspeak: "npm:^4.1.1"
+    minimatch: "npm:^10.1.1"
+    minipass: "npm:^7.1.2"
+    package-json-from-dist: "npm:^1.0.0"
+    path-scurry: "npm:^2.0.0"
+  bin:
+    glob: dist/esm/bin.mjs
+  checksum: 10c0/1ceae07f23e316a6fa74581d9a74be6e8c2e590d2f7205034dd5c0435c53f5f7b712c2be00c3b65bf0a49294a1c6f4b98cd84c7637e29453b5aa13b79f1763a2
   languageName: node
   linkType: hard
 
@@ -8579,6 +9741,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hoist-non-react-statics@npm:^3.3.2":
+  version: 3.3.2
+  resolution: "hoist-non-react-statics@npm:3.3.2"
+  dependencies:
+    react-is: "npm:^16.7.0"
+  checksum: 10c0/fe0889169e845d738b59b64badf5e55fa3cf20454f9203d1eb088df322d49d4318df774828e789898dcb280e8a5521bb59b3203385662ca5e9218a6ca5820e74
+  languageName: node
+  linkType: hard
+
 "html-crush@npm:^6.0.19, html-crush@npm:^6.1.3":
   version: 6.1.3
   resolution: "html-crush@npm:6.1.3"
@@ -8688,6 +9859,13 @@ __metadata:
     agent-base: "npm:^7.1.2"
     debug: "npm:4"
   checksum: 10c0/f729219bc735edb621fa30e6e84e60ee5d00802b8247aac0d7b79b0bd6d4b3294737a337b93b86a0bd9e68099d031858a39260c976dc14cdbba238ba1f8779ac
+  languageName: node
+  linkType: hard
+
+"hyphenate-style-name@npm:^1.0.3":
+  version: 1.1.0
+  resolution: "hyphenate-style-name@npm:1.1.0"
+  checksum: 10c0/bfe88deac2414a41a0d08811e277c8c098f23993d6a1eb17f14a0f11b54c4d42865a63d3cfe1914668eefb9a188e2de58f38b55a179a238fd1fef606893e194f
   languageName: node
   linkType: hard
 
@@ -9065,6 +10243,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-in-browser@npm:^1.0.2, is-in-browser@npm:^1.1.3":
+  version: 1.1.3
+  resolution: "is-in-browser@npm:1.1.3"
+  checksum: 10c0/87e6119a56ec3d84910eb6ad855b4a3ac05b242fc2bc2c28abbf978f76b5a834ec5622165035acaf2844a85856b1a0fbc12bd0cb1ce9e86314ebec675c6fe856
+  languageName: node
+  linkType: hard
+
 "is-interactive@npm:^2.0.0":
   version: 2.0.0
   resolution: "is-interactive@npm:2.0.0"
@@ -9311,6 +10496,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jackspeak@npm:^4.1.1":
+  version: 4.2.3
+  resolution: "jackspeak@npm:4.2.3"
+  dependencies:
+    "@isaacs/cliui": "npm:^9.0.0"
+  checksum: 10c0/b5c0c414f1607c2aa0597f4bf2c03b8443897fccd5fd3c2b3e4f77d556b2bc7c3d3413828ba91e0789f6fb40ad90242f7f89fb20aee9e9d705bc1681f7564f67
+  languageName: node
+  linkType: hard
+
 "jiti@npm:2.6.1, jiti@npm:^2.6.1":
   version: 2.6.1
   resolution: "jiti@npm:2.6.1"
@@ -9444,6 +10638,92 @@ __metadata:
   bin:
     json5: lib/cli.js
   checksum: 10c0/5a04eed94810fa55c5ea138b2f7a5c12b97c3750bc63d11e511dcecbfef758003861522a070c2272764ee0f4e3e323862f386945aeb5b85b87ee43f084ba586c
+  languageName: node
+  linkType: hard
+
+"jss-plugin-camel-case@npm:^10.10.0":
+  version: 10.10.0
+  resolution: "jss-plugin-camel-case@npm:10.10.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.3.1"
+    hyphenate-style-name: "npm:^1.0.3"
+    jss: "npm:10.10.0"
+  checksum: 10c0/29dedf0866837425258eae3b12b72c1de435ea7caddef94ac13044b3a04c4abd8dd238a81fd6e0a4afdbf10c9cb4674df41f50af79554c34c736cd2ecf3752da
+  languageName: node
+  linkType: hard
+
+"jss-plugin-default-unit@npm:^10.10.0":
+  version: 10.10.0
+  resolution: "jss-plugin-default-unit@npm:10.10.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.3.1"
+    jss: "npm:10.10.0"
+  checksum: 10c0/f394d5411114fde7056249f4650de51e6f3e47c64a3d48cee80180a6e75876f0d0d68c96d81458880e1024ca880ed53baade682d36a5f7177046bfef0b280572
+  languageName: node
+  linkType: hard
+
+"jss-plugin-global@npm:^10.10.0":
+  version: 10.10.0
+  resolution: "jss-plugin-global@npm:10.10.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.3.1"
+    jss: "npm:10.10.0"
+  checksum: 10c0/2d24ef0e16cd6ebcce59f132756716ae37fdffe3f59461018636a57ef68298e649f43bd5c346041f1642872aa2cc0629f5ecfb48a20bfb471813318cb8f3935f
+  languageName: node
+  linkType: hard
+
+"jss-plugin-nested@npm:^10.10.0":
+  version: 10.10.0
+  resolution: "jss-plugin-nested@npm:10.10.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.3.1"
+    jss: "npm:10.10.0"
+    tiny-warning: "npm:^1.0.2"
+  checksum: 10c0/868ac4e4bea9dc02fac33f15e3165c008669d69e6b87201f1d8574eb213408b67366302288b49f46acda1320164460daa50e6aac817d34ae3b1c256a03f4ebba
+  languageName: node
+  linkType: hard
+
+"jss-plugin-props-sort@npm:^10.10.0":
+  version: 10.10.0
+  resolution: "jss-plugin-props-sort@npm:10.10.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.3.1"
+    jss: "npm:10.10.0"
+  checksum: 10c0/5579bb21bfe514c12f43bd5e57458badc37c8e5676a47109f45195466a3aed633c61609daef079622421ef7c902b8342d1f96578543fefcb729f0b8dcfd2fe37
+  languageName: node
+  linkType: hard
+
+"jss-plugin-rule-value-function@npm:^10.10.0":
+  version: 10.10.0
+  resolution: "jss-plugin-rule-value-function@npm:10.10.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.3.1"
+    jss: "npm:10.10.0"
+    tiny-warning: "npm:^1.0.2"
+  checksum: 10c0/678bedb49da3b5e93fc1971d691f7f3ad2d7cf15dfc220edab934b70c7571fc383a435371a687a8ae125ab5ccd7bada9712574620959a3d1cd961fbca1583c29
+  languageName: node
+  linkType: hard
+
+"jss-plugin-vendor-prefixer@npm:^10.10.0":
+  version: 10.10.0
+  resolution: "jss-plugin-vendor-prefixer@npm:10.10.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.3.1"
+    css-vendor: "npm:^2.0.8"
+    jss: "npm:10.10.0"
+  checksum: 10c0/e3ad2dfe93d126f722586782aebddcd68dc46c0ad59f99edd65e164ecbb6e4cad6ce85c874f90553fa5fec50c2fd2b1f5984abfc4e3dd49d24033bbc378a2e11
+  languageName: node
+  linkType: hard
+
+"jss@npm:10.10.0, jss@npm:^10.10.0":
+  version: 10.10.0
+  resolution: "jss@npm:10.10.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.3.1"
+    csstype: "npm:^3.0.2"
+    is-in-browser: "npm:^1.1.3"
+    tiny-warning: "npm:^1.0.2"
+  checksum: 10c0/aa5e743a3f40d6df05ae951c6913b6495ef42b3e9539f6875c32bf01c42ab405bd91038d6feca2ed5c67a2947111b0137213983089e2a310ee11fc563208ad61
   languageName: node
   linkType: hard
 
@@ -9676,6 +10956,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"linkifyjs@npm:^4.3.3":
+  version: 4.3.3
+  resolution: "linkifyjs@npm:4.3.3"
+  checksum: 10c0/0eac293927f1465d13625c8c67c83c50d7fda9137c255a4a2ff5970ea4e9ba57de4846b170326e54b9e4e82be24f3705572bc50773737be9b13af5f1e4577798
+  languageName: node
+  linkType: hard
+
 "livereload-js@npm:^3.3.1":
   version: 3.4.1
   resolution: "livereload-js@npm:3.4.1"
@@ -9745,6 +11032,13 @@ __metadata:
   version: 4.1.2
   resolution: "lodash.memoize@npm:4.1.2"
   checksum: 10c0/c8713e51eccc650422716a14cece1809cfe34bc5ab5e242b7f8b4e2241c2483697b971a604252807689b9dd69bfe3a98852e19a5b89d506b000b4187a1285df8
+  languageName: node
+  linkType: hard
+
+"lodash.sortby@npm:^4.7.0":
+  version: 4.7.0
+  resolution: "lodash.sortby@npm:4.7.0"
+  checksum: 10c0/fc48fb54ff7669f33bb32997cab9460757ee99fafaf72400b261c3e10fde21538e47d8cfcbe6a25a31bcb5b7b727c27d52626386fc2de24eb059a6d64a89cdf5
   languageName: node
   linkType: hard
 
@@ -11282,6 +12576,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"orderedmap@npm:^2.0.0":
+  version: 2.1.1
+  resolution: "orderedmap@npm:2.1.1"
+  checksum: 10c0/8d7d266659d1828937046e8b2a7b5f75914e0391db985da0ca75cd2246cccbf6d6f3a0886aa2034da15ee4923e8c45f95f8b588f575f535f0adecdefccc54634
+  languageName: node
+  linkType: hard
+
 "outvariant@npm:1.4.0":
   version: 1.4.0
   resolution: "outvariant@npm:1.4.0"
@@ -11474,7 +12775,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-scurry@npm:^2.0.2":
+"path-scurry@npm:^2.0.0, path-scurry@npm:^2.0.2":
   version: 2.0.2
   resolution: "path-scurry@npm:2.0.2"
   dependencies:
@@ -12525,7 +13826,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prop-types@npm:^15.5.10, prop-types@npm:^15.8.1":
+"prop-types@npm:^15.5.10, prop-types@npm:^15.6.2, prop-types@npm:^15.8.1":
   version: 15.8.1
   resolution: "prop-types@npm:15.8.1"
   dependencies:
@@ -12540,6 +13841,135 @@ __metadata:
   version: 7.1.0
   resolution: "property-information@npm:7.1.0"
   checksum: 10c0/e0fe22cff26103260ad0e82959229106563fa115a54c4d6c183f49d88054e489cc9f23452d3ad584179dc13a8b7b37411a5df873746b5e4086c865874bfa968e
+  languageName: node
+  linkType: hard
+
+"prosemirror-changeset@npm:^2.3.0":
+  version: 2.4.1
+  resolution: "prosemirror-changeset@npm:2.4.1"
+  dependencies:
+    prosemirror-transform: "npm:^1.0.0"
+  checksum: 10c0/ca6b6bab73809dbb8554cddc0a3af666db8bcfed57938314ce6b04b28e41ea355441eaadabcddd9c785727219ad3779534dfa6e33521f0d333e90788b8dc9e3c
+  languageName: node
+  linkType: hard
+
+"prosemirror-commands@npm:^1.6.2":
+  version: 1.7.1
+  resolution: "prosemirror-commands@npm:1.7.1"
+  dependencies:
+    prosemirror-model: "npm:^1.0.0"
+    prosemirror-state: "npm:^1.0.0"
+    prosemirror-transform: "npm:^1.10.2"
+  checksum: 10c0/4884ea7a66b79b51e72bb2ef358284d70e9a071deb4cbfab3dd8ee3449e9a0e34cb391d92f487c013d3716b823fc5568ad5e409a9444b3630ae0b87617c2fca1
+  languageName: node
+  linkType: hard
+
+"prosemirror-dropcursor@npm:^1.8.1":
+  version: 1.8.2
+  resolution: "prosemirror-dropcursor@npm:1.8.2"
+  dependencies:
+    prosemirror-state: "npm:^1.0.0"
+    prosemirror-transform: "npm:^1.1.0"
+    prosemirror-view: "npm:^1.1.0"
+  checksum: 10c0/c3d9e456a64fecc77a6e6a0350116598550dee8cb55f74e8b66fdb26150c48340ddd1f43184134b24d0f2e710b6879ff6ec72c215dc618a6a673320a91c90478
+  languageName: node
+  linkType: hard
+
+"prosemirror-gapcursor@npm:^1.3.2":
+  version: 1.4.1
+  resolution: "prosemirror-gapcursor@npm:1.4.1"
+  dependencies:
+    prosemirror-keymap: "npm:^1.0.0"
+    prosemirror-model: "npm:^1.0.0"
+    prosemirror-state: "npm:^1.0.0"
+    prosemirror-view: "npm:^1.0.0"
+  checksum: 10c0/1719ef91274d0f76f6c5e667d839aae0576e38b1fc08e178425fa076821ef3da88ebd0fe40049d7dd157aa224672270e569f032316de9de588a1baabcfe802f1
+  languageName: node
+  linkType: hard
+
+"prosemirror-history@npm:^1.4.1":
+  version: 1.5.0
+  resolution: "prosemirror-history@npm:1.5.0"
+  dependencies:
+    prosemirror-state: "npm:^1.2.2"
+    prosemirror-transform: "npm:^1.0.0"
+    prosemirror-view: "npm:^1.31.0"
+    rope-sequence: "npm:^1.3.0"
+  checksum: 10c0/9f24c99316c30a52ff40ddd59fc83b5180f1326ee6f466bfa82b847a503b0cdff234c35d5e3decb39ae1382a189ceec7462333ed7d6c34e2c95921892bb98b78
+  languageName: node
+  linkType: hard
+
+"prosemirror-keymap@npm:^1.0.0, prosemirror-keymap@npm:^1.2.2, prosemirror-keymap@npm:^1.2.3":
+  version: 1.2.3
+  resolution: "prosemirror-keymap@npm:1.2.3"
+  dependencies:
+    prosemirror-state: "npm:^1.0.0"
+    w3c-keyname: "npm:^2.2.0"
+  checksum: 10c0/0ec2f8bd9b608d0e6a0cdab1d66f9a6b41edcff0239b32ccca1018a0733e52448e4758218a2d472fb8c33c1609426dc6bad4944b28c1c3d509a83201a23035e9
+  languageName: node
+  linkType: hard
+
+"prosemirror-model@npm:^1.0.0, prosemirror-model@npm:^1.20.0, prosemirror-model@npm:^1.21.0, prosemirror-model@npm:^1.24.1, prosemirror-model@npm:^1.25.4":
+  version: 1.25.7
+  resolution: "prosemirror-model@npm:1.25.7"
+  dependencies:
+    orderedmap: "npm:^2.0.0"
+  checksum: 10c0/c41b3c597a4024dc18f4117a6d3908fb0a9dd143c4d382845654bb8f574acc0445845c1707049556e592f5406654e2c5e9f9a22002f0b25859e8e44d36f52126
+  languageName: node
+  linkType: hard
+
+"prosemirror-schema-list@npm:^1.5.0":
+  version: 1.5.1
+  resolution: "prosemirror-schema-list@npm:1.5.1"
+  dependencies:
+    prosemirror-model: "npm:^1.0.0"
+    prosemirror-state: "npm:^1.0.0"
+    prosemirror-transform: "npm:^1.7.3"
+  checksum: 10c0/e6fd27446bc90556a9797f6ca0cb54e7db53cc7c20fbf633b7d0f4709c45accfa2f3a0f6575fe47aa83cb75781a9b773198d236a44db9d8eef2802a1501e4301
+  languageName: node
+  linkType: hard
+
+"prosemirror-state@npm:^1.0.0, prosemirror-state@npm:^1.2.2, prosemirror-state@npm:^1.4.3, prosemirror-state@npm:^1.4.4":
+  version: 1.4.4
+  resolution: "prosemirror-state@npm:1.4.4"
+  dependencies:
+    prosemirror-model: "npm:^1.0.0"
+    prosemirror-transform: "npm:^1.0.0"
+    prosemirror-view: "npm:^1.27.0"
+  checksum: 10c0/1428636a37c127afe0d11a4f4eb44d75a7f16717940405082bd16fa4c28cfeef9375d49f48e411e5f0fa26f3e5798af7f270edc9bc9b0e647df8bb79983bcd59
+  languageName: node
+  linkType: hard
+
+"prosemirror-tables@npm:^1.6.4":
+  version: 1.8.5
+  resolution: "prosemirror-tables@npm:1.8.5"
+  dependencies:
+    prosemirror-keymap: "npm:^1.2.3"
+    prosemirror-model: "npm:^1.25.4"
+    prosemirror-state: "npm:^1.4.4"
+    prosemirror-transform: "npm:^1.10.5"
+    prosemirror-view: "npm:^1.41.4"
+  checksum: 10c0/d6e8cd9d333987ce6492202d5f815b268bb9a722d81456628eff999444d44fa97e8a801a5a20a44e678892f37053f314885d5a03e1df834653e3ea455f0f9290
+  languageName: node
+  linkType: hard
+
+"prosemirror-transform@npm:^1.0.0, prosemirror-transform@npm:^1.1.0, prosemirror-transform@npm:^1.10.2, prosemirror-transform@npm:^1.10.5, prosemirror-transform@npm:^1.7.3":
+  version: 1.12.0
+  resolution: "prosemirror-transform@npm:1.12.0"
+  dependencies:
+    prosemirror-model: "npm:^1.21.0"
+  checksum: 10c0/e9e94fbb36fa53badc73d27833bac834835246f28a6176fb33c65a85c9025da0c08ac503f860898591a14fcacef58ba18a29e8df5a916cf376084bc17f324753
+  languageName: node
+  linkType: hard
+
+"prosemirror-view@npm:^1.0.0, prosemirror-view@npm:^1.1.0, prosemirror-view@npm:^1.27.0, prosemirror-view@npm:^1.31.0, prosemirror-view@npm:^1.38.1, prosemirror-view@npm:^1.41.4":
+  version: 1.41.8
+  resolution: "prosemirror-view@npm:1.41.8"
+  dependencies:
+    prosemirror-model: "npm:^1.20.0"
+    prosemirror-state: "npm:^1.0.0"
+    prosemirror-transform: "npm:^1.1.0"
+  checksum: 10c0/fae3947fec39e2b274bd10e46a2f3b671708e133dc2cc1fb2af0bd97576abd941bbdcc9dc240adf8b34dd0420a020a4006293450fc9c76e2578dba65de6dd9dc
   languageName: node
   linkType: hard
 
@@ -12741,7 +14171,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-is@npm:^16.13.1":
+"react-is@npm:^16.13.1, react-is@npm:^16.7.0":
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
   checksum: 10c0/33977da7a5f1a287936a0c85639fec6ca74f4f15ef1e59a6bc20338fc73dc69555381e211f7a3529b8150a1f71e4225525b41b60b52965bda53ce7d47377ada1
@@ -12752,6 +14182,13 @@ __metadata:
   version: 17.0.2
   resolution: "react-is@npm:17.0.2"
   checksum: 10c0/2bdb6b93fbb1820b024b496042cce405c57e2f85e777c9aabd55f9b26d145408f9f74f5934676ffdc46f3dcff656d78413a6e43968e7b3f92eea35b3052e9053
+  languageName: node
+  linkType: hard
+
+"react-is@npm:^19.0.0":
+  version: 19.2.6
+  resolution: "react-is@npm:19.2.6"
+  checksum: 10c0/263177f370fc156b279d22570dd6e922a0ad641a4a426a4cb70284b8003b00ef532d59f2beca1d22a1ca0b37f85f9077d7733ca5d344ebecd2942e9bc2a2a3c0
   languageName: node
   linkType: hard
 
@@ -12839,6 +14276,21 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/841938ff16d16a6b76895f4cb2e1fea957e5fe3b30febbf03a54892dae1c9153f2383e231dea0b3ba41192ad2f2849448fa859caccd288943bce32639e971bee
+  languageName: node
+  linkType: hard
+
+"react-transition-group@npm:^4.4.5":
+  version: 4.4.5
+  resolution: "react-transition-group@npm:4.4.5"
+  dependencies:
+    "@babel/runtime": "npm:^7.5.5"
+    dom-helpers: "npm:^5.0.1"
+    loose-envify: "npm:^1.4.0"
+    prop-types: "npm:^15.6.2"
+  peerDependencies:
+    react: ">=16.6.0"
+    react-dom: ">=16.6.0"
+  checksum: 10c0/2ba754ba748faefa15f87c96dfa700d5525054a0141de8c75763aae6734af0740e77e11261a1e8f4ffc08fd9ab78510122e05c21c2d79066c38bb6861a886c82
   languageName: node
   linkType: hard
 
@@ -13331,6 +14783,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rimraf@npm:6.0.1":
+  version: 6.0.1
+  resolution: "rimraf@npm:6.0.1"
+  dependencies:
+    glob: "npm:^11.0.0"
+    package-json-from-dist: "npm:^1.0.0"
+  bin:
+    rimraf: dist/esm/bin.mjs
+  checksum: 10c0/b30b6b072771f0d1e73b4ca5f37bb2944ee09375be9db5f558fcd3310000d29dfcfa93cf7734d75295ad5a7486dc8e40f63089ced1722a664539ffc0c3ece8c6
+  languageName: node
+  linkType: hard
+
 "rimraf@npm:6.1.3":
   version: 6.1.3
   resolution: "rimraf@npm:6.1.3"
@@ -13567,6 +15031,13 @@ __metadata:
   bin:
     rollup: dist/bin/rollup
   checksum: 10c0/48d3f2216b5533639b007e6756e2275c7f594e45adee21ce03674aa2e004406c661f8b86c7a0b471c9e889c6a9efbb29240ca0b7673c50e391406c490c309833
+  languageName: node
+  linkType: hard
+
+"rope-sequence@npm:^1.3.0":
+  version: 1.3.4
+  resolution: "rope-sequence@npm:1.3.4"
+  checksum: 10c0/caa90be3d7a7cad155fb354a4679a1280dc9819c81bd319542a0d893a64e152284abb9cc1631d4351b328016a8d6c35a48c912234edfaf5173daef44b2e3609b
   languageName: node
   linkType: hard
 
@@ -13998,6 +15469,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"source-map@npm:0.8.0-beta.0":
+  version: 0.8.0-beta.0
+  resolution: "source-map@npm:0.8.0-beta.0"
+  dependencies:
+    whatwg-url: "npm:^7.0.0"
+  checksum: 10c0/fb4d9bde9a9fdb2c29b10e5eae6c71d10e09ef467e1afb75fdec2eb7e11fa5b343a2af553f74f18b695dbc0b81f9da2e9fa3d7a317d5985e9939499ec6087835
+  languageName: node
+  linkType: hard
+
 "source-map@npm:^0.6.0, source-map@npm:^0.6.1":
   version: 0.6.1
   resolution: "source-map@npm:0.6.1"
@@ -14422,6 +15902,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"stylis@npm:4.2.0":
+  version: 4.2.0
+  resolution: "stylis@npm:4.2.0"
+  checksum: 10c0/a7128ad5a8ed72652c6eba46bed4f416521bc9745a460ef5741edc725252cebf36ee45e33a8615a7057403c93df0866ab9ee955960792db210bb80abd5ac6543
+  languageName: node
+  linkType: hard
+
 "sucrase@npm:^3.35.0":
   version: 3.35.1
   resolution: "sucrase@npm:3.35.1"
@@ -14654,6 +16141,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tiny-warning@npm:^1.0.2":
+  version: 1.0.3
+  resolution: "tiny-warning@npm:1.0.3"
+  checksum: 10c0/ef8531f581b30342f29670cb41ca248001c6fd7975ce22122bd59b8d62b4fc84ad4207ee7faa95cde982fa3357cd8f4be650142abc22805538c3b1392d7084fa
+  languageName: node
+  linkType: hard
+
 "tinycolor2@npm:^1.4.1":
   version: 1.6.0
   resolution: "tinycolor2@npm:1.6.0"
@@ -14691,6 +16185,15 @@ __metadata:
   version: 1.0.1
   resolution: "toidentifier@npm:1.0.1"
   checksum: 10c0/93937279934bd66cc3270016dd8d0afec14fb7c94a05c72dc57321f8bd1fa97e5bea6d1f7c89e728d077ca31ea125b78320a616a6c6cd0e6b9cb94cb864381c1
+  languageName: node
+  linkType: hard
+
+"tr46@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "tr46@npm:1.0.1"
+  dependencies:
+    punycode: "npm:^2.1.0"
+  checksum: 10c0/41525c2ccce86e3ef30af6fa5e1464e6d8bb4286a58ea8db09228f598889581ef62347153f6636cd41553dc41685bdfad0a9d032ef58df9fbb0792b3447d0f04
   languageName: node
   linkType: hard
 
@@ -14749,6 +16252,48 @@ __metadata:
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62
+  languageName: node
+  linkType: hard
+
+"tsup@npm:8.5.0":
+  version: 8.5.0
+  resolution: "tsup@npm:8.5.0"
+  dependencies:
+    bundle-require: "npm:^5.1.0"
+    cac: "npm:^6.7.14"
+    chokidar: "npm:^4.0.3"
+    consola: "npm:^3.4.0"
+    debug: "npm:^4.4.0"
+    esbuild: "npm:^0.25.0"
+    fix-dts-default-cjs-exports: "npm:^1.0.0"
+    joycon: "npm:^3.1.1"
+    picocolors: "npm:^1.1.1"
+    postcss-load-config: "npm:^6.0.1"
+    resolve-from: "npm:^5.0.0"
+    rollup: "npm:^4.34.8"
+    source-map: "npm:0.8.0-beta.0"
+    sucrase: "npm:^3.35.0"
+    tinyexec: "npm:^0.3.2"
+    tinyglobby: "npm:^0.2.11"
+    tree-kill: "npm:^1.2.2"
+  peerDependencies:
+    "@microsoft/api-extractor": ^7.36.0
+    "@swc/core": ^1
+    postcss: ^8.4.12
+    typescript: ">=4.5.0"
+  peerDependenciesMeta:
+    "@microsoft/api-extractor":
+      optional: true
+    "@swc/core":
+      optional: true
+    postcss:
+      optional: true
+    typescript:
+      optional: true
+  bin:
+    tsup: dist/cli-default.js
+    tsup-node: dist/cli-node.js
+  checksum: 10c0/2eddc1138ad992a2e67d826e92e0b0c4f650367355866c77df8368ade9489e0a8bf2b52b352e97fec83dc690af05881c29c489af27acb86ac2cef38b0d029087
   languageName: node
   linkType: hard
 
@@ -15251,7 +16796,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"use-sync-external-store@npm:^1.5.0":
+"use-sync-external-store@npm:^1.4.0, use-sync-external-store@npm:^1.5.0":
   version: 1.6.0
   resolution: "use-sync-external-store@npm:1.6.0"
   peerDependencies:
@@ -15403,7 +16948,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"w3c-keyname@npm:^2.2.4":
+"w3c-keyname@npm:^2.2.0, w3c-keyname@npm:^2.2.4":
   version: 2.2.8
   resolution: "w3c-keyname@npm:2.2.8"
   checksum: 10c0/37cf335c90efff31672ebb345577d681e2177f7ff9006a9ad47c68c5a9d265ba4a7b39d6c2599ceea639ca9315584ce4bd9c9fbf7a7217bfb7a599e71943c4c4
@@ -15430,6 +16975,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"webidl-conversions@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "webidl-conversions@npm:4.0.2"
+  checksum: 10c0/def5c5ac3479286dffcb604547628b2e6b46c5c5b8a8cfaa8c71dc3bafc85859bde5fbe89467ff861f571ab38987cf6ab3d6e7c80b39b999e50e803c12f3164f
+  languageName: node
+  linkType: hard
+
 "whatwg-encoding@npm:^3.1.1":
   version: 3.1.1
   resolution: "whatwg-encoding@npm:3.1.1"
@@ -15443,6 +16995,17 @@ __metadata:
   version: 4.0.0
   resolution: "whatwg-mimetype@npm:4.0.0"
   checksum: 10c0/a773cdc8126b514d790bdae7052e8bf242970cebd84af62fb2f35a33411e78e981f6c0ab9ed1fe6ec5071b09d5340ac9178e05b52d35a9c4bcf558ba1b1551df
+  languageName: node
+  linkType: hard
+
+"whatwg-url@npm:^7.0.0":
+  version: 7.1.0
+  resolution: "whatwg-url@npm:7.1.0"
+  dependencies:
+    lodash.sortby: "npm:^4.7.0"
+    tr46: "npm:^1.0.1"
+    webidl-conversions: "npm:^4.0.2"
+  checksum: 10c0/2785fe4647690e5a0225a79509ba5e21fdf4a71f9de3eabdba1192483fe006fc79961198e0b99f82751557309f17fc5a07d4d83c251aa5b2f85ba71e674cbee9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Adds a new `@filigran/rich-text-editor` package to the monorepo — a TipTap-based rich text editor with MUI toolbar.

## Changes

### New package `packages/filigran-rich-text-editor`
- `RichTextEditor` component with full TipTap editor + MUI toolbar
- All TipTap extensions bundled (color, highlight, image, table, task list, typography, etc.)
- Custom extensions: `FontSize`, `Paragraph`, `Table`, `TableCell`, `TableCellSplit`, `TableHeader`, `TaskList`, `TaskListItem`, `TextStyle`, `ImageWithOptions`, `PageBreak`
- CSS styles exported via `@filigran/rich-text-editor/styles.css`