### PR TITLE
[filigran-ui] - feat(Multiselect): add the possibility to filter from server side

### DIFF
--- a/packages/filigran-ui/src/components/clients/multi-select.tsx
+++ b/packages/filigran-ui/src/components/clients/multi-select.tsx
@@ -46,6 +46,7 @@ interface MultiSelectFormFieldProps<
   options: T[]
   keyLabel?: keyof T
   keyValue?: keyof T
+  shouldFilter?: boolean
   defaultValue?: string[]
   disabled?: boolean
   placeholder: string
@@ -67,6 +68,7 @@ const MultiSelectFormField = React.forwardRef<
       options,
       keyLabel = 'label',
       keyValue = 'value',
+      shouldFilter=true,
       defaultValue,
       onValueChange,
       onInputChange,
@@ -324,7 +326,8 @@ const MultiSelectFormField = React.forwardRef<
             className="w-[300px] p-0 drop-shadow-xs"
             align="start"
             onEscapeKeyDown={() => setIsPopoverOpen(false)}>
-            <Command onChange={handleSearchInputChange}>
+            {/*ShouldFilter use to filter on client side or server side*/}
+            <Command onChange={handleSearchInputChange} shouldFilter={shouldFilter}>
               <CommandInput
                 placeholder="Search..."
                 onKeyDown={handleInputKeyDown}


### PR DESCRIPTION
Everything is in the title ! 
In the case we want to refresh options with a refetch from backend, the options were not updated. This flag allow the dev to filter from the client side (if true, by default)/server side (if false)