### PR TITLE
fix(chatbot): render nested code fences inside a markdown block as one block (#288)

### DIFF
--- a/packages/filigran-chatbot/src/components/MarkdownMessage.tsx
+++ b/packages/filigran-chatbot/src/components/MarkdownMessage.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { CheckIcon, CopyIcon } from './icons';
+import { hardenNestedCodeFences } from '../utils';
 
 interface MarkdownMessageProps {
   content: string;
@@ -108,7 +109,7 @@ export const MarkdownMessage = ({ content, onRelativeLinkClick }: MarkdownMessag
         ),
       }}
     >
-      {content}
+      {hardenNestedCodeFences(content)}
     </Markdown>
   );
 };

--- a/packages/filigran-chatbot/src/utils/index.ts
+++ b/packages/filigran-chatbot/src/utils/index.ts
@@ -5,6 +5,63 @@ export function hexAlpha(hex: string, alpha: number): string {
   return `${hex}${a}`;
 }
 
+/**
+ * Markdown has no native support for nesting fenced code blocks of the same
+ * length: per the CommonMark spec, the first inner ``` closes the outer block,
+ * so everything after it renders *outside* the code block. LLMs constantly hit
+ * this — when an agent shows a prompt or a full markdown document inside a
+ * ```markdown … ``` fence, that document's own ``` fences shatter the snippet
+ * into alternating code / prose fragments.
+ *
+ * The robust, spec-compliant fix is to make the *outer* fence longer than any
+ * fence it contains: a 4-backtick fence is only closed by a run of ≥4
+ * backticks, so all inner 3-backtick fences become literal content and the
+ * whole document renders as one clean, copyable code block.
+ *
+ * We act only on the unambiguous, dominant case — a 3-backtick opener whose
+ * info string is a markup language (markdown / md / mdx / markup) that actually
+ * contains nested fences — so already-correct markdown is never rewritten
+ * (a correctly authored nested block already uses a 4+-backtick opener, which
+ * we skip).
+ */
+export function hardenNestedCodeFences(raw: string): string {
+  if (!raw) return raw;
+  const lines = raw.split('\n');
+  const fenceRe = /^(\s*)(`{3,})(.*)$/;
+  const markupLang = /^(markdown|md|mdx|markup)\b/i;
+
+  let openerIdx = -1;
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(fenceRe);
+    if (m && m[2].length === 3 && markupLang.test(m[3].trim())) {
+      openerIdx = i;
+      break;
+    }
+  }
+  if (openerIdx === -1) return raw;
+
+  let maxRun = 3;
+  let nestedCount = 0;
+  let lastBareFence = -1;
+  for (let i = openerIdx + 1; i < lines.length; i++) {
+    const m = lines[i].match(fenceRe);
+    if (!m) continue;
+    nestedCount++;
+    maxRun = Math.max(maxRun, m[2].length);
+    if (m[3].trim() === '') lastBareFence = i;
+  }
+  if (nestedCount === 0) return raw;
+
+  const fence = '`'.repeat(Math.max(maxRun + 1, 4));
+  const om = lines[openerIdx].match(fenceRe)!;
+  lines[openerIdx] = `${om[1]}${fence}${om[3]}`;
+  if (lastBareFence > openerIdx) {
+    const cm = lines[lastBareFence].match(fenceRe)!;
+    lines[lastBareFence] = `${cm[1]}${fence}`;
+  }
+  return lines.join('\n');
+}
+
 export const identity = (key: string) => key;
 
 /** Matches a complete `[[FILE:<id>]]` deliverable marker agents embed in prose. */


### PR DESCRIPTION
## Summary

Fixes broken rendering in the chatbot panel (`@filigran/chatbot`, used by OpenCTI & OpenAEV "Ask Ariane") when an assistant message wraps a markdown document inside a fenced code block and that document contains its own ` ``` ` fences.

Markdown/CommonMark cannot nest fenced code blocks of the same length — the first inner ` ``` ` closes the outer block, so everything after it spills out and the snippet shatters into alternating code / prose fragments. This is extremely common with LLM output ("here is the refined prompt / full markdown file…").

The fix pre-processes the content to make the **outer fence longer than any fence it contains** (a 4-backtick fence is only closed by a run of ≥4 backticks), the same spec-compliant approach used by [OpenAI ChatKit](https://github.com/openai/chatkit-js/issues/89) and [Vercel Streamdown](https://streamdown.ai/docs/termination). It only touches the unambiguous case — a 3-backtick `markdown` / `md` / `mdx` opener that actually contains nested fences — so already-correct markdown (e.g. a properly authored 4-backtick block, plain prose, or a single non-markup block) is never rewritten.

## Changes

- `packages/filigran-chatbot/src/utils/index.ts` — new `hardenNestedCodeFences()` helper.
- `packages/filigran-chatbot/src/components/MarkdownMessage.tsx` — apply it to the message content before rendering.

## Behaviour

Before: `` ```markdown `` doc with inner fences → outer block closes early, remainder renders as prose.

After: the whole document renders as one clean, copyable code block; inner fences are shown verbatim; any trailing prose after the block is preserved outside it.

## Test plan

- [x] `tsc --noEmit` compiles the changed sources cleanly.
- [x] `prettier --check` passes on both changed files.
- [x] `yarn build` (rollup) produces `dist/` successfully.
- [x] Standalone logic check: screenshot scenario collapses to a single block; negative cases (4-backtick nesting, plain prose, single `json` block) are left untouched.
- [ ] Visual check in OpenCTI / OpenAEV chat after a `@filigran/chatbot` version bump.

Closes #288
