### PR TITLE
chore(renovate): emit Conventional Commits titles (#294)

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,13 +1,13 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
+    ":semanticCommits",
     "config:recommended"
   ],
   "labels": [
     "dependencies",
     "filigran team"
   ],
-  "commitMessagePrefix": "[deps]",
   "minimumReleaseAge": "3 days",
   "prHourlyLimit": 2,
   "prConcurrentLimit": 100,


### PR DESCRIPTION
## Summary

Renovate now emits Conventional Commits titles (`chore(deps): ...`) instead of the old `[deps]` bracket prefix.

Closes #294