### PR TITLE
fix(chatbot): settle the reasoning window UX and handle stream_retract (#312)

### DIFF
--- a/packages/filigran-chatbot/src/components/ChatMessages.tsx
+++ b/packages/filigran-chatbot/src/components/ChatMessages.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import type { AgentStatusState, ChatAttachment, ChatMessage } from '../types';
 import { splitFileMarkers } from '../utils';
 import { DownloadIcon, FileIcon, InfoIcon } from './icons';
-import { ChatThinking, ThinkingTextBubble } from './ChatThinking';
+import { ChatThinking } from './ChatThinking';
 import { MarkdownMessage } from './MarkdownMessage';
 
 interface ChatMessagesProps {
@@ -208,8 +208,6 @@ export const ChatMessages = ({ messages, isLoading, agentStatus, agentName, logo
                 <span className="font-semibold text-xs text-gray-900 dark:text-white">{agentName}</span>
               </div>
             )}
-
-            {isAssistant && !isEmpty && isStreamingMessage && agentStatus?.thinkingContent && <ThinkingTextBubble content={agentStatus.thinkingContent} />}
 
             {!isAssistant && ((msg.files?.length ?? 0) > 0 || (msg.attachments?.length ?? 0) > 0) && (
               <div className="flex gap-1.5 flex-wrap mb-1.5 justify-end">{buildUserFileBlocks(msg)}</div>

--- a/packages/filigran-chatbot/src/components/ChatThinking.tsx
+++ b/packages/filigran-chatbot/src/components/ChatThinking.tsx
@@ -129,21 +129,30 @@ function cleanReasoningText(text: string): string {
     .trim();
 }
 
+/** A scroll position within this distance of the bottom counts as "pinned". */
+const REASONING_PIN_THRESHOLD_PX = 24;
+
 /**
- * Cursor-style reasoning pane: smaller, lighter text inside a capped-height
- * window that stays pinned to the newest line while tokens stream in, with
- * a soft fade at the top so older reasoning appears to scroll away — framed
- * by the signature breathing accent left-border glow.
+ * Reasoning window — the model's reasoning prose rendered below the status
+ * bubble while the agent works: smaller, dimmed text inside a capped-height
+ * (max-h-40) scrolling window pinned to the newest line, with a Cursor-style
+ * top dissolve once full (soft gradient fade at the top only — the text reads
+ * as scrolling up and dissolving; the bottom stays sharp) — framed by the
+ * breathing accent left-border glow.  Scrolling up detaches the pin so
+ * earlier reasoning can be read while tokens keep streaming; scrolling back
+ * to the bottom re-pins.  The window (and the status bubble above it)
+ * disappears the moment the final answer starts flowing.
  */
 export function ThinkingTextBubble({ content }: { content: string }) {
   const ref = useRef<HTMLDivElement>(null);
   const [isOverflowing, setIsOverflowing] = useState(false);
+  const pinnedRef = useRef(true);
   const cleaned = cleanReasoningText(content);
 
   useEffect(() => {
     const el = ref.current;
     if (!el) return;
-    el.scrollTop = el.scrollHeight;
+    if (pinnedRef.current) el.scrollTop = el.scrollHeight;
     setIsOverflowing(el.scrollHeight > el.clientHeight + 1);
   }, [cleaned]);
 
@@ -156,8 +165,15 @@ export function ThinkingTextBubble({ content }: { content: string }) {
     >
       <div
         ref={ref}
+        onScroll={() => {
+          const el = ref.current;
+          if (!el) return;
+          pinnedRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < REASONING_PIN_THRESHOLD_PX;
+        }}
         className={`max-h-40 overflow-y-auto overscroll-contain [scrollbar-width:none] [&::-webkit-scrollbar]:hidden${
-          isOverflowing ? ' [mask-image:linear-gradient(to_bottom,transparent_0,black_3rem)]' : ''
+          isOverflowing
+            ? ' [mask-image:linear-gradient(to_bottom,transparent_0,rgb(0_0_0/0.25)_1.5rem,rgb(0_0_0/0.7)_3rem,black_4.5rem)]'
+            : ''
         }`}
       >
         <p className="m-0 whitespace-pre-wrap break-words text-xs leading-5 text-gray-500 dark:text-white/45">{cleaned}</p>

--- a/packages/filigran-chatbot/src/hooks/useChat.ts
+++ b/packages/filigran-chatbot/src/hooks/useChat.ts
@@ -450,19 +450,18 @@ export function useChat({
             switch (parsed.action) {
               case 'status': {
                 if (parsed.status === 'tool_start') hasUsedToolsRef.current = true;
-                // Text streamed before a tool call (or a new loop iteration)
-                // is the model thinking out loud, not the final answer.
-                // Fold it into the reasoning pane so it shrinks into the
-                // dimmed thinking window instead of streaming at full size
-                // and then abruptly vanishing when the real answer starts.
-                const isIterationBoundary =
-                  parsed.status === 'tool_start' || parsed.status === 'thinking' || parsed.status === 'analyzing';
-                const folded = isIterationBoundary && accumulated.trim() ? accumulated : '';
-                if (folded) {
+                if (parsed.status === 'stream_retract') {
+                  // Rare: text that streamed as a provisional answer turned
+                  // out to precede tool calls — discard the answer bubble
+                  // (the text re-arrives as thinking_text right after, so it
+                  // lands in the reasoning window instead).
                   accumulated = '';
                   setMessages((prev) => prev.map((m) => (m.id === assistantId ? { ...m, content: '' } : m)));
-                }
-                if (parsed.status === 'thinking_text') {
+                  setAgentStatus((prev) => ({
+                    status: 'analyzing',
+                    thinkingContent: prev?.thinkingContent,
+                  }));
+                } else if (parsed.status === 'thinking_text') {
                   setAgentStatus((prev) => ({
                     ...prev,
                     status: prev?.status ?? 'thinking',
@@ -472,9 +471,7 @@ export function useChat({
                   setAgentStatus((prev) => ({
                     status: parsed.status,
                     tools: parsed.tools,
-                    thinkingContent: folded
-                      ? (prev?.thinkingContent ? `${prev.thinkingContent}\n\n` : '') + folded
-                      : prev?.thinkingContent,
+                    thinkingContent: prev?.thinkingContent,
                   }));
                 }
                 break;


### PR DESCRIPTION
## Summary

Closes #312

Settles the chatbot reasoning display on the standard AI-chat UX (pairs with XTM-One-Platform/xtm-one#1560):

- Reasoning window: small dimmed text in a capped-height (max-h-40) scrolling window pinned to the newest line, with a Cursor-style top dissolve once full (soft gradient fade at the top only - the text reads as scrolling up and dissolving; the bottom stays sharp). Scrolling up detaches the pin so earlier reasoning can be read while tokens keep streaming; scrolling back re-pins.
- The status bubble and the reasoning window now disappear together the moment the final answer starts flowing - reasoning never renders inside the answer area and the answer never renders inside the reasoning window (the ThinkingTextBubble rendered above streaming content was removed).
- New stream_retract event handled: text that streamed as a provisional answer but turned out to precede tool calls is discarded from the answer bubble and re-arrives as thinking_text in the reasoning window (the XTM One agent loop now holds back the first ~350 chars of stream-with-tools text so this is a rare path).
- The interim fold heuristic in useChat is removed - superseded by the backend hold-back window.

## Test plan

- [x] yarn build + tsc pass
- [ ] OpenCTI/OpenAEV embedded chat against an XTM One backend with the hold-back change: preambles appear only in the reasoning window, the window scrolls with the top dissolve, and both indicators disappear when the answer streams
- [ ] Verify light and dark mode rendering of the fade and glow
