### PR TITLE
style(chatbot): add breathing room between the status bubble and the reasoning window (#312)

### DIFF
--- a/packages/filigran-chatbot/src/components/ChatThinking.tsx
+++ b/packages/filigran-chatbot/src/components/ChatThinking.tsx
@@ -160,7 +160,7 @@ export function ThinkingTextBubble({ content }: { content: string }) {
 
   return (
     <div
-      className="ml-11 max-w-[75%] rounded-md border-l-2 bg-[var(--chat-accent)]/[0.03] py-2 pl-3 pr-3"
+      className="ml-11 mt-2.5 max-w-[75%] rounded-md border-l-2 bg-[var(--chat-accent)]/[0.03] py-2 pl-3 pr-3"
       style={{ animation: 'reasoningGlow 3s ease-in-out infinite, chat-fade-in 0.5s ease-out' }}
     >
       <div


### PR DESCRIPTION
Follow-up to #312 / #313. The reasoning window rendered flush against the status bubble in the embedded chats (status row and window share one wrapper, so the parent's gap does not apply between them). Adds mt-2.5 so the window breathes below the bubble, matching the XTM One web chat spacing.