### PR TITLE
fix(chatbot): flip header tooltips below the anchor when the host top bar would hide them (#320)

### DIFF
--- a/packages/filigran-chatbot/src/components/Tooltip.tsx
+++ b/packages/filigran-chatbot/src/components/Tooltip.tsx
@@ -6,6 +6,10 @@ interface TooltipProps {
   children: React.ReactElement;
 }
 
+// Approximate rendered tooltip height (text-xs + py-1) plus the 4px gap.
+// Used to decide whether a top-placed tooltip would overflow the panel.
+const TOOLTIP_CLEARANCE = 28;
+
 function findChatbotRoot(el: HTMLElement | null): HTMLElement {
   let node = el;
   while (node) {
@@ -19,14 +23,23 @@ export const Tooltip = ({ title, children }: TooltipProps) => {
   const ref = useRef<HTMLSpanElement>(null);
   const [show, setShow] = useState(false);
   const [pos, setPos] = useState({ top: 0, left: 0 });
+  const [below, setBelow] = useState(false);
 
   if (!title) return children;
 
   const handleEnter = () => {
     if (!ref.current) return;
     const rect = ref.current.getBoundingClientRect();
+    // Flip below the anchor when a top-placed tooltip would extend above the
+    // chatbot panel's top edge. The tooltip lives inside the panel's stacking
+    // context (z-[1200] in sidebar mode), so anything drawn above the panel
+    // lands in the host app's top-bar zone and is hidden whenever the host
+    // bar stacks higher (e.g. OpenAEV's AppBar at theme.zIndex.drawer + 1).
+    const rootTop = findChatbotRoot(ref.current).getBoundingClientRect().top;
+    const flip = rect.top - rootTop < TOOLTIP_CLEARANCE;
+    setBelow(flip);
     setPos({
-      top: rect.top - 4,
+      top: flip ? rect.bottom + 4 : rect.top - 4,
       left: rect.left + rect.width / 2,
     });
     setShow(true);
@@ -38,7 +51,7 @@ export const Tooltip = ({ title, children }: TooltipProps) => {
       {show &&
         createPortal(
           <span
-            className="pointer-events-none fixed z-[10001] -translate-x-1/2 -translate-y-full whitespace-nowrap rounded-md bg-gray-900 dark:bg-gray-100 px-2 py-1 text-xs text-white dark:text-gray-900 shadow-lg"
+            className={`pointer-events-none fixed z-[10001] -translate-x-1/2 ${below ? '' : '-translate-y-full'} whitespace-nowrap rounded-md bg-gray-900 dark:bg-gray-100 px-2 py-1 text-xs text-white dark:text-gray-900 shadow-lg`}
             style={{ top: pos.top, left: pos.left }}
             role="tooltip"
           >


### PR DESCRIPTION
## Summary

- Fixes #320
- The chatbot header tooltips (Conversation history, New chat, Switch view, Close) render above their trigger, i.e. into the host app's top bar zone (the sidebar panel starts at `top: topOffset`, right under the bar). Since the tooltip is portaled inside the panel root (`z-[1200]`), its local `z-[10001]` cannot beat a host top bar that stacks higher: visible in OpenCTI (`TopBar` at `theme.zIndex.drawer - 1` = 1199) but completely hidden in OpenAEV (`TopBar` at `theme.zIndex.drawer + 1` = 1201).
- `Tooltip.tsx` now flips the tooltip below the anchor whenever a top-placed tooltip would extend above the chatbot panel's top edge, so it always stays inside the panel bounds and never depends on the host's top-bar stacking order. Tooltips elsewhere in the panel keep the existing top placement.

## Test plan

- [ ] In OpenAEV (TopBar above the panel), hover the header icons in sidebar mode: tooltips now appear below the buttons and are fully visible
- [ ] In OpenCTI, hover the same icons: tooltips appear below the buttons, fully visible
- [ ] In floating/fullscreen modes, hover header icons: tooltip flips below near the panel top edge, unchanged elsewhere
- [ ] Tooltips on elements further down the panel still render above the anchor
