### PR TITLE
feat(chatbot): open reasoning details in a dialog matching the XTM One web chat (#322)

### DIFF
--- a/packages/filigran-chatbot/README.md
+++ b/packages/filigran-chatbot/README.md
@@ -256,13 +256,29 @@ data: {"type": "status", "status": "analyzing"}
 data: {"type": "status", "status": "streaming"}
 data: {"type": "stream", "content": "The weather "}
 data: {"type": "stream", "content": "today is sunny."}
-data: {"type": "done", "content": "The weather today is sunny.", "conversation_id": "new-uuid", "tool_names": ["search_web"], "tool_call_count": 1, "iterations": 1, "reasoning": "Let me check the weather data first."}
+data: {"type": "done", "content": "The weather today is sunny.", "conversation_id": "new-uuid", "tool_names": ["search_web"], "tool_call_count": 1, "iterations": 1, "reasoning": "Let me check the weather data first.", "tool_call_trace": [{"name": "search_web", "input": "{\"query\": \"weather\"}", "output": "Sunny, 24C", "success": true}], "transfer_chain": [{"agent_id": "uuid", "agent_name": "General"}], "is_truncated": false}
 ```
 
 The optional `reasoning` field on `done` (and on restored session messages)
 carries the accumulated model reasoning / pre-tool preamble prose for the
-turn. When present it is surfaced in the per-message reasoning-details panel
+turn. When present it is surfaced in the per-message reasoning-details dialog
 (the "i" button), mirroring the XTM One web chat.
+
+The reasoning-details dialog also consumes three more optional `done` fields
+(all parsed defensively — older backends without them fall back to the flat
+tool-name list and the plain "i" affordance):
+
+- `tool_call_trace` — array of `{ name, input, output, success }` entries
+  rendered as expandable rows (numbered, success/failure icon, pretty-printed
+  JSON input, output)
+- `transfer_chain` — array of `{ agent_id, agent_name }` hops rendered as the
+  agent transfer chain
+- `is_truncated` — `true` when the agent's iteration budget was exhausted;
+  the message then shows an always-visible amber warning triangle instead of
+  the hover-only "i" and the dialog opens with a "Turn limit reached" banner
+
+The same fields are read from restored session messages, so the dialog
+survives a page reload.
 
 #### Internal links
 
@@ -435,8 +451,14 @@ function App() {
 - `'Browse agents'`
 - `'Create agent'`
 - `'Reasoning details'`
+- `'Reasoning details — turn limit reached'`
 - `'Model reasoning'`
 - `'iterations'`
+- `'transfer'` / `'transfers'`
+- `'Transfer chain'`
+- `'Turn limit reached.'`
+- `"The agent's iteration budget was exhausted - execution stopped before completing all planned steps. The final response is a best-effort summary of work done so far."`
+- `'Input'` / `'Output'` / `'(no output)'`
 - `'Download'`
 - `'tool call'` / `'tool calls'`
 - `'Uses AI. Verify results.'`

--- a/packages/filigran-chatbot/src/components/ChatMessages.tsx
+++ b/packages/filigran-chatbot/src/components/ChatMessages.tsx
@@ -262,7 +262,11 @@ export const ChatMessages = ({
             {isAssistant &&
               !isEmpty &&
               !isStreamingMessage &&
-              ((msg.toolNames && msg.toolNames.length > 0) || (msg.reasoning ?? '').trim() || msg.isTruncated) && (
+              ((msg.toolNames && msg.toolNames.length > 0) ||
+                (msg.reasoning ?? '').trim() ||
+                (msg.toolCallTrace && msg.toolCallTrace.length > 0) ||
+                (msg.transferChain && msg.transferChain.length > 0) ||
+                msg.isTruncated) && (
                 <>
                   <button
                     type="button"
@@ -276,6 +280,9 @@ export const ChatMessages = ({
                         : 'opacity-50 hover:opacity-100 hover:text-[var(--chat-accent)]'
                     }`}
                     title={msg.isTruncated ? t('Reasoning details — turn limit reached') : t('Reasoning details')}
+                    aria-label={msg.isTruncated ? t('Reasoning details — turn limit reached') : t('Reasoning details')}
+                    aria-haspopup="dialog"
+                    aria-expanded={toolDetailMsgId === msg.id}
                   >
                     {msg.isTruncated ? <AlertTriangleIcon size={14} /> : <InfoIcon size={14} />}
                   </button>

--- a/packages/filigran-chatbot/src/components/ChatMessages.tsx
+++ b/packages/filigran-chatbot/src/components/ChatMessages.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useRef, useState } from 'react';
 import type { AgentStatusState, ChatAttachment, ChatMessage } from '../types';
 import { splitFileMarkers } from '../utils';
-import { BrainIcon, DownloadIcon, FileIcon, InfoIcon, WrenchIcon } from './icons';
-import { ChatThinking, cleanReasoningText } from './ChatThinking';
+import { AlertTriangleIcon, DownloadIcon, FileIcon, InfoIcon } from './icons';
+import { ChatThinking } from './ChatThinking';
 import { MarkdownMessage } from './MarkdownMessage';
+import { ReasoningDetailsDialog } from './ReasoningDetailsDialog';
 
 interface ChatMessagesProps {
   messages: ChatMessage[];
@@ -258,59 +259,29 @@ export const ChatMessages = ({
               </div>
             )}
 
-            {isAssistant && !isEmpty && !isStreamingMessage && ((msg.toolNames && msg.toolNames.length > 0) || (msg.reasoning ?? '').trim()) && (
-              <>
-                <button
-                  type="button"
-                  onClick={() => setToolDetailMsgId(toolDetailMsgId === msg.id ? null : msg.id)}
-                  className="mt-0.5 p-1 rounded-lg opacity-50 hover:opacity-100 hover:text-[var(--chat-accent)] transition-opacity"
-                  title={t('Reasoning details')}
-                >
-                  <InfoIcon size={14} />
-                </button>
-                {toolDetailMsgId === msg.id && (
-                  <div className="mt-1.5 p-3 rounded-lg bg-gray-50 dark:bg-white/[0.04] border border-gray-200 dark:border-white/10 max-w-[90%]">
-                    {/* Header — mirrors the XTM One web chat "Reasoning details"
-                        dialog (title + iterations/calls summary) so the embedded
-                        chatbot and the native web chat read the same. */}
-                    <div className="flex items-center gap-1.5 mb-1">
-                      <WrenchIcon size={13} className="text-[var(--chat-accent)]" />
-                      <span className="text-[0.75rem] font-semibold text-gray-900 dark:text-white">{t('Reasoning details')}</span>
-                    </div>
-                    <p className="text-[0.7rem] text-gray-500 dark:text-white/40 mb-1.5">
-                      {msg.iterations && msg.iterations > 1 ? `${msg.iterations} ${t('iterations')} · ` : ''}
-                      {msg.toolCallCount ?? msg.toolNames?.length ?? 0}{' '}
-                      {(msg.toolCallCount ?? msg.toolNames?.length ?? 0) === 1 ? t('tool call') : t('tool calls')}
-                    </p>
-                    {(msg.reasoning ?? '').trim() && (
-                      <div className="mb-2">
-                        <div className="flex items-center gap-1.5 mb-1">
-                          <BrainIcon size={13} className="text-[var(--chat-accent)]/70" />
-                          <span className="text-[0.7rem] font-medium text-gray-500 dark:text-white/50">{t('Model reasoning')}</span>
-                        </div>
-                        <div className="rounded-md border border-gray-200 dark:border-white/[0.06] bg-white dark:bg-white/[0.01] px-2.5 py-2 max-h-44 overflow-y-auto">
-                          <p className="m-0 whitespace-pre-wrap break-words text-[0.7rem] leading-5 text-gray-500 dark:text-white/45">
-                            {cleanReasoningText(msg.reasoning!)}
-                          </p>
-                        </div>
-                      </div>
-                    )}
-                    {msg.toolNames && msg.toolNames.length > 0 && (
-                      <div className="flex flex-wrap gap-1">
-                        {Array.from(new Set(msg.toolNames)).map((tn) => (
-                          <span
-                            key={tn}
-                            className="inline-flex items-center px-2 py-0.5 rounded-full border border-gray-200 dark:border-white/10 text-[0.68rem] font-mono text-gray-500 dark:text-white/40"
-                          >
-                            {tn.replace(/_/g, ' ')}
-                          </span>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-                )}
-              </>
-            )}
+            {isAssistant &&
+              !isEmpty &&
+              !isStreamingMessage &&
+              ((msg.toolNames && msg.toolNames.length > 0) || (msg.reasoning ?? '').trim() || msg.isTruncated) && (
+                <>
+                  <button
+                    type="button"
+                    onClick={() => setToolDetailMsgId(toolDetailMsgId === msg.id ? null : msg.id)}
+                    className={`mt-0.5 p-1 rounded-lg transition-opacity ${
+                      msg.isTruncated
+                        ? // A truncated turn must be visible at a glance (not
+                          // gated on hover) so the user notices the warning —
+                          // mirrors the XTM One web chat affordance.
+                          'opacity-100 text-amber-500 dark:text-amber-400 hover:text-amber-600 dark:hover:text-amber-300'
+                        : 'opacity-50 hover:opacity-100 hover:text-[var(--chat-accent)]'
+                    }`}
+                    title={msg.isTruncated ? t('Reasoning details — turn limit reached') : t('Reasoning details')}
+                  >
+                    {msg.isTruncated ? <AlertTriangleIcon size={14} /> : <InfoIcon size={14} />}
+                  </button>
+                  {toolDetailMsgId === msg.id && <ReasoningDetailsDialog msg={msg} onClose={() => setToolDetailMsgId(null)} t={t} />}
+                </>
+              )}
           </div>
         );
       })}

--- a/packages/filigran-chatbot/src/components/ChatPanel.tsx
+++ b/packages/filigran-chatbot/src/components/ChatPanel.tsx
@@ -1,7 +1,7 @@
 import { type FunctionComponent, useCallback, useEffect, useRef, useState } from 'react';
 import type { ChatAttachment, ChatMessage, ChatPanelProps } from '../types';
 import { hexAlpha, identity } from '../utils';
-import { parseAttachments } from '../hooks/protocols/parseRestEvent';
+import { parseAttachments, parseToolCallTrace, parseTransferChain } from '../hooks/protocols/parseRestEvent';
 import { useChat } from '../hooks/useChat';
 import { useAgents } from '../hooks/useAgents';
 import { useConversations } from '../hooks/useConversations';
@@ -308,6 +308,9 @@ export const ChatPanel: FunctionComponent<ChatPanelProps> = ({
               tool_call_count?: unknown;
               iterations?: unknown;
               reasoning?: unknown;
+              tool_call_trace?: unknown;
+              transfer_chain?: unknown;
+              is_truncated?: unknown;
             },
             i: number,
           ) => ({
@@ -329,6 +332,9 @@ export const ChatPanel: FunctionComponent<ChatPanelProps> = ({
             toolCallCount: typeof m.tool_call_count === 'number' ? m.tool_call_count : undefined,
             iterations: typeof m.iterations === 'number' ? m.iterations : undefined,
             reasoning: typeof m.reasoning === 'string' ? m.reasoning : undefined,
+            toolCallTrace: parseToolCallTrace(m.tool_call_trace),
+            transferChain: parseTransferChain(m.transfer_chain),
+            isTruncated: m.is_truncated === true || undefined,
           }),
         );
         setMessages(restored);

--- a/packages/filigran-chatbot/src/components/Dropdown.tsx
+++ b/packages/filigran-chatbot/src/components/Dropdown.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useClickOutside } from '../hooks/useClickOutside';
+import { findChatbotRoot } from '../utils';
 
 interface DropdownProps {
   open: boolean;
@@ -9,15 +10,6 @@ interface DropdownProps {
   placement?: 'bottom-start' | 'bottom-end';
   width?: number;
   children: React.ReactNode;
-}
-
-function findChatbotRoot(el: HTMLElement | null): HTMLElement {
-  let node = el;
-  while (node) {
-    if (node.classList.contains('filigran-chatbot')) return node;
-    node = node.parentElement;
-  }
-  return document.body;
 }
 
 export const Dropdown = ({ open, onClose, anchorRef, placement = 'bottom-start', width = 280, children }: DropdownProps) => {

--- a/packages/filigran-chatbot/src/components/ReasoningDetailsDialog.tsx
+++ b/packages/filigran-chatbot/src/components/ReasoningDetailsDialog.tsx
@@ -106,6 +106,7 @@ interface ReasoningDetailsDialogProps {
 export const ReasoningDetailsDialog = ({ msg, onClose, t }: ReasoningDetailsDialogProps) => {
   const hostRef = useRef<HTMLSpanElement>(null);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
   const [root, setRoot] = useState<HTMLElement | null>(null);
 
   useEffect(() => {
@@ -114,7 +115,29 @@ export const ReasoningDetailsDialog = ({ msg, onClose, t }: ReasoningDetailsDial
 
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
+      if (e.key === 'Escape') {
+        onClose();
+        return;
+      }
+      // Focus trap: aria-modal promises focus stays inside the dialog, so
+      // Tab/Shift+Tab cycle within it instead of escaping to the panel.
+      if (e.key !== 'Tab') return;
+      const dialog = dialogRef.current;
+      if (!dialog) return;
+      const focusable = dialog.querySelectorAll<HTMLElement>('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement;
+      if (e.shiftKey) {
+        if (active === first || !dialog.contains(active)) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else if (active === last || !dialog.contains(active)) {
+        e.preventDefault();
+        first.focus();
+      }
     };
     document.addEventListener('keydown', onKeyDown);
     return () => document.removeEventListener('keydown', onKeyDown);
@@ -155,6 +178,7 @@ export const ReasoningDetailsDialog = ({ msg, onClose, t }: ReasoningDetailsDial
             role="presentation"
           >
             <div
+              ref={dialogRef}
               role="dialog"
               aria-modal="true"
               aria-label={t('Reasoning details')}

--- a/packages/filigran-chatbot/src/components/ReasoningDetailsDialog.tsx
+++ b/packages/filigran-chatbot/src/components/ReasoningDetailsDialog.tsx
@@ -13,17 +13,23 @@ import {
   XCircleIcon,
 } from './icons';
 import { cleanReasoningText } from './ChatThinking';
+import { findChatbotRoot } from '../utils';
 
-/** Inputs longer than this are shown raw instead of pretty-printed JSON. */
-const TRACE_INPUT_PRETTY_LIMIT = 10_000;
+/** Trace values longer than this are shown raw instead of pretty-printed JSON. */
+const TRACE_PRETTY_LIMIT = 10_000;
 
-function findChatbotRoot(el: HTMLElement | null): HTMLElement {
-  let node = el;
-  while (node) {
-    if (node.classList.contains('filigran-chatbot')) return node;
-    node = node.parentElement;
+/**
+ * Pretty-print a tool-call input/output when it is compact JSON; anything
+ * else (plain text, oversized payloads, malformed JSON) is shown raw.
+ */
+function prettyTraceValue(raw: string | undefined): string {
+  if (!raw) return '';
+  if (raw.length > TRACE_PRETTY_LIMIT) return raw;
+  try {
+    return JSON.stringify(JSON.parse(raw), null, 2);
+  } catch {
+    return raw;
   }
-  return document.body;
 }
 
 function toolDisplayName(name: string): string {
@@ -34,15 +40,8 @@ function toolDisplayName(name: string): string {
 const ToolCallRow = ({ entry, index, t }: { entry: ToolCallTraceEntry; index: number; t: (key: string) => string }) => {
   const [expanded, setExpanded] = useState(false);
 
-  const inputDisplay = useMemo(() => {
-    if (!entry.input) return '';
-    if (entry.input.length > TRACE_INPUT_PRETTY_LIMIT) return entry.input;
-    try {
-      return JSON.stringify(JSON.parse(entry.input), null, 2);
-    } catch {
-      return entry.input;
-    }
-  }, [entry.input]);
+  const inputDisplay = useMemo(() => prettyTraceValue(entry.input), [entry.input]);
+  const outputDisplay = useMemo(() => prettyTraceValue(entry.output), [entry.output]);
   const hasInput = !!inputDisplay && inputDisplay !== '{}';
 
   return (
@@ -81,7 +80,7 @@ const ToolCallRow = ({ entry, index, t }: { entry: ToolCallTraceEntry; index: nu
           <div className="px-3 py-2 bg-gray-50/50 dark:bg-white/[0.01]">
             <p className="m-0 mb-1.5 text-[0.6rem] text-gray-500 dark:text-white/40 uppercase tracking-wider font-medium">{t('Output')}</p>
             <pre className="m-0 text-[0.7rem] text-gray-600 dark:text-white/60 font-mono whitespace-pre-wrap break-all leading-relaxed max-h-48 overflow-y-auto filigran-chat-scrollable">
-              {entry.output || t('(no output)')}
+              {outputDisplay || t('(no output)')}
             </pre>
           </div>
         </div>

--- a/packages/filigran-chatbot/src/components/ReasoningDetailsDialog.tsx
+++ b/packages/filigran-chatbot/src/components/ReasoningDetailsDialog.tsx
@@ -119,7 +119,10 @@ export const ReasoningDetailsDialog = ({ msg, onClose, t }: ReasoningDetailsDial
     return () => document.removeEventListener('keydown', onKeyDown);
   }, [onClose]);
 
-  const totalCalls = msg.toolCallCount ?? msg.toolNames?.length ?? 0;
+  // Prefer the backend's explicit count, then the detailed trace (what the
+  // dialog body actually renders), then the flat tool-name list — keeps the
+  // header summary consistent with the rows below.
+  const totalCalls = msg.toolCallCount ?? msg.toolCallTrace?.length ?? msg.toolNames?.length ?? 0;
   const tools = msg.toolNames ?? [];
   const iterations = msg.iterations ?? 1;
   const transfers = msg.transferChain ?? [];
@@ -203,7 +206,10 @@ export const ReasoningDetailsDialog = ({ msg, onClose, t }: ReasoningDetailsDial
                     // messages / backends without trace support).
                     <div>
                       {tools.map((tn, i) => (
-                        <div key={`${tn}-${i}`} className="flex items-center gap-3 py-2 border-b border-gray-100 dark:border-white/[0.04] last:border-0">
+                        <div
+                          key={`${tn}-${i}`}
+                          className="flex items-center gap-3 py-2 border-b border-gray-100 dark:border-white/[0.04] last:border-0"
+                        >
                           <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded bg-[var(--chat-accent)]/10 text-[0.65rem] font-medium text-[var(--chat-accent)]">
                             {i + 1}
                           </span>
@@ -223,7 +229,9 @@ export const ReasoningDetailsDialog = ({ msg, onClose, t }: ReasoningDetailsDial
                     </div>
                     <div className="flex items-center gap-1.5 flex-wrap">
                       {transfers.map((tr, i) => (
-                        <div key={tr.agentId || i} className="flex items-center gap-1.5">
+                        // Composite key: the same agent can appear twice in a
+                        // chain (A -> B -> A) and older payloads have no id.
+                        <div key={`${tr.agentId}-${i}`} className="flex items-center gap-1.5">
                           {i > 0 && <span className="text-gray-300 dark:text-white/30 text-[0.72rem]">→</span>}
                           <span className="inline-flex items-center gap-1 rounded-md bg-[var(--chat-accent)]/10 px-2 py-0.5 text-[0.72rem] font-medium text-[var(--chat-accent)]">
                             <BotIcon size={12} />

--- a/packages/filigran-chatbot/src/components/ReasoningDetailsDialog.tsx
+++ b/packages/filigran-chatbot/src/components/ReasoningDetailsDialog.tsx
@@ -1,0 +1,244 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import type { ChatMessage, ToolCallTraceEntry } from '../types';
+import {
+  AlertTriangleIcon,
+  ArrowRightLeftIcon,
+  BotIcon,
+  BrainIcon,
+  CheckCircleIcon,
+  ChevronDownIcon,
+  CloseIcon,
+  WrenchIcon,
+  XCircleIcon,
+} from './icons';
+import { cleanReasoningText } from './ChatThinking';
+
+/** Inputs longer than this are shown raw instead of pretty-printed JSON. */
+const TRACE_INPUT_PRETTY_LIMIT = 10_000;
+
+function findChatbotRoot(el: HTMLElement | null): HTMLElement {
+  let node = el;
+  while (node) {
+    if (node.classList.contains('filigran-chatbot')) return node;
+    node = node.parentElement;
+  }
+  return document.body;
+}
+
+function toolDisplayName(name: string): string {
+  return name.replace(/_/g, ' ');
+}
+
+/** Expandable row for a single tool call in the reasoning-details dialog. */
+const ToolCallRow = ({ entry, index, t }: { entry: ToolCallTraceEntry; index: number; t: (key: string) => string }) => {
+  const [expanded, setExpanded] = useState(false);
+
+  const inputDisplay = useMemo(() => {
+    if (!entry.input) return '';
+    if (entry.input.length > TRACE_INPUT_PRETTY_LIMIT) return entry.input;
+    try {
+      return JSON.stringify(JSON.parse(entry.input), null, 2);
+    } catch {
+      return entry.input;
+    }
+  }, [entry.input]);
+  const hasInput = !!inputDisplay && inputDisplay !== '{}';
+
+  return (
+    <div className="border border-gray-200 dark:border-white/[0.06] rounded-md overflow-hidden">
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+        className="w-full flex items-center gap-2.5 px-3 py-2 hover:bg-gray-50 dark:hover:bg-white/[0.03] transition-colors text-left"
+      >
+        <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded bg-[var(--chat-accent)]/10 text-[0.65rem] font-medium text-[var(--chat-accent)]">
+          {index + 1}
+        </span>
+        {entry.success ? (
+          <CheckCircleIcon size={12} className="shrink-0 text-emerald-500 dark:text-emerald-400" />
+        ) : (
+          <XCircleIcon size={12} className="shrink-0 text-red-500 dark:text-red-400" />
+        )}
+        <span className="flex-1 min-w-0 text-[0.8125rem] text-gray-700 dark:text-white/80 truncate font-mono">{toolDisplayName(entry.name)}</span>
+        <ChevronDownIcon
+          size={14}
+          className={`shrink-0 text-gray-400 dark:text-white/50 transition-transform duration-200 ${expanded ? 'rotate-180' : ''}`}
+        />
+      </button>
+
+      {expanded && (
+        <div className="border-t border-gray-200 dark:border-white/[0.06]">
+          {hasInput && (
+            <div className="px-3 py-2 border-b border-gray-100 dark:border-white/[0.04] bg-gray-50/50 dark:bg-white/[0.01]">
+              <p className="m-0 mb-1.5 text-[0.6rem] text-gray-500 dark:text-white/40 uppercase tracking-wider font-medium">{t('Input')}</p>
+              <pre className="m-0 text-[0.7rem] text-gray-600 dark:text-white/60 font-mono whitespace-pre-wrap break-all leading-relaxed max-h-40 overflow-y-auto filigran-chat-scrollable">
+                {inputDisplay}
+              </pre>
+            </div>
+          )}
+          <div className="px-3 py-2 bg-gray-50/50 dark:bg-white/[0.01]">
+            <p className="m-0 mb-1.5 text-[0.6rem] text-gray-500 dark:text-white/40 uppercase tracking-wider font-medium">{t('Output')}</p>
+            <pre className="m-0 text-[0.7rem] text-gray-600 dark:text-white/60 font-mono whitespace-pre-wrap break-all leading-relaxed max-h-48 overflow-y-auto filigran-chat-scrollable">
+              {entry.output || t('(no output)')}
+            </pre>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+interface ReasoningDetailsDialogProps {
+  msg: ChatMessage;
+  onClose: () => void;
+  t: (key: string) => string;
+}
+
+/**
+ * Modal dialog with the full reasoning details of an assistant message —
+ * mirrors the XTM One web chat dialog (truncation warning, model reasoning,
+ * expandable per-tool-call trace, transfer chain). Rendered as an overlay
+ * covering the chatbot panel so it works in every mode and host without
+ * depending on the host app's stacking order.
+ */
+export const ReasoningDetailsDialog = ({ msg, onClose, t }: ReasoningDetailsDialogProps) => {
+  const hostRef = useRef<HTMLSpanElement>(null);
+  const [root, setRoot] = useState<HTMLElement | null>(null);
+
+  useEffect(() => {
+    setRoot(findChatbotRoot(hostRef.current));
+  }, []);
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [onClose]);
+
+  const totalCalls = msg.toolCallCount ?? msg.toolNames?.length ?? 0;
+  const tools = msg.toolNames ?? [];
+  const iterations = msg.iterations ?? 1;
+  const transfers = msg.transferChain ?? [];
+  const trace = msg.toolCallTrace ?? [];
+  const reasoning = (msg.reasoning ?? '').trim();
+
+  const summaryParts = [
+    iterations > 1 ? `${iterations} ${t('iterations')}` : '',
+    `${totalCalls} ${totalCalls === 1 ? t('tool call') : t('tool calls')}`,
+    transfers.length > 0 ? `${transfers.length} ${transfers.length === 1 ? t('transfer') : t('transfers')}` : '',
+  ].filter(Boolean);
+
+  return (
+    <span ref={hostRef} className="hidden">
+      {root &&
+        createPortal(
+          <div
+            className="absolute inset-0 z-[10000] flex items-center justify-center bg-black/30 dark:bg-black/50 p-4"
+            onClick={onClose}
+            role="presentation"
+          >
+            <div
+              role="dialog"
+              aria-modal="true"
+              aria-label={t('Reasoning details')}
+              onClick={(e) => e.stopPropagation()}
+              className="w-full max-w-md max-h-full flex flex-col rounded-xl border border-gray-200 dark:border-white/10 bg-white dark:bg-[#1e1e2e] shadow-[0_8px_32px_rgba(0,0,0,0.25)] dark:shadow-[0_8px_32px_rgba(0,0,0,0.6)]"
+            >
+              <div className="px-4 pt-3.5 pb-2.5 border-b border-gray-200 dark:border-white/10">
+                <div className="flex items-center gap-2">
+                  <WrenchIcon size={15} className="text-[var(--chat-accent)]" />
+                  <span className="flex-1 text-[0.875rem] font-semibold text-gray-900 dark:text-white">{t('Reasoning details')}</span>
+                  <button
+                    type="button"
+                    onClick={onClose}
+                    aria-label={t('Close')}
+                    className="w-7 h-7 flex items-center justify-center rounded-lg hover:bg-gray-100 dark:hover:bg-white/10 text-gray-500 dark:text-white/40 hover:text-gray-700 dark:hover:text-white/70 transition-colors"
+                  >
+                    <CloseIcon size={16} />
+                  </button>
+                </div>
+                <p className="m-0 mt-0.5 text-[0.72rem] text-gray-500 dark:text-white/40">{summaryParts.join(' · ')}</p>
+              </div>
+
+              <div className="px-4 py-3 overflow-y-auto filigran-chat-scrollable flex flex-col gap-3">
+                {msg.isTruncated && (
+                  <div className="flex items-start gap-2.5 rounded-md border border-amber-500/20 bg-amber-500/5 px-3 py-2.5 text-[0.72rem] text-amber-600 dark:text-amber-300/90">
+                    <AlertTriangleIcon size={14} className="shrink-0 mt-0.5 text-amber-500 dark:text-amber-400" />
+                    <span>
+                      <span className="font-semibold">{t('Turn limit reached.')}</span>{' '}
+                      {t(
+                        "The agent's iteration budget was exhausted - execution stopped before completing all planned steps. The final response is a best-effort summary of work done so far.",
+                      )}
+                    </span>
+                  </div>
+                )}
+
+                {reasoning && (
+                  <div>
+                    <div className="flex items-center gap-1.5 mb-1.5">
+                      <BrainIcon size={13} className="text-[var(--chat-accent)]/70" />
+                      <span className="text-[0.72rem] font-medium text-gray-500 dark:text-white/50">{t('Model reasoning')}</span>
+                    </div>
+                    <div className="rounded-md border border-gray-200 dark:border-white/[0.06] bg-gray-50/50 dark:bg-white/[0.01] px-2.5 py-2 max-h-44 overflow-y-auto filigran-chat-scrollable">
+                      <p className="m-0 whitespace-pre-wrap break-words text-[0.72rem] leading-5 text-gray-500 dark:text-white/45">
+                        {cleanReasoningText(reasoning)}
+                      </p>
+                    </div>
+                  </div>
+                )}
+
+                {trace.length > 0 ? (
+                  <div className="flex flex-col gap-1.5">
+                    {trace.map((entry, i) => (
+                      <ToolCallRow key={`${entry.name}-${i}`} entry={entry} index={i} t={t} />
+                    ))}
+                  </div>
+                ) : (
+                  tools.length > 0 && (
+                    // Fallback when no detailed trace is available (legacy
+                    // messages / backends without trace support).
+                    <div>
+                      {tools.map((tn, i) => (
+                        <div key={`${tn}-${i}`} className="flex items-center gap-3 py-2 border-b border-gray-100 dark:border-white/[0.04] last:border-0">
+                          <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded bg-[var(--chat-accent)]/10 text-[0.65rem] font-medium text-[var(--chat-accent)]">
+                            {i + 1}
+                          </span>
+                          <WrenchIcon size={12} className="shrink-0 text-gray-400 dark:text-white/50" />
+                          <span className="text-[0.8125rem] text-gray-700 dark:text-white/80 truncate font-mono">{toolDisplayName(tn)}</span>
+                        </div>
+                      ))}
+                    </div>
+                  )
+                )}
+
+                {transfers.length > 0 && (
+                  <div>
+                    <div className="flex items-center gap-1.5 mb-1.5">
+                      <ArrowRightLeftIcon size={13} className="text-[var(--chat-accent)]/70" />
+                      <span className="text-[0.72rem] font-medium text-gray-500 dark:text-white/50">{t('Transfer chain')}</span>
+                    </div>
+                    <div className="flex items-center gap-1.5 flex-wrap">
+                      {transfers.map((tr, i) => (
+                        <div key={tr.agentId || i} className="flex items-center gap-1.5">
+                          {i > 0 && <span className="text-gray-300 dark:text-white/30 text-[0.72rem]">→</span>}
+                          <span className="inline-flex items-center gap-1 rounded-md bg-[var(--chat-accent)]/10 px-2 py-0.5 text-[0.72rem] font-medium text-[var(--chat-accent)]">
+                            <BotIcon size={12} />
+                            {tr.agentName}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>,
+          root,
+        )}
+    </span>
+  );
+};

--- a/packages/filigran-chatbot/src/components/ReasoningDetailsDialog.tsx
+++ b/packages/filigran-chatbot/src/components/ReasoningDetailsDialog.tsx
@@ -105,6 +105,7 @@ interface ReasoningDetailsDialogProps {
  */
 export const ReasoningDetailsDialog = ({ msg, onClose, t }: ReasoningDetailsDialogProps) => {
   const hostRef = useRef<HTMLSpanElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
   const [root, setRoot] = useState<HTMLElement | null>(null);
 
   useEffect(() => {
@@ -118,6 +119,15 @@ export const ReasoningDetailsDialog = ({ msg, onClose, t }: ReasoningDetailsDial
     document.addEventListener('keydown', onKeyDown);
     return () => document.removeEventListener('keydown', onKeyDown);
   }, [onClose]);
+
+  // Move initial keyboard focus into the modal (aria-modal) once the portal
+  // is mounted, and hand it back to the trigger when the dialog closes.
+  useEffect(() => {
+    if (!root) return;
+    const previouslyFocused = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    closeButtonRef.current?.focus({ preventScroll: true });
+    return () => previouslyFocused?.focus({ preventScroll: true });
+  }, [root]);
 
   // Prefer the backend's explicit count, then the detailed trace (what the
   // dialog body actually renders), then the flat tool-name list — keeps the
@@ -156,6 +166,7 @@ export const ReasoningDetailsDialog = ({ msg, onClose, t }: ReasoningDetailsDial
                   <WrenchIcon size={15} className="text-[var(--chat-accent)]" />
                   <span className="flex-1 text-[0.875rem] font-semibold text-gray-900 dark:text-white">{t('Reasoning details')}</span>
                   <button
+                    ref={closeButtonRef}
                     type="button"
                     onClick={onClose}
                     aria-label={t('Close')}

--- a/packages/filigran-chatbot/src/components/Tooltip.tsx
+++ b/packages/filigran-chatbot/src/components/Tooltip.tsx
@@ -1,5 +1,6 @@
 import { useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
+import { findChatbotRoot } from '../utils';
 
 interface TooltipProps {
   title: string;
@@ -9,15 +10,6 @@ interface TooltipProps {
 // Approximate rendered tooltip height (text-xs + py-1) plus the 4px gap.
 // Used to decide whether a top-placed tooltip would overflow the panel.
 const TOOLTIP_CLEARANCE = 28;
-
-function findChatbotRoot(el: HTMLElement | null): HTMLElement {
-  let node = el;
-  while (node) {
-    if (node.classList.contains('filigran-chatbot')) return node;
-    node = node.parentElement;
-  }
-  return document.body;
-}
 
 export const Tooltip = ({ title, children }: TooltipProps) => {
   const ref = useRef<HTMLSpanElement>(null);

--- a/packages/filigran-chatbot/src/components/icons/AlertTriangleIcon.tsx
+++ b/packages/filigran-chatbot/src/components/icons/AlertTriangleIcon.tsx
@@ -1,0 +1,20 @@
+import type { IconProps } from '../../types';
+
+export const AlertTriangleIcon = ({ className, size = 24 }: IconProps) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className}
+  >
+    <path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3" />
+    <path d="M12 9v4" />
+    <path d="M12 17h.01" />
+  </svg>
+);

--- a/packages/filigran-chatbot/src/components/icons/ArrowRightLeftIcon.tsx
+++ b/packages/filigran-chatbot/src/components/icons/ArrowRightLeftIcon.tsx
@@ -1,0 +1,21 @@
+import type { IconProps } from '../../types';
+
+export const ArrowRightLeftIcon = ({ className, size = 24 }: IconProps) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className}
+  >
+    <path d="m16 3 4 4-4 4" />
+    <path d="M20 7H4" />
+    <path d="m8 21-4-4 4-4" />
+    <path d="M4 17h16" />
+  </svg>
+);

--- a/packages/filigran-chatbot/src/components/icons/BotIcon.tsx
+++ b/packages/filigran-chatbot/src/components/icons/BotIcon.tsx
@@ -1,0 +1,23 @@
+import type { IconProps } from '../../types';
+
+export const BotIcon = ({ className, size = 24 }: IconProps) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className}
+  >
+    <path d="M12 8V4H8" />
+    <rect width="16" height="12" x="4" y="8" rx="2" />
+    <path d="M2 14h2" />
+    <path d="M20 14h2" />
+    <path d="M15 13v2" />
+    <path d="M9 13v2" />
+  </svg>
+);

--- a/packages/filigran-chatbot/src/components/icons/CheckCircleIcon.tsx
+++ b/packages/filigran-chatbot/src/components/icons/CheckCircleIcon.tsx
@@ -1,0 +1,19 @@
+import type { IconProps } from '../../types';
+
+export const CheckCircleIcon = ({ className, size = 24 }: IconProps) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className}
+  >
+    <circle cx="12" cy="12" r="10" />
+    <path d="m9 12 2 2 4-4" />
+  </svg>
+);

--- a/packages/filigran-chatbot/src/components/icons/XCircleIcon.tsx
+++ b/packages/filigran-chatbot/src/components/icons/XCircleIcon.tsx
@@ -1,0 +1,20 @@
+import type { IconProps } from '../../types';
+
+export const XCircleIcon = ({ className, size = 24 }: IconProps) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className}
+  >
+    <circle cx="12" cy="12" r="10" />
+    <path d="m15 9-6 6" />
+    <path d="m9 9 6 6" />
+  </svg>
+);

--- a/packages/filigran-chatbot/src/components/icons/index.ts
+++ b/packages/filigran-chatbot/src/components/icons/index.ts
@@ -1,5 +1,9 @@
+export * from './AlertTriangleIcon';
+export * from './ArrowRightLeftIcon';
 export * from './AttachFileIcon';
+export * from './BotIcon';
 export * from './BrainIcon';
+export * from './CheckCircleIcon';
 export * from './CheckIcon';
 export * from './ChevronDownIcon';
 export * from './CloseIcon';
@@ -26,3 +30,4 @@ export * from './TerminalIcon';
 export * from './TrashIcon';
 export * from './UserPlusIcon';
 export * from './WrenchIcon';
+export * from './XCircleIcon';

--- a/packages/filigran-chatbot/src/hooks/protocols/parseRestEvent.ts
+++ b/packages/filigran-chatbot/src/hooks/protocols/parseRestEvent.ts
@@ -1,4 +1,4 @@
-import type { ChatAttachment } from '../../types';
+import type { ChatAttachment, ToolCallTraceEntry, TransferChainEntry } from '../../types';
 import type { ParsedAction, ProtocolContext } from './types';
 
 /**
@@ -22,6 +22,48 @@ export function parseAttachments(raw: unknown): ChatAttachment[] | undefined {
       size: typeof a.size === 'number' ? a.size : undefined,
       contentType: typeof a.content_type === 'string' ? a.content_type : undefined,
       fileTag: a.file_tag === 'working_file' ? 'working_file' : 'download_file',
+    });
+  }
+  return out.length > 0 ? out : undefined;
+}
+
+/**
+ * Normalize the raw `tool_call_trace` array (from a `done` event or restored
+ * session metadata) into typed {@link ToolCallTraceEntry} objects. Defensive:
+ * skips entries without a `name`. Returns `undefined` when empty so the
+ * reasoning-details dialog falls back to the flat tool-name list.
+ */
+export function parseToolCallTrace(raw: unknown): ToolCallTraceEntry[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const out: ToolCallTraceEntry[] = [];
+  for (const item of raw) {
+    if (!item || typeof item !== 'object') continue;
+    const e = item as Record<string, unknown>;
+    if (typeof e.name !== 'string' || !e.name) continue;
+    out.push({
+      name: e.name,
+      input: typeof e.input === 'string' ? e.input : undefined,
+      output: typeof e.output === 'string' ? e.output : undefined,
+      success: e.success !== false,
+    });
+  }
+  return out.length > 0 ? out : undefined;
+}
+
+/**
+ * Normalize the raw `transfer_chain` array (from a `done` event or restored
+ * session metadata) into typed {@link TransferChainEntry} objects.
+ */
+export function parseTransferChain(raw: unknown): TransferChainEntry[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const out: TransferChainEntry[] = [];
+  for (const item of raw) {
+    if (!item || typeof item !== 'object') continue;
+    const e = item as Record<string, unknown>;
+    if (typeof e.agent_name !== 'string' || !e.agent_name) continue;
+    out.push({
+      agentId: typeof e.agent_id === 'string' ? e.agent_id : '',
+      agentName: e.agent_name,
     });
   }
   return out.length > 0 ? out : undefined;
@@ -85,6 +127,9 @@ export function parseRestEvent(evt: Record<string, unknown>, ctx: ProtocolContex
       transferAgentName: evt.transfer_agent_name as string | undefined,
       attachments: parseAttachments(evt.attachments),
       reasoning: typeof evt.reasoning === 'string' ? evt.reasoning : undefined,
+      toolCallTrace: parseToolCallTrace(evt.tool_call_trace),
+      transferChain: parseTransferChain(evt.transfer_chain),
+      isTruncated: evt.is_truncated === true || undefined,
     };
   }
 

--- a/packages/filigran-chatbot/src/hooks/protocols/parseRestEvent.ts
+++ b/packages/filigran-chatbot/src/hooks/protocols/parseRestEvent.ts
@@ -44,7 +44,9 @@ export function parseToolCallTrace(raw: unknown): ToolCallTraceEntry[] | undefin
       name: e.name,
       input: typeof e.input === 'string' ? e.input : undefined,
       output: typeof e.output === 'string' ? e.output : undefined,
-      success: e.success !== false,
+      // Only a boolean is honored; a missing/malformed value defaults to
+      // success so unknown states never render a false failure icon.
+      success: typeof e.success === 'boolean' ? e.success : true,
     });
   }
   return out.length > 0 ? out : undefined;

--- a/packages/filigran-chatbot/src/hooks/protocols/types.ts
+++ b/packages/filigran-chatbot/src/hooks/protocols/types.ts
@@ -1,4 +1,4 @@
-import type { ChatAttachment } from '../../types';
+import type { ChatAttachment, ToolCallTraceEntry, TransferChainEntry } from '../../types';
 
 /**
  * Normalized action produced by all protocol parsers.
@@ -17,8 +17,14 @@ export type ParsedAction =
       transferAgentId?: string;
       transferAgentName?: string;
       attachments?: ChatAttachment[];
-      /** Accumulated model reasoning for the turn (reasoning-details panel). */
+      /** Accumulated model reasoning for the turn (reasoning-details dialog). */
       reasoning?: string;
+      /** Per-tool-call execution trace (reasoning-details dialog). */
+      toolCallTrace?: ToolCallTraceEntry[];
+      /** Agent transfer chain for the turn (reasoning-details dialog). */
+      transferChain?: TransferChainEntry[];
+      /** True when the agent's iteration budget was exhausted. */
+      isTruncated?: boolean;
     }
   | { action: 'error'; content: string }
   | { action: 'set_chat_id'; chatId: string }

--- a/packages/filigran-chatbot/src/hooks/useChat.ts
+++ b/packages/filigran-chatbot/src/hooks/useChat.ts
@@ -616,6 +616,9 @@ export function useChat({
                           iterations: parsed.iterations,
                           attachments: parsed.attachments,
                           reasoning: parsed.reasoning,
+                          toolCallTrace: parsed.toolCallTrace,
+                          transferChain: parsed.transferChain,
+                          isTruncated: parsed.isTruncated,
                         }
                       : m,
                   ),

--- a/packages/filigran-chatbot/src/types.ts
+++ b/packages/filigran-chatbot/src/types.ts
@@ -149,10 +149,39 @@ export interface ChatMessage {
   iterations?: number;
   /**
    * Accumulated model reasoning / pre-tool preamble prose for the turn
-   * (from `thinking_text` events), surfaced in the reasoning-details panel
+   * (from `thinking_text` events), surfaced in the reasoning-details dialog
    * after the answer completes — mirroring the XTM One web chat.
    */
   reasoning?: string;
+  /**
+   * Per-tool-call execution trace (name, input, output, success) for the
+   * reasoning-details dialog — same shape the XTM One web chat renders as
+   * expandable rows. Optional: backends without trace support fall back to
+   * the flat `toolNames` list.
+   */
+  toolCallTrace?: ToolCallTraceEntry[];
+  /** Agent transfer chain for the turn (reasoning-details dialog). */
+  transferChain?: TransferChainEntry[];
+  /**
+   * True when the agent's iteration budget was exhausted and the final
+   * response is a best-effort summary — surfaced as an amber warning on the
+   * reasoning-details affordance, mirroring the XTM One web chat.
+   */
+  isTruncated?: boolean;
+}
+
+/** One tool call in the reasoning-details execution trace. */
+export interface ToolCallTraceEntry {
+  name: string;
+  input?: string;
+  output?: string;
+  success: boolean;
+}
+
+/** One hop in the agent transfer chain shown in the reasoning-details dialog. */
+export interface TransferChainEntry {
+  agentId: string;
+  agentName: string;
 }
 
 /**

--- a/packages/filigran-chatbot/src/utils/index.ts
+++ b/packages/filigran-chatbot/src/utils/index.ts
@@ -65,6 +65,21 @@ export function hardenNestedCodeFences(raw: string): string {
 export const identity = (key: string) => key;
 
 /**
+ * Nearest chatbot panel root (`.filigran-chatbot`) for portal-based overlays
+ * (tooltips, dropdowns, dialogs), so they stay inside the panel's stacking
+ * context instead of competing with the host app's z-indexes. Falls back to
+ * `document.body` when rendered outside a panel.
+ */
+export function findChatbotRoot(el: HTMLElement | null): HTMLElement {
+  let node = el;
+  while (node) {
+    if (node.classList.contains('filigran-chatbot')) return node;
+    node = node.parentElement;
+  }
+  return document.body;
+}
+
+/**
  * Compact relative-time label for the conversation history menu
  * ("just now", "5m ago", "3h ago", "2d ago", then a short date).
  * Returns an empty string for missing/unparseable timestamps so the row


### PR DESCRIPTION
﻿## Summary

- Fixes #322
- The reasoning-details "i" affordance now opens a modal dialog mirroring the XTM One web chat instead of the small inline expander: title + summary (iterations - tool calls - transfers), "Turn limit reached" amber banner, model reasoning block, expandable per-tool-call execution trace (numbered rows, success/failure icon, pretty-printed JSON input, output), and the agent transfer chain. When no detailed trace is available the dialog falls back to the numbered flat tool list, same as the web chat.
- New `ChatMessage` fields `toolCallTrace`, `transferChain`, `isTruncated` are parsed defensively from both the live `done` SSE payload and the session restore (`parseToolCallTrace` / `parseTransferChain` shared by both paths), so backends without the new keys degrade gracefully to the previous behavior.
- A truncated turn surfaces an always-visible amber triangle instead of the hover-only "i", matching the web chat warning affordance.
- The dialog renders as an overlay scoped to the chatbot panel root, so it works in sidebar/floating/fullscreen and in every host regardless of the host top bar stacking (same constraint as #320). Escape and backdrop click close it.
- New icons (AlertTriangle, CheckCircle, XCircle, ArrowRightLeft, Bot) follow the existing Lucide-style inline SVG pattern.

Companion change: the XTM One platform proxy now emits `tool_call_trace` and `is_truncated` in the `done` payload and session restore (see FiligranHQ/xtm-one companion PR); `transfer_chain` was already emitted.

## Review feedback addressed (commit 015c5eb)

- The reasoning-details affordance now also renders when a message carries only `toolCallTrace` and/or `transferChain` (a backend can emit the trace without `tool_names`/`reasoning`); the icon-only trigger gained `aria-label`, `aria-haspopup="dialog"` and `aria-expanded`.
- The dialog header count falls back to the trace length before the flat tool-name list (`toolCallCount ?? toolCallTrace.length ?? toolNames.length ?? 0`), so it can never read "0 tool calls" above rendered trace rows.
- Transfer-chain chips use a composite `agentId-index` React key - the same agent can appear twice in a chain (A -> B -> A) and older payloads have no `agent_id`.
- README: documented the new `done`-payload fields (`tool_call_trace`, `transfer_chain`, `is_truncated`) including the restore behavior, and the new translation keys.

## Review feedback addressed (commit b48714e)

- `parseToolCallTrace` coerces `success` with an explicit `typeof e.success === 'boolean' ? e.success : true` (behaviorally equivalent to the previous `!== false`, but the intent - only a literal boolean is honored, unknown states never render a false failure icon - is now readable and matches the file's defensive-parsing style).
- The dialog now manages keyboard focus: initial focus moves to the Close button once the portal mounts (required for `aria-modal`), and focus is handed back to the trigger when the dialog closes.

## Review feedback addressed (commit 73865b1)

- Full Tab focus trap: the keydown handler cycles Tab/Shift+Tab across the dialog's focusable elements (first <-> last at the boundaries, and pulls focus back inside if it escaped), with `dialogRef` attached to the `role="dialog"` element - completing the `aria-modal` contract together with the initial-focus and focus-return behavior from the previous commit.
- Branch also merged with `main` (picks up the #321 tooltip flip fix), then fully rebased onto `main` for a linear history (the merge commit is gone; the rebased tree was verified byte-identical).

## Review feedback addressed (commit 6094d0d)

- The trace Output block now goes through the same pretty-printing as Input (shared `prettyTraceValue` helper: compact JSON expanded, plain-text / oversized / malformed payloads raw), matching the web chat and this description.
- `findChatbotRoot` extracted to `utils/` and reused by `Tooltip`, `Dropdown` and `ReasoningDetailsDialog` (the DOM-walk was copy-pasted three times; #321 flagged this as a follow-up and its merge into this branch made the extraction conflict-free).

## Verification

- `tsc --noEmit` on `src/**` - clean (only the pre-existing `eslint.config.ts` `@eslint/js` resolution error remains, untouched)
- `prettier --check src/**/*.{ts,tsx}` - clean
- `yarn build` - dist/index.js + dist/index.d.ts build

## Test plan

- [ ] In OpenCTI/OpenAEV with an agent that calls tools: hover an answered message, click "i" -> dialog opens centered over the panel with summary, reasoning, and trace rows
- [ ] Expand a trace row -> pretty-printed input + output, success/failure icon correct
- [ ] Message restored after page reload keeps the same dialog content (session restore path)
- [ ] Backend without tool_call_trace (older platform) -> dialog falls back to the numbered tool list
- [ ] Truncated turn (iteration budget exhausted) -> amber triangle visible without hover, banner shown in dialog
- [ ] Transfer between agents -> transfer chain chips rendered
- [ ] Escape / backdrop click / X button close the dialog; light and dark themes render correctly




