### PR TITLE
feat(chatbot): dynamic waiting experience with mini-game and away-completion notices (#325)

### DIFF
--- a/packages/filigran-chatbot/package.json
+++ b/packages/filigran-chatbot/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "git+https://github.com/FiligranHQ/filigran-ui.git"
   },
-  "version": "3.6.1",
+  "version": "3.7.0",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/filigran-chatbot/src/components/ChatMessages.tsx
+++ b/packages/filigran-chatbot/src/components/ChatMessages.tsx
@@ -15,6 +15,8 @@ interface ChatMessagesProps {
   onRelativeLinkClick?: (href: string) => void;
   /** Download an agent-generated file via the host app's backend proxy. */
   onDownloadFile?: (attachment: ChatAttachment) => void;
+  /** Host-level override for the waiting mini-game / dynamic messages. */
+  miniGameEnabled?: boolean;
   t: (key: string) => string;
 }
 
@@ -41,6 +43,7 @@ export const ChatMessages = ({
   logoIcon,
   onRelativeLinkClick,
   onDownloadFile,
+  miniGameEnabled = true,
   t,
 }: ChatMessagesProps) => {
   const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -226,7 +229,7 @@ export const ChatMessages = ({
         if (isThinking) {
           return (
             <div key={msg.id}>
-              <ChatThinking agentStatus={agentStatus} logoIcon={logoIcon} t={t} />
+              <ChatThinking agentStatus={agentStatus} logoIcon={logoIcon} t={t} miniGameEnabled={miniGameEnabled} />
             </div>
           );
         }

--- a/packages/filigran-chatbot/src/components/ChatPanel.tsx
+++ b/packages/filigran-chatbot/src/components/ChatPanel.tsx
@@ -176,6 +176,13 @@ export const ChatPanel: FunctionComponent<ChatPanelProps> = ({
   const firstName = user.firstName;
   const agentName = transferredAgent?.name || selectedAgent?.name || 'Assistant';
 
+  // Key on `.filigran-chatbot.fixed` (the panel root carries both in every
+  // mode) rather than `.filigran-chatbot` alone, which the toggle button also
+  // uses — otherwise focusing the toggle would be mistaken for viewing the chat.
+  // Stable reference (useCallback) so the notifier's effect doesn't re-run on
+  // every render — the panel re-renders frequently while a response streams.
+  const isViewingChat = useCallback(() => typeof document !== 'undefined' && !!document.activeElement?.closest('.filigran-chatbot.fixed'), []);
+
   // Notify when a long turn finishes and the user is not watching the chat —
   // away (tab hidden / another window) or in-app but focused outside the panel.
   useAwayCompletionNotice({
@@ -184,10 +191,7 @@ export const ChatPanel: FunctionComponent<ChatPanelProps> = ({
     t,
     enabled: notifyOnComplete,
     onComplete: onTaskComplete,
-    // Key on `.filigran-chatbot.fixed` (the panel root carries both in every
-    // mode) rather than `.filigran-chatbot` alone, which the toggle button also
-    // uses — otherwise focusing the toggle would be mistaken for viewing the chat.
-    isViewingChat: () => typeof document !== 'undefined' && !!document.activeElement?.closest('.filigran-chatbot.fixed'),
+    isViewingChat,
   });
 
   // Download an agent-generated file. The URL is resolved against the host

--- a/packages/filigran-chatbot/src/components/ChatPanel.tsx
+++ b/packages/filigran-chatbot/src/components/ChatPanel.tsx
@@ -184,7 +184,10 @@ export const ChatPanel: FunctionComponent<ChatPanelProps> = ({
     t,
     enabled: notifyOnComplete,
     onComplete: onTaskComplete,
-    isViewingChat: () => typeof document !== 'undefined' && !!document.activeElement?.closest('.filigran-chatbot'),
+    // Key on `.filigran-chatbot.fixed` (the panel root carries both in every
+    // mode) rather than `.filigran-chatbot` alone, which the toggle button also
+    // uses — otherwise focusing the toggle would be mistaken for viewing the chat.
+    isViewingChat: () => typeof document !== 'undefined' && !!document.activeElement?.closest('.filigran-chatbot.fixed'),
   });
 
   // Download an agent-generated file. The URL is resolved against the host

--- a/packages/filigran-chatbot/src/components/ChatPanel.tsx
+++ b/packages/filigran-chatbot/src/components/ChatPanel.tsx
@@ -6,6 +6,7 @@ import { useChat } from '../hooks/useChat';
 import { useAgents } from '../hooks/useAgents';
 import { useConversations } from '../hooks/useConversations';
 import { useSidebarResize } from '../hooks/useSidebarResize';
+import { useAwayCompletionNotice } from '../hooks/useAwayCompletionNotice';
 import { DefaultLogoIcon } from './icons';
 import { ChatHeader } from './ChatHeader';
 import { ChatInput } from './ChatInput';
@@ -50,6 +51,9 @@ export const ChatPanel: FunctionComponent<ChatPanelProps> = ({
   pageContext,
   pushContentSelector,
   backendType = 'rest',
+  miniGameEnabled = true,
+  notifyOnComplete = true,
+  onTaskComplete,
 }) => {
   const [modeMenuOpen, setModeMenuOpen] = useState(false);
 
@@ -171,6 +175,9 @@ export const ChatPanel: FunctionComponent<ChatPanelProps> = ({
   const resolvedLogo = logoIcon ?? <DefaultLogoIcon size={24} />;
   const firstName = user.firstName;
   const agentName = transferredAgent?.name || selectedAgent?.name || 'Assistant';
+
+  // Notify on away-completion (tab hidden / multitasking) of a long-running turn.
+  useAwayCompletionNotice({ isLoading, agentName, t, enabled: notifyOnComplete, onComplete: onTaskComplete });
 
   // Download an agent-generated file. The URL is resolved against the host
   // app's own backend proxy (apiBaseUrl), NOT the upstream chat service:
@@ -434,6 +441,7 @@ export const ChatPanel: FunctionComponent<ChatPanelProps> = ({
           logoIcon={resolvedLogo}
           onRelativeLinkClick={onRelativeLinkClick}
           onDownloadFile={canDownload ? handleDownloadFile : undefined}
+          miniGameEnabled={miniGameEnabled}
           t={t}
         />
       )}

--- a/packages/filigran-chatbot/src/components/ChatPanel.tsx
+++ b/packages/filigran-chatbot/src/components/ChatPanel.tsx
@@ -176,8 +176,16 @@ export const ChatPanel: FunctionComponent<ChatPanelProps> = ({
   const firstName = user.firstName;
   const agentName = transferredAgent?.name || selectedAgent?.name || 'Assistant';
 
-  // Notify on away-completion (tab hidden / multitasking) of a long-running turn.
-  useAwayCompletionNotice({ isLoading, agentName, t, enabled: notifyOnComplete, onComplete: onTaskComplete });
+  // Notify when a long turn finishes and the user is not watching the chat —
+  // away (tab hidden / another window) or in-app but focused outside the panel.
+  useAwayCompletionNotice({
+    isLoading,
+    agentName,
+    t,
+    enabled: notifyOnComplete,
+    onComplete: onTaskComplete,
+    isViewingChat: () => typeof document !== 'undefined' && !!document.activeElement?.closest('.filigran-chatbot'),
+  });
 
   // Download an agent-generated file. The URL is resolved against the host
   // app's own backend proxy (apiBaseUrl), NOT the upstream chat service:

--- a/packages/filigran-chatbot/src/components/ChatThinking.tsx
+++ b/packages/filigran-chatbot/src/components/ChatThinking.tsx
@@ -200,11 +200,38 @@ function formatElapsed(seconds: number): string {
  */
 const ELAPSED_DISPLAY_THRESHOLD_S = 15;
 
+/**
+ * The reasoning window flips to the waiting game once nothing has progressed
+ * for this long — i.e. no reasoning at all, or a reasoning stream that stalled.
+ */
+const STALL_DELAY_MS = 7000;
+
+/**
+ * True once `signal` has stayed unchanged for `delayMs`. Re-arms whenever the
+ * signal changes, so resumed reasoning clears the flag immediately. Used to
+ * detect a stalled (or absent) reasoning stream so we can show the waiting game
+ * in the meantime and flip back to the reasoning the moment it resumes.
+ */
+function useStalled(signal: number, delayMs: number): boolean {
+  const [stalled, setStalled] = useState(false);
+  useEffect(() => {
+    setStalled(false);
+    const id = window.setTimeout(() => setStalled(true), delayMs);
+    return () => window.clearTimeout(id);
+  }, [signal, delayMs]);
+  return stalled;
+}
+
 export const ChatThinking = ({ agentStatus, logoIcon, t, miniGameEnabled = true }: ChatThinkingProps) => {
   const { label, StatusIcon, showDots } = resolveStatusVisual(agentStatus, t);
   const thinkingContent = agentStatus?.thinkingContent;
   const elapsedS = agentStatus?.elapsedS;
   const showElapsed = typeof elapsedS === 'number' && elapsedS >= ELAPSED_DISPLAY_THRESHOLD_S;
+  // Show the waiting game when reasoning is absent or has stalled for 7s; flip
+  // back to the reasoning window the moment new reasoning text resumes (the
+  // accumulated content carries the continuation).
+  const stalled = useStalled(thinkingContent?.length ?? 0, STALL_DELAY_MS);
+  const showGame = miniGameEnabled && stalled;
 
   return (
     <>
@@ -233,7 +260,11 @@ export const ChatThinking = ({ agentStatus, logoIcon, t, miniGameEnabled = true 
           </div>
         </div>
       </div>
-      {thinkingContent ? <ThinkingTextBubble content={thinkingContent} /> : <ChatWaitingGame t={t} enabled={miniGameEnabled} />}
+      {thinkingContent && !showGame ? (
+        <ThinkingTextBubble content={thinkingContent} />
+      ) : showGame ? (
+        <ChatWaitingGame t={t} enabled={miniGameEnabled} />
+      ) : null}
     </>
   );
 };

--- a/packages/filigran-chatbot/src/components/ChatThinking.tsx
+++ b/packages/filigran-chatbot/src/components/ChatThinking.tsx
@@ -204,7 +204,7 @@ const ELAPSED_DISPLAY_THRESHOLD_S = 15;
  * The reasoning window flips to the waiting game once nothing has progressed
  * for this long — i.e. no reasoning at all, or a reasoning stream that stalled.
  */
-const STALL_DELAY_MS = 7000;
+const STALL_DELAY_MS = 5000;
 
 /**
  * True once `signal` has stayed unchanged for `delayMs`. Re-arms whenever the
@@ -227,7 +227,7 @@ export const ChatThinking = ({ agentStatus, logoIcon, t, miniGameEnabled = true 
   const thinkingContent = agentStatus?.thinkingContent;
   const elapsedS = agentStatus?.elapsedS;
   const showElapsed = typeof elapsedS === 'number' && elapsedS >= ELAPSED_DISPLAY_THRESHOLD_S;
-  // Show the waiting game when reasoning is absent or has stalled for 7s; flip
+  // Show the waiting game when reasoning is absent or has stalled for 5s; flip
   // back to the reasoning window the moment new reasoning text resumes (the
   // accumulated content carries the continuation).
   const stalled = useStalled(thinkingContent?.length ?? 0, STALL_DELAY_MS);

--- a/packages/filigran-chatbot/src/components/ChatThinking.tsx
+++ b/packages/filigran-chatbot/src/components/ChatThinking.tsx
@@ -210,15 +210,18 @@ const STALL_DELAY_MS = 5000;
  * True once `signal` has stayed unchanged for `delayMs`. Re-arms whenever the
  * signal changes, so resumed reasoning clears the flag immediately. Used to
  * detect a stalled (or absent) reasoning stream so we can show the waiting game
- * in the meantime and flip back to the reasoning the moment it resumes.
+ * in the meantime and flip back to the reasoning the moment it resumes. Arms no
+ * timer (and never flips) while `enabled` is false, so a host that disables the
+ * waiting game schedules no timeouts or re-renders for it.
  */
-function useStalled(signal: number, delayMs: number): boolean {
+function useStalled(signal: number, delayMs: number, enabled: boolean): boolean {
   const [stalled, setStalled] = useState(false);
   useEffect(() => {
     setStalled(false);
+    if (!enabled) return;
     const id = window.setTimeout(() => setStalled(true), delayMs);
     return () => window.clearTimeout(id);
-  }, [signal, delayMs]);
+  }, [signal, delayMs, enabled]);
   return stalled;
 }
 
@@ -230,7 +233,7 @@ export const ChatThinking = ({ agentStatus, logoIcon, t, miniGameEnabled = true 
   // Show the waiting game when reasoning is absent or has stalled for 5s; flip
   // back to the reasoning window the moment new reasoning text resumes (the
   // accumulated content carries the continuation).
-  const stalled = useStalled(thinkingContent?.length ?? 0, STALL_DELAY_MS);
+  const stalled = useStalled(thinkingContent?.length ?? 0, STALL_DELAY_MS, miniGameEnabled);
   const showGame = miniGameEnabled && stalled;
 
   return (

--- a/packages/filigran-chatbot/src/components/ChatThinking.tsx
+++ b/packages/filigran-chatbot/src/components/ChatThinking.tsx
@@ -216,8 +216,18 @@ const STALL_DELAY_MS = 5000;
  */
 function useStalled(signal: number, delayMs: number, enabled: boolean): boolean {
   const [stalled, setStalled] = useState(false);
-  useEffect(() => {
+  const prevSignalRef = useRef(signal);
+
+  // Clear the flag synchronously during render (not in an effect) the moment
+  // the signal changes or the feature is disabled, so resumed reasoning flips
+  // back without a one-frame lag where the waiting game lingers.
+  const signalChanged = prevSignalRef.current !== signal;
+  prevSignalRef.current = signal;
+  if (stalled && (signalChanged || !enabled)) {
     setStalled(false);
+  }
+
+  useEffect(() => {
     if (!enabled) return;
     const id = window.setTimeout(() => setStalled(true), delayMs);
     return () => window.clearTimeout(id);

--- a/packages/filigran-chatbot/src/components/ChatThinking.tsx
+++ b/packages/filigran-chatbot/src/components/ChatThinking.tsx
@@ -12,11 +12,14 @@ import {
   UserPlusIcon,
   WrenchIcon,
 } from './icons';
+import { ChatWaitingGame } from './ChatWaitingGame';
 
 interface ChatThinkingProps {
   agentStatus: AgentStatusState | null;
   logoIcon?: React.ReactNode;
   t: (key: string) => string;
+  /** Host-level override for the waiting mini-game / dynamic messages. */
+  miniGameEnabled?: boolean;
 }
 
 type IconComponent = (props: IconProps) => React.JSX.Element;
@@ -197,7 +200,7 @@ function formatElapsed(seconds: number): string {
  */
 const ELAPSED_DISPLAY_THRESHOLD_S = 15;
 
-export const ChatThinking = ({ agentStatus, logoIcon, t }: ChatThinkingProps) => {
+export const ChatThinking = ({ agentStatus, logoIcon, t, miniGameEnabled = true }: ChatThinkingProps) => {
   const { label, StatusIcon, showDots } = resolveStatusVisual(agentStatus, t);
   const thinkingContent = agentStatus?.thinkingContent;
   const elapsedS = agentStatus?.elapsedS;
@@ -230,7 +233,7 @@ export const ChatThinking = ({ agentStatus, logoIcon, t }: ChatThinkingProps) =>
           </div>
         </div>
       </div>
-      {thinkingContent && <ThinkingTextBubble content={thinkingContent} />}
+      {thinkingContent ? <ThinkingTextBubble content={thinkingContent} /> : <ChatWaitingGame t={t} enabled={miniGameEnabled} />}
     </>
   );
 };

--- a/packages/filigran-chatbot/src/components/ChatThinking.tsx
+++ b/packages/filigran-chatbot/src/components/ChatThinking.tsx
@@ -218,21 +218,23 @@ function useStalled(signal: number, delayMs: number, enabled: boolean): boolean 
   const [stalled, setStalled] = useState(false);
   const prevSignalRef = useRef(signal);
 
-  // Clear the flag synchronously during render (not in an effect) the moment
-  // the signal changes or the feature is disabled, so resumed reasoning flips
-  // back without a one-frame lag where the waiting game lingers.
+  // Did the signal change since the last settled render? When it did, reasoning
+  // has just resumed, so we report "not stalled" for this very render without a
+  // render-phase state update (discouraged in React / brittle under StrictMode
+  // and concurrent rendering). The effect below then resets the flag and re-arms
+  // the timer — deriving the value here keeps the flip back to the reasoning
+  // window free of the one-frame lag a clear-in-effect alone would leave.
   const signalChanged = prevSignalRef.current !== signal;
-  prevSignalRef.current = signal;
-  if (stalled && (signalChanged || !enabled)) {
-    setStalled(false);
-  }
 
   useEffect(() => {
+    prevSignalRef.current = signal;
+    setStalled(false);
     if (!enabled) return;
     const id = window.setTimeout(() => setStalled(true), delayMs);
     return () => window.clearTimeout(id);
   }, [signal, delayMs, enabled]);
-  return stalled;
+
+  return enabled && stalled && !signalChanged;
 }
 
 export const ChatThinking = ({ agentStatus, logoIcon, t, miniGameEnabled = true }: ChatThinkingProps) => {

--- a/packages/filigran-chatbot/src/components/ChatWaitingGame.tsx
+++ b/packages/filigran-chatbot/src/components/ChatWaitingGame.tsx
@@ -24,8 +24,6 @@ const DEFAULT_MESSAGES = [
 /** localStorage key for the per-browser mini-game preference (on by default). */
 const PREF_KEY = 'filigranChatMiniGame';
 
-/** Only reveal the game on genuinely long waits, so normal replies stay clean. */
-const REVEAL_DELAY_MS = 7000;
 /** Plain (no-game) message rotation cadence. */
 const PLAIN_ROTATE_MS = 2600;
 
@@ -314,33 +312,27 @@ export const ChatWaitingGame = ({ t, enabled = true }: ChatWaitingGameProps) => 
   const messages = useMemo(() => DEFAULT_MESSAGES.map((m) => t(m)), [t]);
   const reducedMotion = usePrefersReducedMotion();
   const [minigameOn, setMinigameOn] = useState(readPref);
-  const [visible, setVisible] = useState(false);
   const [msgIndex, setMsgIndex] = useState(0);
   const canvasRef = useRef<HTMLCanvasElement>(null);
 
   const playMode = enabled && minigameOn && !reducedMotion;
 
-  useEffect(() => {
-    const id = window.setTimeout(() => setVisible(true), REVEAL_DELAY_MS);
-    return () => window.clearTimeout(id);
-  }, []);
-
   // Plain-text rotation when the game is off / reduced motion.
   useEffect(() => {
-    if (!visible || playMode) return;
+    if (playMode) return;
     const id = window.setInterval(() => setMsgIndex((i) => (i + 1) % messages.length), PLAIN_ROTATE_MS);
     return () => window.clearInterval(id);
-  }, [visible, playMode, messages.length]);
+  }, [playMode, messages.length]);
 
   // Canvas engine when the game is on.
   useEffect(() => {
-    if (!visible || !playMode) return;
+    if (!playMode) return;
     const canvas = canvasRef.current;
     if (!canvas) return;
     return createInvaderGame(canvas, messages, setMsgIndex);
-  }, [visible, playMode, messages]);
+  }, [playMode, messages]);
 
-  if (!enabled || !visible) return null;
+  if (!enabled) return null;
 
   const current = messages[msgIndex % messages.length];
 

--- a/packages/filigran-chatbot/src/components/ChatWaitingGame.tsx
+++ b/packages/filigran-chatbot/src/components/ChatWaitingGame.tsx
@@ -24,8 +24,8 @@ const DEFAULT_MESSAGES = [
 /** localStorage key for the per-browser mini-game preference (on by default). */
 const PREF_KEY = 'filigranChatMiniGame';
 
-/** Quick interactions should stay clean — only reveal the game after a beat. */
-const REVEAL_DELAY_MS = 2200;
+/** Only reveal the game on genuinely long waits, so normal replies stay clean. */
+const REVEAL_DELAY_MS = 7000;
 /** Plain (no-game) message rotation cadence. */
 const PLAIN_ROTATE_MS = 2600;
 

--- a/packages/filigran-chatbot/src/components/ChatWaitingGame.tsx
+++ b/packages/filigran-chatbot/src/components/ChatWaitingGame.tsx
@@ -232,33 +232,34 @@ function createInvaderGame(canvas: HTMLCanvasElement, messages: string[], onMess
     }
   }
 
-  function withAlpha(a: number): string {
-    return `color-mix(in srgb, ${accent} ${Math.round(a * 100)}%, transparent)`;
-  }
-
   function draw(): void {
     ctx.clearRect(0, 0, cssW, cssH);
 
+    // Single solid fill colour throughout; vary opacity via globalAlpha rather
+    // than CSS color-mix() strings, which are not reliably accepted as a canvas
+    // fillStyle on every browser (some fall back to opaque black).
+    ctx.fillStyle = accent;
+
     ctx.font = arcadeFont(fontPx);
     ctx.textBaseline = 'middle';
-    ctx.fillStyle = withAlpha(0.85);
+    ctx.globalAlpha = 0.85;
     for (const l of letters) {
       if (l.alive) ctx.fillText(l.char, l.x, letterY);
     }
 
-    ctx.fillStyle = accent;
+    ctx.globalAlpha = 1;
     for (const b of bullets) {
       ctx.fillRect(b.x - 1, b.y, 2, 7);
     }
 
     for (const p of particles) {
-      ctx.fillStyle = withAlpha(Math.max(p.life, 0) * 0.9);
+      ctx.globalAlpha = Math.max(p.life, 0) * 0.9;
       ctx.fillRect(p.x - 1.5, p.y - 1.5, 3, 3);
     }
 
+    ctx.globalAlpha = 1;
     const frame = INVADER_FRAMES[legFrame];
     const ox = Math.round(shipX - SPRITE_W / 2);
-    ctx.fillStyle = accent;
     for (let r = 0; r < frame.length; r++) {
       const row = frame[r];
       for (let c = 0; c < row.length; c++) {

--- a/packages/filigran-chatbot/src/components/ChatWaitingGame.tsx
+++ b/packages/filigran-chatbot/src/components/ChatWaitingGame.tsx
@@ -68,8 +68,13 @@ function usePrefersReducedMotion(): boolean {
     if (typeof window === 'undefined' || !window.matchMedia) return;
     const mql = window.matchMedia('(prefers-reduced-motion: reduce)');
     const onChange = () => setReduced(mql.matches);
-    mql.addEventListener('change', onChange);
-    return () => mql.removeEventListener('change', onChange);
+    // Older Safari/WebKit only expose the deprecated addListener/removeListener.
+    if (typeof mql.addEventListener === 'function') {
+      mql.addEventListener('change', onChange);
+      return () => mql.removeEventListener('change', onChange);
+    }
+    mql.addListener(onChange);
+    return () => mql.removeListener(onChange);
   }, []);
   return reduced;
 }

--- a/packages/filigran-chatbot/src/components/ChatWaitingGame.tsx
+++ b/packages/filigran-chatbot/src/components/ChatWaitingGame.tsx
@@ -354,8 +354,13 @@ export const ChatWaitingGame = ({ t, enabled = true }: ChatWaitingGameProps) => 
   const current = messages[msgIndex % messages.length];
 
   return (
-    <div className="ml-11 mt-2.5 max-w-[78%]" role="status" aria-live="polite">
-      <span className="sr-only">{current}</span>
+    <div className="ml-11 mt-2.5 max-w-[78%]">
+      {/* Keep the live region scoped to the announced text only — wrapping the
+          whole UI (including the toggle button) made screen readers re-announce
+          the control alongside each message change. */}
+      <span className="sr-only" role="status" aria-live="polite">
+        {current}
+      </span>
       <div className="relative overflow-hidden rounded-md bg-[var(--chat-accent)]/[0.03]" style={{ animation: 'chat-fade-in 0.5s ease-out' }}>
         {playMode ? (
           <canvas ref={canvasRef} aria-hidden className="block w-full" style={{ height: GAME_HEIGHT }} />
@@ -375,6 +380,7 @@ export const ChatWaitingGame = ({ t, enabled = true }: ChatWaitingGameProps) => 
               setMinigameOn(next);
               writePref(next);
             }}
+            aria-pressed={minigameOn}
             aria-label={minigameOn ? t('Turn off the waiting mini-game') : t('Turn on the waiting mini-game')}
             title={minigameOn ? t('Turn off the waiting mini-game') : t('Turn on the waiting mini-game')}
             className={`absolute top-1 right-1 rounded p-1 transition-opacity ${

--- a/packages/filigran-chatbot/src/components/ChatWaitingGame.tsx
+++ b/packages/filigran-chatbot/src/components/ChatWaitingGame.tsx
@@ -288,14 +288,23 @@ function createInvaderGame(canvas: HTMLCanvasElement, messages: string[], onMess
     layout();
   }
 
-  const ro = new ResizeObserver(applySize);
-  ro.observe(canvas);
+  // Prefer ResizeObserver; fall back to a window resize listener on older
+  // browsers / embedded webviews where it is unavailable (an unguarded
+  // `new ResizeObserver(...)` would throw and break the waiting experience).
+  let ro: ResizeObserver | null = null;
+  if (typeof ResizeObserver !== 'undefined') {
+    ro = new ResizeObserver(applySize);
+    ro.observe(canvas);
+  } else {
+    window.addEventListener('resize', applySize);
+  }
   applySize();
   raf = requestAnimationFrame(loop);
 
   return () => {
     cancelAnimationFrame(raf);
-    ro.disconnect();
+    if (ro) ro.disconnect();
+    else window.removeEventListener('resize', applySize);
   };
 }
 

--- a/packages/filigran-chatbot/src/components/ChatWaitingGame.tsx
+++ b/packages/filigran-chatbot/src/components/ChatWaitingGame.tsx
@@ -361,14 +361,24 @@ export const ChatWaitingGame = ({ t, enabled = true }: ChatWaitingGameProps) => 
       <span className="sr-only" role="status" aria-live="polite">
         {current}
       </span>
-      <div className="relative overflow-hidden rounded-md bg-[var(--chat-accent)]/[0.03]" style={{ animation: 'chat-fade-in 0.5s ease-out' }}>
+      {/* Suppress every non-essential animation (fade-ins, the blinking caret)
+          under prefers-reduced-motion, so the reduced-motion path really is
+          motion-free — only the plain dimmed text rotates. */}
+      <div
+        className="relative overflow-hidden rounded-md bg-[var(--chat-accent)]/[0.03]"
+        style={reducedMotion ? undefined : { animation: 'chat-fade-in 0.5s ease-out' }}
+      >
         {playMode ? (
           <canvas ref={canvasRef} aria-hidden className="block w-full" style={{ height: GAME_HEIGHT }} />
         ) : (
           <div className="flex items-center" style={{ height: GAME_HEIGHT }}>
-            <span key={current} className="px-3 text-xs text-gray-500 dark:text-white/45" style={{ animation: 'chat-fade-in 0.4s ease-out' }}>
+            <span
+              key={current}
+              className="px-3 text-xs text-gray-500 dark:text-white/45"
+              style={reducedMotion ? undefined : { animation: 'chat-fade-in 0.4s ease-out' }}
+            >
               {current}
-              <span className="ml-0.5 inline-block w-1 h-3 align-middle bg-[var(--chat-accent)]/60 animate-pulse" />
+              <span className={`ml-0.5 inline-block w-1 h-3 align-middle bg-[var(--chat-accent)]/60 ${reducedMotion ? '' : 'animate-pulse'}`} />
             </span>
           </div>
         )}

--- a/packages/filigran-chatbot/src/components/ChatWaitingGame.tsx
+++ b/packages/filigran-chatbot/src/components/ChatWaitingGame.tsx
@@ -332,12 +332,14 @@ export const ChatWaitingGame = ({ t, enabled = true }: ChatWaitingGameProps) => 
 
   const playMode = enabled && minigameOn && !reducedMotion;
 
-  // Plain-text rotation when the game is off / reduced motion.
+  // Plain-text rotation when the game is off / reduced motion. Skipped while the
+  // game drives the index, and entirely when the feature is disabled (so a
+  // disabled host arms no timer); `enabled` is a dep so toggling it cleans up.
   useEffect(() => {
-    if (playMode) return;
+    if (playMode || !enabled) return;
     const id = window.setInterval(() => setMsgIndex((i) => (i + 1) % messages.length), PLAIN_ROTATE_MS);
     return () => window.clearInterval(id);
-  }, [playMode, messages.length]);
+  }, [playMode, enabled, messages.length]);
 
   // Canvas engine when the game is on.
   useEffect(() => {

--- a/packages/filigran-chatbot/src/components/ChatWaitingGame.tsx
+++ b/packages/filigran-chatbot/src/components/ChatWaitingGame.tsx
@@ -1,0 +1,381 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { GamepadIcon } from './icons';
+
+/**
+ * Playful, rotating "still working on it" messages shown below the status
+ * bubble during longer waits. They double as the Space Invader's targets:
+ * the little invader ship erases them letter by letter, then the next one
+ * fades in. Kept short and upbeat so they fit on one line in the narrow
+ * floating panel and read as a sense of progress rather than noise.
+ */
+const DEFAULT_MESSAGES = [
+  'Crunching the data',
+  'Connecting the dots',
+  'Consulting the sources',
+  'Thinking it through',
+  'Reticulating splines',
+  'Analyzing the details',
+  'Almost there',
+  'Putting it together',
+  'Polishing the answer',
+  'Wrapping things up',
+];
+
+/** localStorage key for the per-browser mini-game preference (on by default). */
+const PREF_KEY = 'filigranChatMiniGame';
+
+/** Quick interactions should stay clean — only reveal the game after a beat. */
+const REVEAL_DELAY_MS = 2200;
+/** Plain (no-game) message rotation cadence. */
+const PLAIN_ROTATE_MS = 2600;
+
+/** Canvas height in CSS px — room for the target row + the gliding ship. */
+const GAME_HEIGHT = 70;
+
+/** Chunky monospace for the retro arcade feel + even letter spacing. */
+const arcadeFont = (px: number): string => `700 ${px}px 'Courier New', ui-monospace, monospace`;
+
+/**
+ * Classic 11x8 "crab" invader, two leg frames toggled while it glides — the
+ * silhouette reads instantly as a Space Invader. `1` = filled pixel.
+ */
+const INVADER_FRAMES: string[][] = [
+  ['00100000100', '00010001000', '00111111100', '01101110110', '11111111111', '10111111101', '10100000101', '00011011000'],
+  ['00100000100', '10010001001', '10111111101', '11101110111', '11111111111', '00111111100', '00100000100', '01000000010'],
+];
+
+function readPref(): boolean {
+  if (typeof window === 'undefined') return true;
+  try {
+    return window.localStorage.getItem(PREF_KEY) !== 'off';
+  } catch {
+    return true;
+  }
+}
+
+function writePref(on: boolean): void {
+  try {
+    window.localStorage.setItem(PREF_KEY, on ? 'on' : 'off');
+  } catch {
+    /* private mode / disabled storage — fall back to in-memory state only */
+  }
+}
+
+function usePrefersReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return false;
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  });
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return;
+    const mql = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const onChange = () => setReduced(mql.matches);
+    mql.addEventListener('change', onChange);
+    return () => mql.removeEventListener('change', onChange);
+  }, []);
+  return reduced;
+}
+
+interface Letter {
+  char: string;
+  x: number;
+  w: number;
+  alive: boolean;
+}
+
+interface Bullet {
+  x: number;
+  y: number;
+}
+
+interface Particle {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  life: number;
+}
+
+/**
+ * Self-contained canvas mini-game. Owns its own rAF loop, resize handling and
+ * lifecycle; the only thing it reports back is the index of the message it is
+ * currently destroying, so the host can keep an accessible text mirror in sync.
+ * Returns a teardown function.
+ */
+function createInvaderGame(canvas: HTMLCanvasElement, messages: string[], onMessage: (index: number) => void): () => void {
+  const maybeCtx = canvas.getContext('2d');
+  if (!maybeCtx) return () => {};
+  const ctx: CanvasRenderingContext2D = maybeCtx;
+
+  let raf = 0;
+  let cssW = 0;
+  const cssH = GAME_HEIGHT;
+  let fontPx = 13;
+  let accent = '#7b5cff';
+
+  let msgIndex = 0;
+  let letters: Letter[] = [];
+  let targetIndex = -1;
+  let bullets: Bullet[] = [];
+  let particles: Particle[] = [];
+  let shipX = 0;
+  let cooldown = 0;
+  let clearedAt = 0;
+  let legFrame = 0;
+  let legTimer = 0;
+  let last = performance.now();
+
+  const PX = 2;
+  const SPRITE_W = 11 * PX;
+  const SPRITE_H = 8 * PX;
+  const shipTop = cssH - SPRITE_H - 4;
+  const letterY = Math.round(cssH * 0.42);
+
+  function resolveAccent(): void {
+    const v = getComputedStyle(canvas).getPropertyValue('--chat-accent').trim();
+    if (v) accent = v;
+  }
+
+  function firstAlive(from: number): number {
+    for (let i = from; i < letters.length; i++) {
+      if (letters[i].alive) return i;
+    }
+    return -1;
+  }
+
+  function layout(): void {
+    if (cssW <= 0) return;
+    const text = messages[msgIndex % messages.length] || '';
+    onMessage(msgIndex % messages.length);
+
+    // Shrink the font until the message fits the available width.
+    fontPx = 13;
+    for (; fontPx >= 8; fontPx--) {
+      ctx.font = arcadeFont(fontPx);
+      if (ctx.measureText(text).width <= cssW - 16) break;
+    }
+    ctx.font = arcadeFont(fontPx);
+
+    const widths = Array.from(text).map((ch) => ctx.measureText(ch).width);
+    const total = widths.reduce((a, b) => a + b, 0);
+    let x = (cssW - total) / 2;
+    letters = Array.from(text).map((ch, i) => {
+      const lx = x;
+      x += widths[i];
+      return { char: ch, x: lx, w: widths[i], alive: ch.trim().length > 0 };
+    });
+    targetIndex = firstAlive(0);
+    bullets = [];
+    particles = [];
+    cooldown = 0;
+    clearedAt = 0;
+    if (shipX <= 0) shipX = cssW / 2;
+  }
+
+  function letterCenter(i: number): number {
+    return letters[i].x + letters[i].w / 2;
+  }
+
+  function update(dt: number): void {
+    const dtf = Math.min(dt / 16.6667, 3);
+
+    legTimer += dt;
+    if (legTimer > 320) {
+      legTimer = 0;
+      legFrame ^= 1;
+    }
+
+    if (targetIndex === -1) {
+      // Message fully cleared — brief pause, then load the next one.
+      if (clearedAt === 0) clearedAt = performance.now();
+      else if (performance.now() - clearedAt > 650) {
+        msgIndex++;
+        layout();
+      }
+    } else {
+      const targetX = letterCenter(targetIndex);
+      shipX += (targetX - shipX) * Math.min(0.16 * dtf, 1);
+      cooldown -= dt;
+      if (bullets.length === 0 && cooldown <= 0 && Math.abs(shipX - targetX) < 4) {
+        bullets.push({ x: shipX, y: shipTop });
+        cooldown = 130;
+      }
+    }
+
+    for (let i = bullets.length - 1; i >= 0; i--) {
+      bullets[i].y -= 2.6 * dtf;
+      if (bullets[i].y <= letterY) {
+        // Hit: detonate the current target letter and advance.
+        if (targetIndex !== -1) {
+          const cx = letterCenter(targetIndex);
+          letters[targetIndex].alive = false;
+          for (let p = 0; p < 7; p++) {
+            const ang = (Math.PI * 2 * p) / 7 + Math.random();
+            const spd = 0.6 + Math.random() * 1.4;
+            particles.push({ x: cx, y: letterY, vx: Math.cos(ang) * spd, vy: Math.sin(ang) * spd, life: 1 });
+          }
+          targetIndex = firstAlive(targetIndex + 1);
+        }
+        bullets.splice(i, 1);
+      }
+    }
+
+    for (let i = particles.length - 1; i >= 0; i--) {
+      const p = particles[i];
+      p.x += p.vx * dtf;
+      p.y += p.vy * dtf;
+      p.life -= 0.045 * dtf;
+      if (p.life <= 0) particles.splice(i, 1);
+    }
+  }
+
+  function withAlpha(a: number): string {
+    return `color-mix(in srgb, ${accent} ${Math.round(a * 100)}%, transparent)`;
+  }
+
+  function draw(): void {
+    ctx.clearRect(0, 0, cssW, cssH);
+
+    ctx.font = arcadeFont(fontPx);
+    ctx.textBaseline = 'middle';
+    ctx.fillStyle = withAlpha(0.85);
+    for (const l of letters) {
+      if (l.alive) ctx.fillText(l.char, l.x, letterY);
+    }
+
+    ctx.fillStyle = accent;
+    for (const b of bullets) {
+      ctx.fillRect(b.x - 1, b.y, 2, 7);
+    }
+
+    for (const p of particles) {
+      ctx.fillStyle = withAlpha(Math.max(p.life, 0) * 0.9);
+      ctx.fillRect(p.x - 1.5, p.y - 1.5, 3, 3);
+    }
+
+    const frame = INVADER_FRAMES[legFrame];
+    const ox = Math.round(shipX - SPRITE_W / 2);
+    ctx.fillStyle = accent;
+    for (let r = 0; r < frame.length; r++) {
+      const row = frame[r];
+      for (let c = 0; c < row.length; c++) {
+        if (row[c] === '1') ctx.fillRect(ox + c * PX, shipTop + r * PX, PX, PX);
+      }
+    }
+  }
+
+  function loop(now: number): void {
+    const dt = now - last;
+    last = now;
+    if (!document.hidden && cssW > 0) {
+      update(dt);
+      draw();
+    }
+    raf = requestAnimationFrame(loop);
+  }
+
+  function applySize(): void {
+    const rect = canvas.getBoundingClientRect();
+    const dpr = window.devicePixelRatio || 1;
+    cssW = rect.width;
+    canvas.width = Math.max(1, Math.round(cssW * dpr));
+    canvas.height = Math.round(cssH * dpr);
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    resolveAccent();
+    layout();
+  }
+
+  const ro = new ResizeObserver(applySize);
+  ro.observe(canvas);
+  applySize();
+  raf = requestAnimationFrame(loop);
+
+  return () => {
+    cancelAnimationFrame(raf);
+    ro.disconnect();
+  };
+}
+
+interface ChatWaitingGameProps {
+  t: (key: string) => string;
+  /** Host-level override; when false the feature is hidden entirely. */
+  enabled?: boolean;
+}
+
+/**
+ * Waiting experience shown below the status bubble during longer waits:
+ * dynamic rotating messages with an optional Space Invader mini-game that
+ * shoots the message letters away one by one. The game can be toggled off
+ * per browser (preference persisted in localStorage); when off — or when the
+ * OS requests reduced motion — the messages simply rotate as plain dimmed
+ * text, so the "dynamic loading messages" feedback always stands on its own.
+ */
+export const ChatWaitingGame = ({ t, enabled = true }: ChatWaitingGameProps) => {
+  const messages = useMemo(() => DEFAULT_MESSAGES.map((m) => t(m)), [t]);
+  const reducedMotion = usePrefersReducedMotion();
+  const [minigameOn, setMinigameOn] = useState(readPref);
+  const [visible, setVisible] = useState(false);
+  const [msgIndex, setMsgIndex] = useState(0);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  const playMode = enabled && minigameOn && !reducedMotion;
+
+  useEffect(() => {
+    const id = window.setTimeout(() => setVisible(true), REVEAL_DELAY_MS);
+    return () => window.clearTimeout(id);
+  }, []);
+
+  // Plain-text rotation when the game is off / reduced motion.
+  useEffect(() => {
+    if (!visible || playMode) return;
+    const id = window.setInterval(() => setMsgIndex((i) => (i + 1) % messages.length), PLAIN_ROTATE_MS);
+    return () => window.clearInterval(id);
+  }, [visible, playMode, messages.length]);
+
+  // Canvas engine when the game is on.
+  useEffect(() => {
+    if (!visible || !playMode) return;
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    return createInvaderGame(canvas, messages, setMsgIndex);
+  }, [visible, playMode, messages]);
+
+  if (!enabled || !visible) return null;
+
+  const current = messages[msgIndex % messages.length];
+
+  return (
+    <div className="ml-11 mt-2.5 max-w-[78%]" role="status" aria-live="polite">
+      <span className="sr-only">{current}</span>
+      <div className="relative overflow-hidden rounded-md bg-[var(--chat-accent)]/[0.03]" style={{ animation: 'chat-fade-in 0.5s ease-out' }}>
+        {playMode ? (
+          <canvas ref={canvasRef} aria-hidden className="block w-full" style={{ height: GAME_HEIGHT }} />
+        ) : (
+          <div className="flex items-center" style={{ height: GAME_HEIGHT }}>
+            <span key={current} className="px-3 text-xs text-gray-500 dark:text-white/45" style={{ animation: 'chat-fade-in 0.4s ease-out' }}>
+              {current}
+              <span className="ml-0.5 inline-block w-1 h-3 align-middle bg-[var(--chat-accent)]/60 animate-pulse" />
+            </span>
+          </div>
+        )}
+        {!reducedMotion && (
+          <button
+            type="button"
+            onClick={() => {
+              const next = !minigameOn;
+              setMinigameOn(next);
+              writePref(next);
+            }}
+            aria-label={minigameOn ? t('Turn off the waiting mini-game') : t('Turn on the waiting mini-game')}
+            title={minigameOn ? t('Turn off the waiting mini-game') : t('Turn on the waiting mini-game')}
+            className={`absolute top-1 right-1 rounded p-1 transition-opacity ${
+              minigameOn ? 'text-[var(--chat-accent)] opacity-50 hover:opacity-100' : 'text-gray-400 dark:text-white/40 opacity-40 hover:opacity-90'
+            }`}
+          >
+            <GamepadIcon size={13} />
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/packages/filigran-chatbot/src/components/icons/GamepadIcon.tsx
+++ b/packages/filigran-chatbot/src/components/icons/GamepadIcon.tsx
@@ -1,0 +1,22 @@
+import type { IconProps } from '../../types';
+
+export const GamepadIcon = ({ className, size = 24 }: IconProps) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className}
+  >
+    <line x1="6" x2="10" y1="11" y2="11" />
+    <line x1="8" x2="8" y1="9" y2="13" />
+    <line x1="15" x2="15.01" y1="12" y2="12" />
+    <line x1="18" x2="18.01" y1="10" y2="10" />
+    <path d="M17.32 5H6.68a4 4 0 0 0-3.978 3.59c-.006.052-.01.101-.017.152C2.604 9.416 2 14.456 2 16a3 3 0 0 0 3 3c1 0 1.5-.5 2-1l1.414-1.414A2 2 0 0 1 9.828 16h4.344a2 2 0 0 1 1.414.586L17 18c.5.5 1 1 2 1a3 3 0 0 0 3-3c0-1.545-.604-6.584-.685-7.258-.007-.05-.011-.1-.017-.151A4 4 0 0 0 17.32 5z" />
+  </svg>
+);

--- a/packages/filigran-chatbot/src/components/icons/index.ts
+++ b/packages/filigran-chatbot/src/components/icons/index.ts
@@ -17,6 +17,7 @@ export * from './FileIcon';
 export * from './FloatingIcon';
 export * from './FullscreenExitIcon';
 export * from './FullscreenIcon';
+export * from './GamepadIcon';
 export * from './GlobeIcon';
 export * from './HistoryIcon';
 export * from './InfoIcon';

--- a/packages/filigran-chatbot/src/hooks/useAwayCompletionNotice.ts
+++ b/packages/filigran-chatbot/src/hooks/useAwayCompletionNotice.ts
@@ -80,11 +80,11 @@ export function useAwayCompletionNotice({ isLoading, agentName, t, enabled = tru
   const sawHiddenRef = useRef(false);
 
   // Stop the flash and restore the title as soon as the user returns to the
-  // tab. Bound once for the hook's lifetime and torn down on unmount, so we
-  // never leak listeners (and never leave the title flashing after the panel
-  // is gone).
+  // tab. Bound only while the feature is enabled and torn down on unmount (or
+  // when the host disables it), so we never leak listeners or leave the title
+  // flashing after the panel is gone.
   useEffect(() => {
-    if (typeof document === 'undefined') return;
+    if (!enabled || typeof document === 'undefined') return;
     const clearOnReturn = () => {
       if (!document.hidden) stopTitleFlash();
     };
@@ -95,17 +95,18 @@ export function useAwayCompletionNotice({ isLoading, agentName, t, enabled = tru
       window.removeEventListener('focus', clearOnReturn);
       stopTitleFlash();
     };
-  }, []);
+  }, [enabled]);
 
-  // Track whether the tab was hidden at any point during the turn.
+  // Track whether the tab was hidden at any point during the turn. Skipped
+  // entirely when the feature is disabled.
   useEffect(() => {
-    if (!isLoading) return;
+    if (!enabled || !isLoading) return;
     const onVisibility = () => {
       if (document.hidden) sawHiddenRef.current = true;
     };
     document.addEventListener('visibilitychange', onVisibility);
     return () => document.removeEventListener('visibilitychange', onVisibility);
-  }, [isLoading]);
+  }, [enabled, isLoading]);
 
   useEffect(() => {
     const wasLoading = wasLoadingRef.current;

--- a/packages/filigran-chatbot/src/hooks/useAwayCompletionNotice.ts
+++ b/packages/filigran-chatbot/src/hooks/useAwayCompletionNotice.ts
@@ -91,7 +91,14 @@ interface UseAwayCompletionNoticeOptions {
  *    when `isViewingChat` is supplied): host toast only.
  *  - **Actively watching**: nothing — the streamed answer is the feedback.
  */
-export function useAwayCompletionNotice({ isLoading, agentName, t, enabled = true, onComplete, isViewingChat }: UseAwayCompletionNoticeOptions): void {
+export function useAwayCompletionNotice({
+  isLoading,
+  agentName,
+  t,
+  enabled = true,
+  onComplete,
+  isViewingChat,
+}: UseAwayCompletionNoticeOptions): void {
   const wasLoadingRef = useRef(false);
   const startRef = useRef(0);
 

--- a/packages/filigran-chatbot/src/hooks/useAwayCompletionNotice.ts
+++ b/packages/filigran-chatbot/src/hooks/useAwayCompletionNotice.ts
@@ -8,8 +8,14 @@ const MIN_NOTICE_MS = 4000;
 /** Document-title flash cadence while the user is away. */
 const TITLE_FLASH_MS = 1200;
 
+// The document title is a single page-global resource, so the flash is shared
+// across hook instances on purpose (per-hook timers would fight over the one
+// `document.title` and clobber each other's saved title). `activeHooks` ref-
+// counts mounted, enabled instances so one panel unmounting never cancels a
+// flash another panel still owns — only the last one to leave restores it.
 let flashTimer: number | null = null;
 let originalTitle: string | null = null;
+let activeHooks = 0;
 
 /** Stop flashing and restore the page title captured when the flash began. */
 function stopTitleFlash(): void {
@@ -108,6 +114,7 @@ export function useAwayCompletionNotice({
   // flashing after the panel is gone.
   useEffect(() => {
     if (!enabled || typeof document === 'undefined') return;
+    activeHooks += 1;
     const clearOnReturn = () => {
       if (!document.hidden && document.hasFocus()) stopTitleFlash();
     };
@@ -116,7 +123,10 @@ export function useAwayCompletionNotice({
     return () => {
       document.removeEventListener('visibilitychange', clearOnReturn);
       window.removeEventListener('focus', clearOnReturn);
-      stopTitleFlash();
+      activeHooks = Math.max(0, activeHooks - 1);
+      // Only restore the title once the last consumer leaves, so unmounting one
+      // panel never cancels another panel's in-flight flash.
+      if (activeHooks === 0) stopTitleFlash();
     };
   }, [enabled]);
 

--- a/packages/filigran-chatbot/src/hooks/useAwayCompletionNotice.ts
+++ b/packages/filigran-chatbot/src/hooks/useAwayCompletionNotice.ts
@@ -1,0 +1,123 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * A turn must run at least this long before its completion is worth an
+ * away-notification — instant replies never raise one.
+ */
+const MIN_NOTICE_MS = 4000;
+/** Document-title flash cadence while the user is away. */
+const TITLE_FLASH_MS = 1200;
+
+let flashTimer: number | null = null;
+let originalTitle: string | null = null;
+let returnListenerBound = false;
+
+/** Stop flashing and restore the page title captured when the flash began. */
+function stopTitleFlash(): void {
+  if (flashTimer !== null) {
+    window.clearInterval(flashTimer);
+    flashTimer = null;
+  }
+  if (originalTitle !== null) {
+    document.title = originalTitle;
+    originalTitle = null;
+  }
+}
+
+/**
+ * Flash the document title so a multitasking user notices the answer landed
+ * even from another tab. Restores the original title the moment the tab
+ * regains focus. Title flashing needs no permission and is the reliable
+ * baseline of the completion notification.
+ */
+function startTitleFlash(message: string): void {
+  if (typeof document === 'undefined') return;
+  if (originalTitle === null) originalTitle = document.title;
+  if (flashTimer !== null) window.clearInterval(flashTimer);
+  let showMessage = true;
+  document.title = message;
+  flashTimer = window.setInterval(() => {
+    showMessage = !showMessage;
+    document.title = showMessage ? message : (originalTitle ?? message);
+  }, TITLE_FLASH_MS);
+
+  if (!returnListenerBound) {
+    returnListenerBound = true;
+    const clearOnReturn = () => {
+      if (!document.hidden) stopTitleFlash();
+    };
+    document.addEventListener('visibilitychange', clearOnReturn);
+    window.addEventListener('focus', clearOnReturn);
+  }
+}
+
+/**
+ * Best-effort OS notification — only fired when the user has already granted
+ * permission. We deliberately never call `Notification.requestPermission()`
+ * unprompted: the title flash (and host toast) cover the case where OS
+ * notifications are unavailable.
+ */
+function notifyOS(title: string, body: string): void {
+  try {
+    if (typeof Notification === 'undefined' || Notification.permission !== 'granted') return;
+    new Notification(title, { body, tag: 'filigran-chat-complete' });
+  } catch {
+    /* Notification constructor can throw on some platforms — ignore. */
+  }
+}
+
+interface UseAwayCompletionNoticeOptions {
+  /** True while a response is being generated. */
+  isLoading: boolean;
+  /** Name of the answering agent, used in the notification body. */
+  agentName: string;
+  t: (key: string) => string;
+  /** Master switch (default true). */
+  enabled?: boolean;
+  /** Host hook fired on an away-completion (e.g. to raise an in-app toast). */
+  onComplete?: () => void;
+}
+
+/**
+ * Raise a discreet notification when a long-running turn finishes while the
+ * user is away (tab hidden / multitasking). When the user is actively
+ * watching, the streamed answer is itself the feedback, so nothing fires.
+ */
+export function useAwayCompletionNotice({ isLoading, agentName, t, enabled = true, onComplete }: UseAwayCompletionNoticeOptions): void {
+  const wasLoadingRef = useRef(false);
+  const startRef = useRef(0);
+  const sawHiddenRef = useRef(false);
+
+  // Track whether the tab was hidden at any point during the turn.
+  useEffect(() => {
+    if (!isLoading) return;
+    const onVisibility = () => {
+      if (document.hidden) sawHiddenRef.current = true;
+    };
+    document.addEventListener('visibilitychange', onVisibility);
+    return () => document.removeEventListener('visibilitychange', onVisibility);
+  }, [isLoading]);
+
+  useEffect(() => {
+    const wasLoading = wasLoadingRef.current;
+    wasLoadingRef.current = isLoading;
+
+    if (isLoading && !wasLoading) {
+      startRef.current = Date.now();
+      sawHiddenRef.current = typeof document !== 'undefined' && document.hidden;
+      return;
+    }
+
+    if (!isLoading && wasLoading && enabled) {
+      const elapsed = Date.now() - startRef.current;
+      const away = sawHiddenRef.current || (typeof document !== 'undefined' && document.hidden);
+      if (elapsed >= MIN_NOTICE_MS && away) {
+        const title = t('Response ready');
+        const body = agentName ? `${agentName} ${t('has finished')}` : t('Your answer is ready');
+        startTitleFlash(title);
+        notifyOS(title, body);
+        onComplete?.();
+      }
+    }
+  }, [isLoading, enabled, agentName, t, onComplete]);
+}

--- a/packages/filigran-chatbot/src/hooks/useAwayCompletionNotice.ts
+++ b/packages/filigran-chatbot/src/hooks/useAwayCompletionNotice.ts
@@ -1,8 +1,8 @@
 import { useEffect, useRef } from 'react';
 
 /**
- * A turn must run at least this long before its completion is worth an
- * away-notification — instant replies never raise one.
+ * A turn must run at least this long before its completion is worth a
+ * notification — instant replies never raise one.
  */
 const MIN_NOTICE_MS = 4000;
 /** Document-title flash cadence while the user is away. */
@@ -10,6 +10,7 @@ const TITLE_FLASH_MS = 1200;
 
 let flashTimer: number | null = null;
 let originalTitle: string | null = null;
+let returnListenerBound = false;
 
 /** Stop flashing and restore the page title captured when the flash began. */
 function stopTitleFlash(): void {
@@ -25,10 +26,9 @@ function stopTitleFlash(): void {
 
 /**
  * Flash the document title so a multitasking user notices the answer landed
- * even from another tab. The flash is stopped (and the title restored) the
- * moment the tab regains focus by the hook-scoped listeners below. Title
- * flashing needs no permission and is the reliable baseline of the completion
- * notification.
+ * even from another tab or window. Restores the original title the moment the
+ * tab is visible AND focused again. Title flashing needs no permission and is
+ * the reliable baseline of the completion notification.
  */
 function startTitleFlash(message: string): void {
   if (typeof document === 'undefined') return;
@@ -40,12 +40,21 @@ function startTitleFlash(message: string): void {
     showMessage = !showMessage;
     document.title = showMessage ? message : (originalTitle ?? message);
   }, TITLE_FLASH_MS);
+
+  if (!returnListenerBound) {
+    returnListenerBound = true;
+    const clearOnReturn = () => {
+      if (!document.hidden && document.hasFocus()) stopTitleFlash();
+    };
+    document.addEventListener('visibilitychange', clearOnReturn);
+    window.addEventListener('focus', clearOnReturn);
+  }
 }
 
 /**
  * Best-effort OS notification — only fired when the user has already granted
  * permission. We deliberately never call `Notification.requestPermission()`
- * unprompted: the title flash (and host toast) cover the case where OS
+ * unprompted: the title flash (and the host toast) cover the case where OS
  * notifications are unavailable.
  */
 function notifyOS(title: string, body: string): void {
@@ -65,48 +74,43 @@ interface UseAwayCompletionNoticeOptions {
   t: (key: string) => string;
   /** Master switch (default true). */
   enabled?: boolean;
-  /** Host hook fired on an away-completion (e.g. to raise an in-app toast). */
-  onComplete?: () => void;
+  /**
+   * Host hook fired when a long turn finishes and the user is not actively
+   * watching the chat — either away (tab hidden / another window) or in-app
+   * but focused elsewhere. Lets the host raise its own in-app toast (the
+   * chatbot has no toast surface of its own).
+   */
+  onComplete?: (title: string, body: string) => void;
+  /**
+   * Returns true when the user's focus is within the chat surface. When
+   * provided, the toast also fires if the user is in the app but looking
+   * elsewhere (panel open in a corner while they work in the main app). When
+   * omitted, only the away case triggers it.
+   */
+  isViewingChat?: () => boolean;
 }
 
 /**
- * Raise a discreet notification when a long-running turn finishes while the
- * user is away (tab hidden / multitasking). When the user is actively
- * watching, the streamed answer is itself the feedback, so nothing fires.
+ * Notify the user when a long-running turn finishes and they are not watching
+ * the chat. State is read at completion (never latched mid-turn) so someone who
+ * stepped away but returned before the turn finished is not pinged:
+ *  - **Away** (tab hidden or another window/app focused): document-title flash +
+ *    OS notification (when granted) + host toast.
+ *  - **In-app but elsewhere** (window focused, but focus is outside the chat —
+ *    only when `isViewingChat` is supplied): host toast only.
+ *  - **Actively watching** (focused, looking at the chat): nothing — the
+ *    streamed answer is itself the feedback.
  */
-export function useAwayCompletionNotice({ isLoading, agentName, t, enabled = true, onComplete }: UseAwayCompletionNoticeOptions): void {
+export function useAwayCompletionNotice({
+  isLoading,
+  agentName,
+  t,
+  enabled = true,
+  onComplete,
+  isViewingChat,
+}: UseAwayCompletionNoticeOptions): void {
   const wasLoadingRef = useRef(false);
   const startRef = useRef(0);
-  const sawHiddenRef = useRef(false);
-
-  // Stop the flash and restore the title as soon as the user returns to the
-  // tab. Bound only while the feature is enabled and torn down on unmount (or
-  // when the host disables it), so we never leak listeners or leave the title
-  // flashing after the panel is gone.
-  useEffect(() => {
-    if (!enabled || typeof document === 'undefined') return;
-    const clearOnReturn = () => {
-      if (!document.hidden) stopTitleFlash();
-    };
-    document.addEventListener('visibilitychange', clearOnReturn);
-    window.addEventListener('focus', clearOnReturn);
-    return () => {
-      document.removeEventListener('visibilitychange', clearOnReturn);
-      window.removeEventListener('focus', clearOnReturn);
-      stopTitleFlash();
-    };
-  }, [enabled]);
-
-  // Track whether the tab was hidden at any point during the turn. Skipped
-  // entirely when the feature is disabled.
-  useEffect(() => {
-    if (!enabled || !isLoading) return;
-    const onVisibility = () => {
-      if (document.hidden) sawHiddenRef.current = true;
-    };
-    document.addEventListener('visibilitychange', onVisibility);
-    return () => document.removeEventListener('visibilitychange', onVisibility);
-  }, [enabled, isLoading]);
 
   useEffect(() => {
     const wasLoading = wasLoadingRef.current;
@@ -114,20 +118,25 @@ export function useAwayCompletionNotice({ isLoading, agentName, t, enabled = tru
 
     if (isLoading && !wasLoading) {
       startRef.current = Date.now();
-      sawHiddenRef.current = typeof document !== 'undefined' && document.hidden;
       return;
     }
 
     if (!isLoading && wasLoading && enabled) {
       const elapsed = Date.now() - startRef.current;
-      const away = sawHiddenRef.current || (typeof document !== 'undefined' && document.hidden);
-      if (elapsed >= MIN_NOTICE_MS && away) {
-        const title = t('Response ready');
-        const body = agentName ? `${agentName} ${t('has finished')}` : t('Your answer is ready');
+      if (elapsed < MIN_NOTICE_MS) return;
+      const hidden = typeof document !== 'undefined' && document.hidden;
+      const unfocused = typeof document !== 'undefined' && !document.hasFocus();
+      const away = hidden || unfocused;
+      const viewingChat = isViewingChat ? isViewingChat() : true;
+      // Focused tab + looking at the chat → the streamed answer is the feedback.
+      if (!away && viewingChat) return;
+      const title = t('Response ready');
+      const body = agentName ? `${agentName} ${t('has finished')}` : t('Your answer is ready');
+      if (away) {
         startTitleFlash(title);
         notifyOS(title, body);
-        onComplete?.();
       }
+      onComplete?.(title, body);
     }
-  }, [isLoading, enabled, agentName, t, onComplete]);
+  }, [isLoading, enabled, agentName, t, onComplete, isViewingChat]);
 }

--- a/packages/filigran-chatbot/src/hooks/useAwayCompletionNotice.ts
+++ b/packages/filigran-chatbot/src/hooks/useAwayCompletionNotice.ts
@@ -10,7 +10,6 @@ const TITLE_FLASH_MS = 1200;
 
 let flashTimer: number | null = null;
 let originalTitle: string | null = null;
-let returnListenerBound = false;
 
 /** Stop flashing and restore the page title captured when the flash began. */
 function stopTitleFlash(): void {
@@ -26,9 +25,10 @@ function stopTitleFlash(): void {
 
 /**
  * Flash the document title so a multitasking user notices the answer landed
- * even from another tab. Restores the original title the moment the tab
- * regains focus. Title flashing needs no permission and is the reliable
- * baseline of the completion notification.
+ * even from another tab. The flash is stopped (and the title restored) the
+ * moment the tab regains focus by the hook-scoped listeners below. Title
+ * flashing needs no permission and is the reliable baseline of the completion
+ * notification.
  */
 function startTitleFlash(message: string): void {
   if (typeof document === 'undefined') return;
@@ -40,15 +40,6 @@ function startTitleFlash(message: string): void {
     showMessage = !showMessage;
     document.title = showMessage ? message : (originalTitle ?? message);
   }, TITLE_FLASH_MS);
-
-  if (!returnListenerBound) {
-    returnListenerBound = true;
-    const clearOnReturn = () => {
-      if (!document.hidden) stopTitleFlash();
-    };
-    document.addEventListener('visibilitychange', clearOnReturn);
-    window.addEventListener('focus', clearOnReturn);
-  }
 }
 
 /**
@@ -87,6 +78,24 @@ export function useAwayCompletionNotice({ isLoading, agentName, t, enabled = tru
   const wasLoadingRef = useRef(false);
   const startRef = useRef(0);
   const sawHiddenRef = useRef(false);
+
+  // Stop the flash and restore the title as soon as the user returns to the
+  // tab. Bound once for the hook's lifetime and torn down on unmount, so we
+  // never leak listeners (and never leave the title flashing after the panel
+  // is gone).
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    const clearOnReturn = () => {
+      if (!document.hidden) stopTitleFlash();
+    };
+    document.addEventListener('visibilitychange', clearOnReturn);
+    window.addEventListener('focus', clearOnReturn);
+    return () => {
+      document.removeEventListener('visibilitychange', clearOnReturn);
+      window.removeEventListener('focus', clearOnReturn);
+      stopTitleFlash();
+    };
+  }, []);
 
   // Track whether the tab was hidden at any point during the turn.
   useEffect(() => {

--- a/packages/filigran-chatbot/src/hooks/useAwayCompletionNotice.ts
+++ b/packages/filigran-chatbot/src/hooks/useAwayCompletionNotice.ts
@@ -10,7 +10,6 @@ const TITLE_FLASH_MS = 1200;
 
 let flashTimer: number | null = null;
 let originalTitle: string | null = null;
-let returnListenerBound = false;
 
 /** Stop flashing and restore the page title captured when the flash began. */
 function stopTitleFlash(): void {
@@ -26,9 +25,10 @@ function stopTitleFlash(): void {
 
 /**
  * Flash the document title so a multitasking user notices the answer landed
- * even from another tab or window. Restores the original title the moment the
- * tab is visible AND focused again. Title flashing needs no permission and is
- * the reliable baseline of the completion notification.
+ * even from another tab or window. The flash is stopped (and the title
+ * restored) the moment the tab is visible AND focused again, by the
+ * hook-scoped listeners below. Title flashing needs no permission and is the
+ * reliable baseline of the completion notification.
  */
 function startTitleFlash(message: string): void {
   if (typeof document === 'undefined') return;
@@ -40,15 +40,6 @@ function startTitleFlash(message: string): void {
     showMessage = !showMessage;
     document.title = showMessage ? message : (originalTitle ?? message);
   }, TITLE_FLASH_MS);
-
-  if (!returnListenerBound) {
-    returnListenerBound = true;
-    const clearOnReturn = () => {
-      if (!document.hidden && document.hasFocus()) stopTitleFlash();
-    };
-    document.addEventListener('visibilitychange', clearOnReturn);
-    window.addEventListener('focus', clearOnReturn);
-  }
 }
 
 /**
@@ -78,7 +69,7 @@ interface UseAwayCompletionNoticeOptions {
    * Host hook fired when a long turn finishes and the user is not actively
    * watching the chat — either away (tab hidden / another window) or in-app
    * but focused elsewhere. Lets the host raise its own in-app toast (the
-   * chatbot has no toast surface of its own).
+   * chatbot has no toast surface of its own). Receives the translated strings.
    */
   onComplete?: (title: string, body: string) => void;
   /**
@@ -96,21 +87,31 @@ interface UseAwayCompletionNoticeOptions {
  * stepped away but returned before the turn finished is not pinged:
  *  - **Away** (tab hidden or another window/app focused): document-title flash +
  *    OS notification (when granted) + host toast.
- *  - **In-app but elsewhere** (window focused, but focus is outside the chat —
- *    only when `isViewingChat` is supplied): host toast only.
- *  - **Actively watching** (focused, looking at the chat): nothing — the
- *    streamed answer is itself the feedback.
+ *  - **In-app but elsewhere** (window focused, focus outside the chat — only
+ *    when `isViewingChat` is supplied): host toast only.
+ *  - **Actively watching**: nothing — the streamed answer is the feedback.
  */
-export function useAwayCompletionNotice({
-  isLoading,
-  agentName,
-  t,
-  enabled = true,
-  onComplete,
-  isViewingChat,
-}: UseAwayCompletionNoticeOptions): void {
+export function useAwayCompletionNotice({ isLoading, agentName, t, enabled = true, onComplete, isViewingChat }: UseAwayCompletionNoticeOptions): void {
   const wasLoadingRef = useRef(false);
   const startRef = useRef(0);
+
+  // Stop the flash and restore the title as soon as the user returns to a
+  // visible, focused tab. Bound only while enabled and torn down on unmount (or
+  // when the host disables it), so we never leak listeners or leave the title
+  // flashing after the panel is gone.
+  useEffect(() => {
+    if (!enabled || typeof document === 'undefined') return;
+    const clearOnReturn = () => {
+      if (!document.hidden && document.hasFocus()) stopTitleFlash();
+    };
+    document.addEventListener('visibilitychange', clearOnReturn);
+    window.addEventListener('focus', clearOnReturn);
+    return () => {
+      document.removeEventListener('visibilitychange', clearOnReturn);
+      window.removeEventListener('focus', clearOnReturn);
+      stopTitleFlash();
+    };
+  }, [enabled]);
 
   useEffect(() => {
     const wasLoading = wasLoadingRef.current;

--- a/packages/filigran-chatbot/src/types.ts
+++ b/packages/filigran-chatbot/src/types.ts
@@ -134,17 +134,19 @@ export interface ChatPanelProps {
    */
   miniGameEnabled?: boolean;
   /**
-   * Notify the user when a long-running turn finishes while they are away
-   * (tab hidden / multitasking) via a document-title flash and — when already
-   * granted — a browser notification. Default: true.
+   * Notify the user when a long-running turn finishes while they are not
+   * watching the chat — away (tab hidden / another window) via a document-title
+   * flash and a browser notification (when already granted), or in-app but
+   * looking elsewhere via the `onTaskComplete` host toast. Default: true.
    */
   notifyOnComplete?: boolean;
   /**
-   * Called when an away-completion notification fires, so the host can also
-   * surface it through its own notification system (the chatbot has no toast
-   * surface of its own).
+   * Called when a long turn finishes and the user is not actively watching the
+   * chat (away, or in-app but focused elsewhere) so the host can raise its own
+   * in-app toast (the chatbot has no toast surface of its own). Receives the
+   * already-translated `title` and `body`.
    */
-  onTaskComplete?: () => void;
+  onTaskComplete?: (title: string, body: string) => void;
 }
 
 export interface ChatToggleButtonProps {

--- a/packages/filigran-chatbot/src/types.ts
+++ b/packages/filigran-chatbot/src/types.ts
@@ -126,6 +126,25 @@ export interface ChatPanelProps {
    * - 'ag-ui': AG-UI protocol (https://github.com/ag-ui-protocol/ag-ui)
    */
   backendType?: BackendType;
+  /**
+   * Show the waiting experience during longer waits: dynamic rotating status
+   * messages plus an optional Space Invader mini-game that shoots the message
+   * letters away one by one. Users can still toggle the game off per browser
+   * from the panel; this prop is a host-level master switch. Default: true.
+   */
+  miniGameEnabled?: boolean;
+  /**
+   * Notify the user when a long-running turn finishes while they are away
+   * (tab hidden / multitasking) via a document-title flash and — when already
+   * granted — a browser notification. Default: true.
+   */
+  notifyOnComplete?: boolean;
+  /**
+   * Called when an away-completion notification fires, so the host can also
+   * surface it through its own notification system (the chatbot has no toast
+   * surface of its own).
+   */
+  onTaskComplete?: () => void;
 }
 
 export interface ChatToggleButtonProps {


### PR DESCRIPTION
## Summary

Bring a richer "waiting experience" to the `@filigran/chatbot` panel so the loading/thinking state feels alive during longer agent turns. Because OpenCTI and OpenAEV both render this package's `ChatPanel`, this single change makes the waiting experience identical across XTM One, OpenCTI and OpenAEV.

Companion of XTM-One-Platform/xtm-one#1596 (same feature in the XTM One web chat).

Closes #325

## What changed

- New `ChatWaitingGame` component (self-contained canvas mini-game):
  - Dynamic, rotating status messages shown below the status bubble during longer waits.
  - Space Invader mini-game: a pixel invader glides along the bottom and shoots the message letters away one by one (DPR-aware canvas, single rAF loop, pauses when the tab is hidden).
  - Per-browser on/off control on the panel (persisted in localStorage). Skipped entirely under `prefers-reduced-motion`, where the messages still rotate as plain dimmed text (and even that path is motion-free - no fade-ins or pulsing caret), so the dynamic-messages feedback stands on its own.
  - Accessible: a `role="status"` + `aria-live` text mirror scoped to the announced message text; the canvas is `aria-hidden` and the toggle exposes `aria-pressed`.
- `ChatThinking` drives the reveal via a staleness flag: it keeps the reasoning window while reasoning text is actively streaming, but if reasoning stalls (or never starts) for 5s it flips to the waiting game, and flips back the moment reasoning resumes (the accumulated text carries the continuation).
- New `useAwayCompletionNotice` hook (wired in `ChatPanel`): when a long-running turn finishes and the user is not actively watching the chat, it notifies them. Away (tab hidden / another window): document-title flash (restored on return) + browser notification when permission was already granted + host toast. In-app but looking elsewhere (panel open in a corner while working in the main app): host toast only. Actively watching: nothing - the streamed answer is the feedback. The away/focus state is read at completion (never latched mid-turn), so stepping away and returning before the turn finishes does not ping. We never prompt for notification permission unprompted.
- New `ChatPanel` props: `miniGameEnabled` (default true), `notifyOnComplete` (default true), `onTaskComplete(title, body)` (host hook for an in-app toast; receives the already-translated strings).
- New `GamepadIcon`; `@filigran/chatbot` bumped to `3.7.0`.

## Review hardening

Driven by the automated review passes:

- Title-flash listeners are hook-scoped: bound only while the feature is enabled and removed on unmount, instead of being attached forever from inside `startTitleFlash`. The shared document-title flash is ref-counted across notifier instances so one panel unmounting never cancels another panel's in-flight flash.
- `usePrefersReducedMotion` falls back to the deprecated `addListener` / `removeListener` on older Safari/WebKit that lack `MediaQueryList.addEventListener`.
- The waiting experience schedules no work when the host disables it: the `useAwayCompletionNotice` effects and `ChatThinking`'s `useStalled` timer early-return (and tear down) when `notifyOnComplete` / `miniGameEnabled` are false.
- The canvas engine guards `ResizeObserver` and falls back to a `window` `resize` listener when it is unavailable (older browsers / embedded webviews), and uses a solid `fillStyle` with `globalAlpha` rather than a `color-mix()` string some browsers reject, so the waiting experience never throws or loses its styling.
- `useStalled` derives its returned value during render (a "signal changed since the last settled render" check) instead of calling `setState` in the render phase, so it is safe under StrictMode / concurrent rendering while still flipping back from the waiting game to the reasoning window with no one-frame lag.
- Accessibility: the `role="status"` / `aria-live` live region is scoped to the `sr-only` text mirror only (not the toggle control, which was previously re-announced on every message change), and the mini-game toggle exposes its on/off state via `aria-pressed`.
- Reduced motion is honored end to end: under `prefers-reduced-motion` the plain (no-game) waiting UI drops its `chat-fade-in` animations and the blinking caret's pulse, so only the dimmed text rotates.
- `isViewingChat` is memoized with `useCallback` so the away-completion effect keeps a stable reference and does not re-run on every render while a response streams.

## Notes

- Defaults are on, so consuming apps only need to bump to `@filigran/chatbot` `3.7.0` to get the feature (no code changes required).
- The pre-existing `@eslint/js` resolution warning during the Rollup build comes from `eslint.config.ts` and is unrelated to this change. CI builds all packages and the website successfully.

## Test plan

- [x] `yarn build:filigran-chatbot` succeeds.
- [ ] In the chat playground, send a message to a slow agent: after reasoning stalls for ~5s a rotating message + Space Invader appears below the status bubble and erases the text letter by letter; it flips back to the reasoning window the moment reasoning resumes, and disappears when the answer streams.
- [ ] Toggle the mini-game off from the panel control -> plain rotating text; reload -> preference persists.
- [ ] Enable OS "reduce motion" -> only plain rotating text, no canvas/toggle, no fade-in or pulsing caret.
- [ ] Send a message, switch to another tab, wait for completion -> the document title flashes (and a browser notification fires if permission is granted).
- [ ] Send a message, keep the panel open but click into the main app, wait for completion -> the host `onTaskComplete` toast fires.
