### PR TITLE
fix(chatbot): render markdown tables with a column-count mismatch (#327)

### DIFF
--- a/packages/filigran-chatbot/package.json
+++ b/packages/filigran-chatbot/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "git+https://github.com/FiligranHQ/filigran-ui.git"
   },
-  "version": "3.7.2",
+  "version": "3.7.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/filigran-chatbot/package.json
+++ b/packages/filigran-chatbot/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "git+https://github.com/FiligranHQ/filigran-ui.git"
   },
-  "version": "3.7.1",
+  "version": "3.7.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/filigran-chatbot/src/components/MarkdownMessage.tsx
+++ b/packages/filigran-chatbot/src/components/MarkdownMessage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { CheckIcon, CopyIcon } from './icons';
@@ -51,6 +51,11 @@ const toInternalHref = (href?: string): string | null => {
 
 export const MarkdownMessage = ({ content, onRelativeLinkClick }: MarkdownMessageProps) => {
   const [copiedBlock, setCopiedBlock] = useState<string | null>(null);
+
+  // Preprocess once per `content`: this component re-renders on UI-only state
+  // (e.g. `copiedBlock`), and both passes scan the whole message, so memoizing
+  // keeps that work off the hot path for large messages.
+  const processedContent = useMemo(() => normalizeMarkdownTables(hardenNestedCodeFences(content)), [content]);
 
   const handleCopyCode = (code: string) => {
     navigator.clipboard.writeText(code);
@@ -144,7 +149,7 @@ export const MarkdownMessage = ({ content, onRelativeLinkClick }: MarkdownMessag
         ),
       }}
     >
-      {normalizeMarkdownTables(hardenNestedCodeFences(content))}
+      {processedContent}
     </Markdown>
   );
 };

--- a/packages/filigran-chatbot/src/components/MarkdownMessage.tsx
+++ b/packages/filigran-chatbot/src/components/MarkdownMessage.tsx
@@ -144,7 +144,7 @@ export const MarkdownMessage = ({ content, onRelativeLinkClick }: MarkdownMessag
         ),
       }}
     >
-      {hardenNestedCodeFences(normalizeMarkdownTables(content))}
+      {normalizeMarkdownTables(hardenNestedCodeFences(content))}
     </Markdown>
   );
 };

--- a/packages/filigran-chatbot/src/components/MarkdownMessage.tsx
+++ b/packages/filigran-chatbot/src/components/MarkdownMessage.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { CheckIcon, CopyIcon } from './icons';
-import { hardenNestedCodeFences } from '../utils';
+import { hardenNestedCodeFences, normalizeMarkdownTables } from '../utils';
 
 interface MarkdownMessageProps {
   content: string;
@@ -144,7 +144,7 @@ export const MarkdownMessage = ({ content, onRelativeLinkClick }: MarkdownMessag
         ),
       }}
     >
-      {hardenNestedCodeFences(content)}
+      {hardenNestedCodeFences(normalizeMarkdownTables(content))}
     </Markdown>
   );
 };

--- a/packages/filigran-chatbot/src/utils/index.ts
+++ b/packages/filigran-chatbot/src/utils/index.ts
@@ -145,9 +145,14 @@ export function normalizeMarkdownTables(raw: string): string {
     const delimCells = splitCells(delim);
     if (headerCols < 2 || delimCells.length === headerCols) continue;
 
+    // Keep the header row's indentation on the rewritten delimiter: GFM drops a
+    // table whose delimiter row dedents away from its header, so a repaired
+    // table nested in a list item must stay aligned with it. Top-level tables
+    // have empty indentation, so their output is unchanged.
+    const indent = header.slice(0, header.length - header.trimStart().length);
     const aligns: string[] = [];
     for (let c = 0; c < headerCols; c++) aligns.push(delimCells[c] ? alignOf(delimCells[c]) : '---');
-    lines[i + 1] = `| ${aligns.join(' | ')} |`;
+    lines[i + 1] = `${indent}| ${aligns.join(' | ')} |`;
   }
   return lines.join('\n');
 }

--- a/packages/filigran-chatbot/src/utils/index.ts
+++ b/packages/filigran-chatbot/src/utils/index.ts
@@ -122,6 +122,10 @@ export function normalizeMarkdownTables(raw: string): string {
   const fenceRe = /^\s*(?:(?:>\s?)|(?:[-*+]\s+)|(?:\d{1,9}[.)]\s+))*(`{3,}|~{3,})(.*)$/;
   let fenceChar: string | null = null;
   let fenceLen = 0;
+  // A pipe-table header can share its line with a list-item marker (e.g.
+  // `- | a | b |`). Strip a leading list marker before counting columns so the
+  // count matches the cells GFM sees inside the list item, not the marker.
+  const listMarkerRe = /^\s*(?:[-*+]\s+|\d{1,9}[.)]\s+)/;
   for (let i = 0; i < lines.length - 1; i++) {
     const fenceMatch = lines[i].match(fenceRe);
     if (fenceMatch) {
@@ -141,15 +145,20 @@ export function normalizeMarkdownTables(raw: string): string {
     const delim = lines[i + 1];
     if (!header.includes('|') || isDelimiterRow(header) || !isDelimiterRow(delim)) continue;
 
-    const headerCols = splitCells(header).length;
+    // A table can start on a list-item line, so both the cells and the
+    // delimiter's alignment live AFTER the marker. Anchor the rewritten
+    // delimiter to that content offset (padding the marker width with spaces) so
+    // it stays a continuation line of the list item: GFM drops a table whose
+    // delimiter dedents away from its header. Without a marker this is just the
+    // header's leading whitespace, so top-level tables are emitted unchanged.
+    const markerMatch = header.match(listMarkerRe);
+    const offset = markerMatch ? markerMatch[0].length : header.length - header.trimStart().length;
+    const indent = markerMatch ? ' '.repeat(offset) : header.slice(0, offset);
+
+    const headerCols = splitCells(header.slice(offset)).length;
     const delimCells = splitCells(delim);
     if (headerCols < 2 || delimCells.length === headerCols) continue;
 
-    // Keep the header row's indentation on the rewritten delimiter: GFM drops a
-    // table whose delimiter row dedents away from its header, so a repaired
-    // table nested in a list item must stay aligned with it. Top-level tables
-    // have empty indentation, so their output is unchanged.
-    const indent = header.slice(0, header.length - header.trimStart().length);
     const aligns: string[] = [];
     for (let c = 0; c < headerCols; c++) aligns.push(delimCells[c] ? alignOf(delimCells[c]) : '---');
     lines[i + 1] = `${indent}| ${aligns.join(' | ')} |`;

--- a/packages/filigran-chatbot/src/utils/index.ts
+++ b/packages/filigran-chatbot/src/utils/index.ts
@@ -78,11 +78,29 @@ export function normalizeMarkdownTables(raw: string): string {
   if (!raw || raw.indexOf('|') === -1) return raw;
   const lines = raw.split('\n');
 
+  // Splits on unescaped `|` only. A manual walk (rather than a negative
+  // lookbehind, which is unsupported on older engines and would throw at parse
+  // time in an untranspiled ESNext bundle) keeps `\|` inside a cell intact.
   const splitCells = (row: string): string[] => {
     let s = row.trim();
     if (s.startsWith('|')) s = s.slice(1);
     if (s.endsWith('|')) s = s.slice(0, -1);
-    return s.split(/(?<!\\)\|/);
+    const cells: string[] = [];
+    let current = '';
+    for (let i = 0; i < s.length; i++) {
+      const ch = s[i];
+      if (ch === '\\' && i + 1 < s.length) {
+        current += ch + s[i + 1];
+        i++;
+      } else if (ch === '|') {
+        cells.push(current);
+        current = '';
+      } else {
+        current += ch;
+      }
+    }
+    cells.push(current);
+    return cells;
   };
   const isDelimiterRow = (row: string): boolean => row.includes('|') && /^\s*\|?\s*:?-+:?\s*(\|\s*:?-+:?\s*)*\|?\s*$/.test(row);
   const alignOf = (cell: string): string => {
@@ -92,16 +110,26 @@ export function normalizeMarkdownTables(raw: string): string {
     return left && right ? ':-:' : right ? '--:' : left ? ':--' : '---';
   };
 
-  let fence: string | null = null;
+  // Track both the fence character AND its run length: per CommonMark a closing
+  // fence must use the same character and be at least as long as the opener, so
+  // a shorter run (```) must not close a longer one (````), and a closing fence
+  // carries no info string.
+  let fenceChar: string | null = null;
+  let fenceLen = 0;
   for (let i = 0; i < lines.length - 1; i++) {
-    const fenceMatch = lines[i].match(/^\s*(`{3,}|~{3,})/);
+    const fenceMatch = lines[i].match(/^\s*(`{3,}|~{3,})(.*)$/);
     if (fenceMatch) {
-      const marker = fenceMatch[1][0];
-      if (fence === null) fence = marker;
-      else if (marker === fence) fence = null;
+      const run = fenceMatch[1];
+      if (fenceChar === null) {
+        fenceChar = run[0];
+        fenceLen = run.length;
+      } else if (run[0] === fenceChar && run.length >= fenceLen && fenceMatch[2].trim() === '') {
+        fenceChar = null;
+        fenceLen = 0;
+      }
       continue;
     }
-    if (fence !== null) continue;
+    if (fenceChar !== null) continue;
 
     const header = lines[i];
     const delim = lines[i + 1];

--- a/packages/filigran-chatbot/src/utils/index.ts
+++ b/packages/filigran-chatbot/src/utils/index.ts
@@ -62,6 +62,62 @@ export function hardenNestedCodeFences(raw: string): string {
   return lines.join('\n');
 }
 
+/**
+ * GFM renders a pipe table only when the delimiter row (`|---|---|`) has the
+ * SAME number of columns as the header row. LLMs frequently miscount (e.g. a
+ * 4-column header followed by a 3-column delimiter), and a server-side guard can
+ * corrupt the delimiter — in either case the whole table silently degrades to
+ * raw `| … |` text. This repairs a mismatched delimiter row to the header's
+ * column count (preserving any alignment colons) so the table renders.
+ *
+ * It only rewrites a delimiter that is ACTUALLY mismatched, so already-valid
+ * tables are never touched. Fenced code blocks are skipped, and setext headings
+ * (underlines with no `|`) are never mistaken for a table.
+ */
+export function normalizeMarkdownTables(raw: string): string {
+  if (!raw || raw.indexOf('|') === -1) return raw;
+  const lines = raw.split('\n');
+
+  const splitCells = (row: string): string[] => {
+    let s = row.trim();
+    if (s.startsWith('|')) s = s.slice(1);
+    if (s.endsWith('|')) s = s.slice(0, -1);
+    return s.split(/(?<!\\)\|/);
+  };
+  const isDelimiterRow = (row: string): boolean => row.includes('|') && /^\s*\|?\s*:?-+:?\s*(\|\s*:?-+:?\s*)*\|?\s*$/.test(row);
+  const alignOf = (cell: string): string => {
+    const c = cell.trim();
+    const left = c.startsWith(':');
+    const right = c.endsWith(':');
+    return left && right ? ':-:' : right ? '--:' : left ? ':--' : '---';
+  };
+
+  let fence: string | null = null;
+  for (let i = 0; i < lines.length - 1; i++) {
+    const fenceMatch = lines[i].match(/^\s*(`{3,}|~{3,})/);
+    if (fenceMatch) {
+      const marker = fenceMatch[1][0];
+      if (fence === null) fence = marker;
+      else if (marker === fence) fence = null;
+      continue;
+    }
+    if (fence !== null) continue;
+
+    const header = lines[i];
+    const delim = lines[i + 1];
+    if (!header.includes('|') || isDelimiterRow(header) || !isDelimiterRow(delim)) continue;
+
+    const headerCols = splitCells(header).length;
+    const delimCells = splitCells(delim);
+    if (headerCols < 2 || delimCells.length === headerCols) continue;
+
+    const aligns: string[] = [];
+    for (let c = 0; c < headerCols; c++) aligns.push(delimCells[c] ? alignOf(delimCells[c]) : '---');
+    lines[i + 1] = `| ${aligns.join(' | ')} |`;
+  }
+  return lines.join('\n');
+}
+
 export const identity = (key: string) => key;
 
 /**

--- a/packages/filigran-chatbot/src/utils/index.ts
+++ b/packages/filigran-chatbot/src/utils/index.ts
@@ -116,11 +116,14 @@ export function normalizeMarkdownTables(raw: string): string {
   // Track both the fence character AND its run length: per CommonMark a closing
   // fence must use the same character and be at least as long as the opener, so
   // a shorter run (```) must not close a longer one (````), and a closing fence
-  // carries no info string.
+  // carries no info string. Optional blockquote / list-item markers are allowed
+  // before the run so fences nested in those containers (e.g. `- ```) are still
+  // recognised and the table inside them is left untouched.
+  const fenceRe = /^\s*(?:(?:>\s?)|(?:[-*+]\s+)|(?:\d{1,9}[.)]\s+))*(`{3,}|~{3,})(.*)$/;
   let fenceChar: string | null = null;
   let fenceLen = 0;
   for (let i = 0; i < lines.length - 1; i++) {
-    const fenceMatch = lines[i].match(/^\s*(`{3,}|~{3,})(.*)$/);
+    const fenceMatch = lines[i].match(fenceRe);
     if (fenceMatch) {
       const run = fenceMatch[1];
       if (fenceChar === null) {

--- a/packages/filigran-chatbot/src/utils/index.ts
+++ b/packages/filigran-chatbot/src/utils/index.ts
@@ -103,11 +103,14 @@ export function normalizeMarkdownTables(raw: string): string {
     return cells;
   };
   const isDelimiterRow = (row: string): boolean => row.includes('|') && /^\s*\|?\s*:?-+:?\s*(\|\s*:?-+:?\s*)*\|?\s*$/.test(row);
+  // Emit the canonical 3-hyphen delimiter form. remark-gfm accepts a single
+  // hyphen, but `---` (with optional alignment colons) is the portable form
+  // every Markdown renderer agrees on, so prefer it.
   const alignOf = (cell: string): string => {
     const c = cell.trim();
     const left = c.startsWith(':');
     const right = c.endsWith(':');
-    return left && right ? ':-:' : right ? '--:' : left ? ':--' : '---';
+    return left && right ? ':---:' : right ? '---:' : left ? ':---' : '---';
   };
 
   // Track both the fence character AND its run length: per CommonMark a closing


### PR DESCRIPTION
## Summary

Closes #327.

A GFM pipe table degrades to raw `| ... |` text whenever its delimiter row (`|---|---|`) has a different column count than the header row - GFM treats the whole table as invalid. LLMs frequently miscount columns (a 4-column header with a 3-column delimiter), and an upstream guard can corrupt the delimiter, so agent answers that should show a table sometimes show raw pipes instead.

## Change

- Add `normalizeMarkdownTables` (in `utils`) and apply it in `MarkdownMessage`: it repairs a mismatched delimiter row to the header's column count (preserving alignment colons) before rendering. It only rewrites a delimiter that is ACTUALLY mismatched, so already-valid tables are never touched.
- Repaired delimiter cells are emitted in the canonical 3-hyphen form (`:---:`, `:---`, `---:`, `---`) - the portable shape every Markdown renderer agrees on.
- The repaired delimiter is anchored to the header's content offset. A top-level table keeps its exact leading whitespace; when the header sits on a list-item line (e.g. `- | a | b | c |`, or an ordered `1. ...`) the list marker is stripped before counting columns and the delimiter is padded by the marker width, so it stays a continuation line aligned with the list content. Counting the marker as a cell, or dedenting the delimiter to column 0, makes GFM drop the table - which previously even corrupted an already-valid same-line-marker table. Top-level tables have empty indentation, so their output is byte-identical.
- Cell splitting is engine-portable: it walks each row character by character and splits on unescaped `|` only, instead of a negative-lookbehind regex. Lookbehind is unsupported on older engines (e.g. Safari < 16.4) and this package ships `target: ESNext` untranspiled (rollup + terser minify but do not downlevel syntax), so the regex would have thrown a `SyntaxError` at parse time and taken the whole bundle down. Splitting on the unescaped pipe (even inside an inline code span) deliberately matches how remark-gfm itself counts table columns, so our count never diverges from the renderer.
- Fenced code blocks are skipped with CommonMark-correct fence tracking: it records both the fence character and the opening run length and only closes on a same-character run that is at least as long and carries no info string, so a shorter fence run can no longer close a longer opener. Fence detection also allows blockquote (`>`) and list-item (`-`/`*`/`+`, `1.`/`1)`) markers before the run, so a mismatched table inside a list-item or blockquote code fence is left untouched instead of being rewritten. Setext headings (no `|`) are never mistaken for a table.
- The normalizer runs AFTER `hardenNestedCodeFences` (`normalizeMarkdownTables(hardenNestedCodeFences(content))`). Hardening widens the outer fence of a ```` ```markdown ```` block that contains nested fences; running it first means a mismatched table that ends up inside that widened block is left untouched, while tables outside code blocks are still repaired.
- `MarkdownMessage` memoizes the preprocessing (`useMemo` keyed on `content`), so `hardenNestedCodeFences` + `normalizeMarkdownTables` only run when the message text changes, not on UI-only re-renders (e.g. the copy-button state). Both are pure transforms, so the rendered output is unchanged.
- No manual `package.json` version bump - the release workflow owns version bumps.

## Context

This is the chatbot companion to the XTM One fix (XTM-One-Platform/xtm-one#1632), which also removes a backend repetition guard that was injecting a `Generation error detected` warning into wide tables and breaking them. Shipping the normalizer here keeps OpenCTI / OpenAEV table rendering identical to XTM One.

## Test plan

- `yarn build:filigran-chatbot` succeeds.
- In the playground, an assistant message whose table delimiter has fewer columns than the header renders as a table, not raw pipes.
- An already-valid table renders unchanged; a fenced code block that contains pipe characters - including a 4-backtick fence wrapping shorter 3-backtick fences, and a fence nested in a list item or blockquote - is left untouched.
- Verified against the installed remark-gfm parser: single-hyphen and canonical 3-hyphen delimiters both render; an unescaped pipe inside a code span is counted as a column separator (matching our splitter), while an escaped `\|` stays inside its cell.
- Verified the in-list case: a mismatched table whose header is indented under a list item renders 0 tables before the repair and 1 table (nested under the list item) after it, because the repaired delimiter keeps the header's indentation.
- Verified the same-line list-marker case: a column-mismatched table whose header shares a list-item line (unordered `- ...` or ordered `1. ...`) renders 0 tables before the repair and 1 after, while an already-valid same-line-marker table is left untouched (it was previously corrupted to 0 tables).
- Verified the pipeline order: a mismatched table sitting inside a ```` ```markdown ```` block with nested fences is left untouched after hardening, instead of being rewritten.
