### PR TITLE
fix(chatbot): auto-scroll the waiting mini-game into view when following (#329)

### DIFF
--- a/packages/filigran-chatbot/src/components/ChatWaitingGame.tsx
+++ b/packages/filigran-chatbot/src/components/ChatWaitingGame.tsx
@@ -79,6 +79,22 @@ function usePrefersReducedMotion(): boolean {
   return reduced;
 }
 
+/** Px-from-bottom within which the user is considered "still following". */
+const FOLLOW_THRESHOLD_PX = 140;
+
+/** Nearest vertically-scrollable ancestor of `el`, or null. */
+function findScrollParent(el: HTMLElement | null): HTMLElement | null {
+  let node = el?.parentElement ?? null;
+  while (node) {
+    const oy = getComputedStyle(node).overflowY;
+    if ((oy === 'auto' || oy === 'scroll') && node.scrollHeight > node.clientHeight) {
+      return node;
+    }
+    node = node.parentElement;
+  }
+  return null;
+}
+
 interface Letter {
   char: string;
   x: number;
@@ -323,22 +339,6 @@ interface ChatWaitingGameProps {
  * OS requests reduced motion — the messages simply rotate as plain dimmed
  * text, so the "dynamic loading messages" feedback always stands on its own.
  */
-/** Px-from-bottom within which the user is considered "still following". */
-const FOLLOW_THRESHOLD_PX = 140;
-
-/** Nearest vertically-scrollable ancestor of `el`, or null. */
-function findScrollParent(el: HTMLElement | null): HTMLElement | null {
-  let node = el?.parentElement ?? null;
-  while (node) {
-    const oy = getComputedStyle(node).overflowY;
-    if ((oy === 'auto' || oy === 'scroll') && node.scrollHeight > node.clientHeight) {
-      return node;
-    }
-    node = node.parentElement;
-  }
-  return null;
-}
-
 export const ChatWaitingGame = ({ t, enabled = true }: ChatWaitingGameProps) => {
   const messages = useMemo(() => DEFAULT_MESSAGES.map((m) => t(m)), [t]);
   const reducedMotion = usePrefersReducedMotion();

--- a/packages/filigran-chatbot/src/components/ChatWaitingGame.tsx
+++ b/packages/filigran-chatbot/src/components/ChatWaitingGame.tsx
@@ -323,14 +323,44 @@ interface ChatWaitingGameProps {
  * OS requests reduced motion — the messages simply rotate as plain dimmed
  * text, so the "dynamic loading messages" feedback always stands on its own.
  */
+/** Px-from-bottom within which the user is considered "still following". */
+const FOLLOW_THRESHOLD_PX = 140;
+
+/** Nearest vertically-scrollable ancestor of `el`, or null. */
+function findScrollParent(el: HTMLElement | null): HTMLElement | null {
+  let node = el?.parentElement ?? null;
+  while (node) {
+    const oy = getComputedStyle(node).overflowY;
+    if ((oy === 'auto' || oy === 'scroll') && node.scrollHeight > node.clientHeight) {
+      return node;
+    }
+    node = node.parentElement;
+  }
+  return null;
+}
+
 export const ChatWaitingGame = ({ t, enabled = true }: ChatWaitingGameProps) => {
   const messages = useMemo(() => DEFAULT_MESSAGES.map((m) => t(m)), [t]);
   const reducedMotion = usePrefersReducedMotion();
   const [minigameOn, setMinigameOn] = useState(readPref);
   const [msgIndex, setMsgIndex] = useState(0);
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const rootRef = useRef<HTMLDivElement>(null);
 
   const playMode = enabled && minigameOn && !reducedMotion;
+
+  // The game mounts below the last message but, unlike streamed reasoning/answer
+  // text (which auto-scrolls on length change), nothing else triggers a scroll —
+  // so at the bottom it lands under the fold. Reveal it on mount IF the user is
+  // still following the bottom; if they scrolled up to read history, leave them.
+  useEffect(() => {
+    const scroller = findScrollParent(rootRef.current);
+    if (!scroller) return;
+    const distance = scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight;
+    if (distance <= FOLLOW_THRESHOLD_PX) {
+      scroller.scrollTop = scroller.scrollHeight;
+    }
+  }, []);
 
   // Plain-text rotation when the game is off / reduced motion. Skipped while the
   // game drives the index, and entirely when the feature is disabled (so a
@@ -354,7 +384,7 @@ export const ChatWaitingGame = ({ t, enabled = true }: ChatWaitingGameProps) => 
   const current = messages[msgIndex % messages.length];
 
   return (
-    <div className="ml-11 mt-2.5 max-w-[78%]">
+    <div ref={rootRef} className="ml-11 mt-2.5 max-w-[78%]">
       {/* Keep the live region scoped to the announced text only — wrapping the
           whole UI (including the toggle button) made screen readers re-announce
           the control alongside each message change. */}


### PR DESCRIPTION
## Summary

Closes #329.

When the waiting mini-game appeared at the bottom of the chat it was not scrolled into view (unlike streamed reasoning/answer text), so a user following the conversation had to scroll down manually to see it.

## Root cause

`ChatMessages` auto-scrolls on `messages` change and on `thinkingContent` length change. The mini-game appears later (when reasoning stalls) with neither signal changing, so nothing scrolled and the game sat under the fold.

## Fix

On mount, `ChatWaitingGame` reveals itself into view IF the user is still following the bottom (within `FOLLOW_THRESHOLD_PX` of the nearest scroll container's bottom). If they have scrolled up to read history, their position is left untouched. Self-contained in the component, so it works the same wherever the game is rendered.

A small follow-up commit keeps it tidy: `FOLLOW_THRESHOLD_PX` and the `findScrollParent` helper now sit with the other module-level helpers, so the `ChatWaitingGame` JSDoc stays directly above the component. Pure relocation, no behavior change.

No `package.json` version bump - the `release-version` workflow owns versioning.

## Context

Parity with the XTM One fix (XTM-One-Platform/xtm-one#1641 follow-up); same behavior across XTM One, OpenCTI and OpenAEV.

## Test plan

- [x] `yarn build:filigran-chatbot` succeeds.
- [ ] Send a message and stay at the bottom: when the mini-game appears it scrolls into view automatically.
- [ ] Scroll up to read history while waiting: the view is NOT yanked when the game appears.
