### PR TITLE
fix(chatbot): skip completion notice while the chat panel is visible (#331)

### DIFF
--- a/packages/filigran-chatbot/src/components/ChatPanel.tsx
+++ b/packages/filigran-chatbot/src/components/ChatPanel.tsx
@@ -176,15 +176,35 @@ export const ChatPanel: FunctionComponent<ChatPanelProps> = ({
   const firstName = user.firstName;
   const agentName = transferredAgent?.name || selectedAgent?.name || 'Assistant';
 
-  // Key on `.filigran-chatbot.fixed` (the panel root carries both in every
-  // mode) rather than `.filigran-chatbot` alone, which the toggle button also
-  // uses — otherwise focusing the toggle would be mistaken for viewing the chat.
-  // Stable reference (useCallback) so the notifier's effect doesn't re-run on
-  // every render — the panel re-renders frequently while a response streams.
-  const isViewingChat = useCallback(() => typeof document !== 'undefined' && !!document.activeElement?.closest('.filigran-chatbot.fixed'), []);
+  // "Viewing the chat" must mean the panel is on screen in the active tab —
+  // NOT that an element inside it currently holds focus. In sidebar (and
+  // floating) mode the user routinely reads a streamed answer while their focus
+  // stays in the host app, so the previous focus-within test
+  // (`document.activeElement.closest('.filigran-chatbot.fixed')`) wrongly
+  // classified them as "not viewing" and fired a redundant completion toast for
+  // an answer sitting right in front of them. The host mounts `<ChatPanel/>`
+  // only while the widget is open, so a mounted + visible panel root means the
+  // answer is visible to the user; the notifier still treats a hidden tab or an
+  // unfocused window as "away" and notifies there. A host that keeps the panel
+  // mounted but `display:none` while "closed" is likewise reported as not
+  // viewing (checkVisibility() === false), so completion still notifies. The
+  // `.fixed` qualifier targets the panel root, never the toggle button (which
+  // carries `.filigran-chatbot` alone). Stable reference (useCallback) so the
+  // notifier's effect doesn't re-run on every render — the panel re-renders
+  // frequently while a response streams; the DOM is queried live on each call.
+  const isViewingChat = useCallback(() => {
+    if (typeof document === 'undefined') return false;
+    const panel = document.querySelector('.filigran-chatbot.fixed') as
+      | (HTMLElement & { checkVisibility?: () => boolean })
+      | null;
+    if (!panel) return false;
+    return panel.checkVisibility ? panel.checkVisibility() : true;
+  }, []);
 
   // Notify when a long turn finishes and the user is not watching the chat —
-  // away (tab hidden / another window) or in-app but focused outside the panel.
+  // away (tab hidden / another window / panel closed-or-hidden). An open,
+  // on-screen panel in the focused tab counts as watching, so no toast fires
+  // for an answer the user can already see.
   useAwayCompletionNotice({
     isLoading,
     agentName,

--- a/packages/filigran-chatbot/src/components/ChatPanel.tsx
+++ b/packages/filigran-chatbot/src/components/ChatPanel.tsx
@@ -194,11 +194,15 @@ export const ChatPanel: FunctionComponent<ChatPanelProps> = ({
   // frequently while a response streams; the DOM is queried live on each call.
   const isViewingChat = useCallback(() => {
     if (typeof document === 'undefined') return false;
-    const panel = document.querySelector('.filigran-chatbot.fixed') as
-      | (HTMLElement & { checkVisibility?: () => boolean })
-      | null;
+    const panel = document.querySelector('.filigran-chatbot.fixed') as (HTMLElement & { checkVisibility?: () => boolean }) | null;
     if (!panel) return false;
-    return panel.checkVisibility ? panel.checkVisibility() : true;
+    if (typeof panel.checkVisibility === 'function') return panel.checkVisibility();
+    // Fallback for browsers without Element.checkVisibility(): a display:none
+    // panel generates no layout box, so an empty client-rect list means hidden
+    // (works for the position:fixed root, whose offsetParent is null even when
+    // shown). Erring toward "not viewing" keeps the documented closed/hidden
+    // path notifying instead of silently swallowing the notice on older engines.
+    return panel.getClientRects().length > 0;
   }, []);
 
   // Notify when a long turn finishes and the user is not watching the chat —

--- a/packages/filigran-chatbot/src/hooks/useAwayCompletionNotice.ts
+++ b/packages/filigran-chatbot/src/hooks/useAwayCompletionNotice.ts
@@ -74,8 +74,9 @@ interface UseAwayCompletionNoticeOptions {
   /**
    * Host hook fired when a long turn finishes and the user is not actively
    * watching the chat — either away (tab hidden / another window) or in-app
-   * but focused elsewhere. Lets the host raise its own in-app toast (the
-   * chatbot has no toast surface of its own). Receives the translated strings.
+   * with the chat surface closed/hidden (`isViewingChat` reports not-viewing).
+   * Lets the host raise its own in-app toast (the chatbot has no toast surface
+   * of its own). Receives the translated strings.
    */
   onComplete?: (title: string, body: string) => void;
   /**

--- a/packages/filigran-chatbot/src/hooks/useAwayCompletionNotice.ts
+++ b/packages/filigran-chatbot/src/hooks/useAwayCompletionNotice.ts
@@ -79,10 +79,14 @@ interface UseAwayCompletionNoticeOptions {
    */
   onComplete?: (title: string, body: string) => void;
   /**
-   * Returns true when the user's focus is within the chat surface. When
-   * provided, the toast also fires if the user is in the app but looking
-   * elsewhere (panel open in a corner while they work in the main app). When
-   * omitted, only the away case triggers it.
+   * Returns true when the chat surface is on screen for the user (the panel is
+   * open and visible) — NOT merely whether focus sits inside it. When provided,
+   * the notice also fires if the chat surface is hidden/closed while the tab is
+   * still focused (e.g. a docked sidebar the host has collapsed). It must NOT
+   * key on focus-within: in sidebar/floating mode the user reads a streamed
+   * answer while their focus stays in the host app, and pinging them for an
+   * answer they can already see is exactly the noise this guards against. When
+   * omitted, only the away case (tab hidden / window unfocused) triggers it.
    */
   isViewingChat?: () => boolean;
 }
@@ -93,9 +97,11 @@ interface UseAwayCompletionNoticeOptions {
  * stepped away but returned before the turn finished is not pinged:
  *  - **Away** (tab hidden or another window/app focused): document-title flash +
  *    OS notification (when granted) + host toast.
- *  - **In-app but elsewhere** (window focused, focus outside the chat — only
- *    when `isViewingChat` is supplied): host toast only.
- *  - **Actively watching**: nothing — the streamed answer is the feedback.
+ *  - **Surface not visible** (window focused & tab visible, but the chat panel
+ *    is closed/hidden — only when `isViewingChat` reports not-viewing): host
+ *    toast only.
+ *  - **Actively watching** (tab visible, window focused, panel on screen):
+ *    nothing — the streamed answer is itself the feedback.
  */
 export function useAwayCompletionNotice({
   isLoading,

--- a/packages/filigran-chatbot/src/types.ts
+++ b/packages/filigran-chatbot/src/types.ts
@@ -136,15 +136,15 @@ export interface ChatPanelProps {
   /**
    * Notify the user when a long-running turn finishes while they are not
    * watching the chat — away (tab hidden / another window) via a document-title
-   * flash and a browser notification (when already granted), or in-app but
-   * looking elsewhere via the `onTaskComplete` host toast. Default: true.
+   * flash and a browser notification (when already granted), or in-app with the
+   * chat panel closed/hidden via the `onTaskComplete` host toast. Default: true.
    */
   notifyOnComplete?: boolean;
   /**
    * Called when a long turn finishes and the user is not actively watching the
-   * chat (away, or in-app but focused elsewhere) so the host can raise its own
-   * in-app toast (the chatbot has no toast surface of its own). Receives the
-   * already-translated `title` and `body`.
+   * chat (away, or in-app with the chat panel closed/hidden) so the host can
+   * raise its own in-app toast (the chatbot has no toast surface of its own).
+   * Receives the already-translated `title` and `body`.
    */
   onTaskComplete?: (title: string, body: string) => void;
 }


### PR DESCRIPTION
## Summary

- Fixes a spurious completion notification raised while the chat panel is open and visible.
- `isViewingChat` now reflects whether the panel is on screen (mounted + visible via `checkVisibility()`), not whether focus sits inside it.
- The "away" path (tab hidden / window unfocused) is unchanged and still notifies.

In sidebar / floating mode (OpenCTI / OpenAEV) the user often reads a streamed answer while focus stays in the host app. The old focus-within test (`document.activeElement?.closest('.filigran-chatbot.fixed')`) classified that as "not viewing" and fired a host toast (OpenAEV: a success toast) for an answer already on screen.

## Behavior after the fix

- Chat open and visible, tab focused, reading the answer: no notice.
- Another browser tab (document hidden): notify (title flash + OS notification + host toast).
- Another window / app (window unfocused): notify.
- Panel kept mounted but display:none ("closed"): notify (`checkVisibility()` is false; on engines without that API an empty `getClientRects()` is used as the equivalent check).

## Notes

- Hosts that fully unmount the panel on close cannot raise a notice from inside the panel; covering "notify when fully closed" needs a host-level notifier (potential follow-up).
- Cross-browser hardening (review follow-up): `isViewingChat` invokes `checkVisibility()` only behind a `typeof === 'function'` guard, and when the API is absent it falls back to `panel.getClientRects().length > 0` (rather than assuming "viewing"), so the closed/hidden notify path still holds on older engines.
- Doc consistency (review follow-up): the `onComplete` hook option and the host-facing `notifyOnComplete` / `onTaskComplete` JSDoc now describe the visibility-based model (the in-app toast fires when the panel is closed/hidden), replacing the stale focus-within wording. Comment-only.
- Ships to OpenCTI / OpenAEV via a new @filigran/chatbot release + dependency bump.

## Test plan

- [ ] Sidebar mode: send a long prompt, click into the host app (focus leaves the panel), let it finish -> no toast.
- [ ] Switch to another tab before completion -> toast + title flash on return.
- [ ] Focus another window before completion -> toast + title flash.
- [ ] Panel open and focused, watch it finish -> no toast.

Closes #331
