### PR TITLE
fix(rich-text-editor): add node export for CommonJS compatibility (#333)

### DIFF
--- a/packages/filigran-rich-text-editor/package.json
+++ b/packages/filigran-rich-text-editor/package.json
@@ -17,6 +17,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
+      "node": "./dist/index.cjs",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },


### PR DESCRIPTION
### Proposed changes

* Added a `node` condition in `exports` for `@filigran/rich-text-editor` so Node.js resolves the CJS build first (`./dist/index.cjs`).
* Kept `import` pointing to ESM (`./dist/index.js`) for bundlers (Vite/browser), preserving current behavior.

### Related issues

* Closes #333 

### How to test this PR

1. Install the package version from this branch in a Node.js test environment (Vitest/Jest).
2. Import `@filigran/rich-text-editor` in a test running in Node ESM mode.
3. Confirm the previous error is gone:  
   `Directory import .../@mui/material/styles is not supported`.
4. Optionally verify in a Vite app that ESM path is still used and build/runtime behavior is unchanged.

### Checklist

- [x] The PR title follows the Conventional Commits convention `type(scope?): description (#issue)`
- [x] I signed my commits
- [x] This PR is linked to an issue
- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I added/updated the relevant documentation
- [x] Where necessary, I refactored code to improve the overall quality

### Further comments

This is a targeted compatibility fix for Node.js ESM resolution with `@mui/material` v6.x (no `exports` map).  
No source code or build artifacts changed; only package export conditions and patch version were updated.  
Node picks the `node` condition (`.cjs`), while bundlers continue to use `import` (`.js`), maintaining compatibility across environments.