### PR TITLE
fix(rich-text-editor): move @tiptap dependencies to dependencies section (#335)

### DIFF
--- a/packages/filigran-rich-text-editor/package.json
+++ b/packages/filigran-rich-text-editor/package.json
@@ -30,12 +30,14 @@
   "peerDependencies": {
     "@mui/icons-material": ">=5",
     "@mui/material": ">=5",
-    "@tiptap/core": ">=3",
-    "@tiptap/pm": ">=3",
-    "@tiptap/react": ">=3",
     "react": ">=18",
     "react-color": ">=2",
     "react-dom": ">=18"
+  },
+  "dependencies": {
+    "@tiptap/core": "^3.23.1",
+    "@tiptap/pm": "^3.23.1",
+    "@tiptap/react": "^3.23.1"
   },
   "devDependencies": {
     "@mui/icons-material": "6.5.0",

--- a/packages/filigran-rich-text-editor/package.json
+++ b/packages/filigran-rich-text-editor/package.json
@@ -35,9 +35,9 @@
     "react-dom": ">=18"
   },
   "dependencies": {
-    "@tiptap/core": "^3.23.1",
-    "@tiptap/pm": "^3.23.1",
-    "@tiptap/react": "^3.23.1"
+    "@tiptap/core": "3.23.1",
+    "@tiptap/pm": "3.23.1",
+    "@tiptap/react": "3.23.1"
   },
   "devDependencies": {
     "@mui/icons-material": "6.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2259,9 +2259,6 @@ __metadata:
   peerDependencies:
     "@mui/icons-material": ">=5"
     "@mui/material": ">=5"
-    "@tiptap/core": ">=3"
-    "@tiptap/pm": ">=3"
-    "@tiptap/react": ">=3"
     react: ">=18"
     react-color: ">=2"
     react-dom: ">=18"


### PR DESCRIPTION
### Proposed changes

* Move `@tiptap/core`, `@tiptap/pm` and `@tiptap/react` from `peerDependencies` to `dependencies` in `@filigran/rich-text-editor`
* Consumer applications no longer need to install tiptap themselves — it is resolved automatically as a sub-dependency

### Related issues

* Closes #335 

### How to test this PR

Install `@filigran/rich-text-editor` in a project that does **not** declare any `@tiptap/*` dependency and verify that the editor renders correctly without any missing module error.

### Checklist

- [x] The PR title follows the Conventional Commits convention `type(scope?): description (#issue)`
- [x] I signed my commits
- [x] This PR is linked to an issue
- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I added/updated the relevant documentation
- [x] Where necessary, I refactored code to improve the overall quality

### Further comments

