### PR TITLE
feat(accordion): replace arrow icon by ArrowDropDown (#338)

### DIFF
--- a/packages/filigran-ui/src/components/clients/accordion.tsx
+++ b/packages/filigran-ui/src/components/clients/accordion.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import * as AccordionPrimitive from '@radix-ui/react-accordion'
-import {ArrowDropDownIcon, KeyboardArrowDownIcon} from '@filigran/icon'
+import {ArrowDropDownIcon} from '@filigran/icon'
 import * as React from 'react'
 import {cn} from '../../lib/utils'
 

--- a/packages/filigran-ui/src/components/clients/accordion.tsx
+++ b/packages/filigran-ui/src/components/clients/accordion.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import * as AccordionPrimitive from '@radix-ui/react-accordion'
-import {KeyboardArrowDownIcon} from '@filigran/icon'
+import {ArrowDropDownIcon, KeyboardArrowDownIcon} from '@filigran/icon'
 import * as React from 'react'
 import {cn} from '../../lib/utils'
 
@@ -32,7 +32,7 @@ const AccordionTrigger = React.forwardRef<
       )}
       {...props}>
       {children}
-      <KeyboardArrowDownIcon className="h-3 w-3 shrink-0 transition-transform duration-200" />
+      <ArrowDropDownIcon className="h-5 w-5 shrink-0 transition-transform duration-200" />
     </AccordionPrimitive.Trigger>
   </AccordionPrimitive.Header>
 ))


### PR DESCRIPTION
<!--
Thank you very much for your pull request! We as a community driven project
depend on support and contributions like this.

Title convention (Conventional Commits + GitHub reference):
  type(scope?): description (#issue)
Types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert.
See .github/LABELS.md for the full taxonomy.
-->

### Proposed changes

On Accordion component, replace ChevronIcon by ArrowDropDown:
<img width="251" height="92" alt="image" src="https://github.com/user-attachments/assets/6033a9d4-f31f-4711-9bed-2cc92440a738" />


### Related issues

<!-- This PR must be linked to an issue. Use a closing keyword. -->
* Closes #338

### How to test this PR

<!-- Please give example or instructions for the reviewer to test this PR. -->
Test the icon displayed is the ArrowDropDownIcon 

### Checklist

- [x] The PR title follows the Conventional Commits convention `type(scope?): description (#issue)`
- [x] I signed my commits
- [x] This PR is linked to an issue
- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I added/updated the relevant documentation
- [x] Where necessary, I refactored code to improve the overall quality

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you considered. -->
