### PR TITLE
fix(rich-text-editor): restore setParagraph command in Paragraph extension (#343)

### DIFF
--- a/packages/filigran-rich-text-editor/src/richTextEditor/extensions/Paragraph.ts
+++ b/packages/filigran-rich-text-editor/src/richTextEditor/extensions/Paragraph.ts
@@ -39,6 +39,7 @@ export const Paragraph = ParagraphBase.extend({
 
   addCommands() {
     return {
+      ...this.parent?.(),
       indent:
         () =>
           ({ commands, editor }) => {


### PR DESCRIPTION
### Proposed changes

* Spread `...this.parent?.()` in `addCommands()` of the custom `Paragraph` extension so the base `setParagraph` command is no longer dropped
* Aligns `addCommands()` with the existing pattern already used in `addAttributes()` in the same file

### Related issues

* Closes #343

### How to test this PR

1. Integrate the built package in OpenCTI (or any app using `RichTextEditor`)
2. Type some text and open the heading/paragraph dropdown in the toolbar
3. Select **"Paragraph"** — should apply without errors
4. Select a heading level, then switch back to **"Paragraph"** — same, no error

### Checklist

- [x] The PR title follows the Conventional Commits convention `type(scope?): description (#issue)`
- [x] I signed my commits
- [x] This PR is linked to an issue
- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I added/updated the relevant documentation
- [ ] Where necessary, I refactored code to improve the overall quality

### Further comments

The custom `Paragraph` extension overrode `addCommands()` to add `indent`/`outdent` but did not call `this.parent?.()`, silently removing all commands inherited from `@tiptap/extension-paragraph` (including `setParagraph`). The fix is a one-liner consistent with how `addAttributes()` already merges parent attributes in the same file.