### PR TITLE
feat(rich-text-editor): add variant and className props (#345)

### DIFF
--- a/packages/filigran-rich-text-editor/src/RichTextEditor.tsx
+++ b/packages/filigran-rich-text-editor/src/RichTextEditor.tsx
@@ -39,6 +39,12 @@ import { FontSize } from './richTextEditor/extensions/FontSize';
 import { Paragraph } from './richTextEditor/extensions/Paragraph';
 import type { Theme } from '@mui/material/styles';
 import { TaskList } from './richTextEditor/extensions/TaskList';
+
+declare module '@mui/material/styles' {
+  interface TypeBackground {
+    accent?: string;
+  }
+}
 import { TaskItem } from './richTextEditor/extensions/TaskListItem';
 import { Div } from './richTextEditor/extensions/Div';
 
@@ -749,10 +755,9 @@ export const RichTextEditor: React.FC<RichTextEditorProps> = ({
     display: 'flex',
     flexDirection: 'column',
     ...(isOutlined && {
-      border: `1px solid ${theme.palette.mode === 'dark' ? 'rgba(255,255,255,0.23)' : 'rgba(0,0,0,0.23)'}`,
-      borderRadius: theme.shape.borderRadius,
-      overflow: 'hidden',
+      '--rte-border-color': theme.palette.text.primary,
       '--rte-primary-color': theme.palette.primary.main,
+      '--rte-border-radius': `${theme.shape.borderRadius}px`,
     } as React.CSSProperties),
   };
 
@@ -765,7 +770,7 @@ export const RichTextEditor: React.FC<RichTextEditorProps> = ({
     >
       <div
         style={isOutlined ? {
-          backgroundColor: theme.palette.background.default,
+          backgroundColor: theme.palette.background.accent,
           borderBottom: `1px solid ${theme.palette.divider}`,
         } : undefined}
       >
@@ -776,6 +781,7 @@ export const RichTextEditor: React.FC<RichTextEditorProps> = ({
         onOpenImagePopover={openImagePopoverFromToolbar}
         isSourceMode={sourceMode}
         onToggleSourceMode={toggleSourceMode}
+        variant={variant}
       />
       </div>
       <div

--- a/packages/filigran-rich-text-editor/src/RichTextEditor.tsx
+++ b/packages/filigran-rich-text-editor/src/RichTextEditor.tsx
@@ -39,16 +39,16 @@ import { FontSize } from './richTextEditor/extensions/FontSize';
 import { Paragraph } from './richTextEditor/extensions/Paragraph';
 import type { Theme } from '@mui/material/styles';
 import { TaskList } from './richTextEditor/extensions/TaskList';
+import { TaskItem } from './richTextEditor/extensions/TaskListItem';
+import { Div } from './richTextEditor/extensions/Div';
+
+import './styles/TiptapEditor.css';
 
 declare module '@mui/material/styles' {
   interface TypeBackground {
     accent?: string;
   }
 }
-import { TaskItem } from './richTextEditor/extensions/TaskListItem';
-import { Div } from './richTextEditor/extensions/Div';
-
-import './styles/TiptapEditor.css';
 
 export const TIPTAP_EDITOR_SELECTOR = '.tiptap-editor-content.ProseMirror';
 
@@ -770,7 +770,7 @@ export const RichTextEditor: React.FC<RichTextEditorProps> = ({
     >
       <div
         style={isOutlined ? {
-          backgroundColor: theme.palette.background.accent,
+          backgroundColor: theme.palette.background.accent ?? theme.palette.background.default,
           borderBottom: `1px solid ${theme.palette.divider}`,
         } : undefined}
       >

--- a/packages/filigran-rich-text-editor/src/RichTextEditor.tsx
+++ b/packages/filigran-rich-text-editor/src/RichTextEditor.tsx
@@ -62,6 +62,10 @@ export interface RichTextEditorProps {
   disabled?: boolean;
   disableWatchdog?: boolean;
   placeholder?: string;
+  /** Visual variant. "standard" (default) = current borderless look. "outlined" = MUI-style border + focus ring. */
+  variant?: 'standard' | 'outlined';
+  /** Additional CSS class name on the root wrapper div */
+  className?: string;
 }
 
 const createEditorAdapter = (editor: Editor): RichTextEditorAdapter => ({
@@ -78,6 +82,8 @@ export const RichTextEditor: React.FC<RichTextEditorProps> = ({
   onFocus,
   disabled = false,
   placeholder = '',
+  variant = 'standard',
+  className,
 }) => {
   const theme = useTheme<Theme>();
   const isDark = theme.palette?.mode === 'dark';
@@ -736,11 +742,33 @@ export const RichTextEditor: React.FC<RichTextEditorProps> = ({
     return null;
   }
 
+  const isOutlined = variant === 'outlined';
+
+  const wrapperStyle: React.CSSProperties = {
+    height: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+    ...(isOutlined && {
+      border: `1px solid ${theme.palette.mode === 'dark' ? 'rgba(255,255,255,0.23)' : 'rgba(0,0,0,0.23)'}`,
+      borderRadius: theme.shape.borderRadius,
+      overflow: 'hidden',
+      '--rte-primary-color': theme.palette.primary.main,
+    } as React.CSSProperties),
+  };
+
+  const wrapperClassName = `rich-text-editor-wrapper${isOutlined ? ' rich-text-editor-outlined' : ''}${className ? ` ${className}` : ''}`;
+
   return (
     <div
-      className="rich-text-editor-wrapper"
-      style={{ height: '100%', display: 'flex', flexDirection: 'column' }}
+      className={wrapperClassName}
+      style={wrapperStyle}
     >
+      <div
+        style={isOutlined ? {
+          backgroundColor: theme.palette.background.default,
+          borderBottom: `1px solid ${theme.palette.divider}`,
+        } : undefined}
+      >
       <TiptapEditorToolbar
         editor={editor}
         disabled={disabled}
@@ -749,6 +777,7 @@ export const RichTextEditor: React.FC<RichTextEditorProps> = ({
         isSourceMode={sourceMode}
         onToggleSourceMode={toggleSourceMode}
       />
+      </div>
       <div
         ref={editorWrapRef}
         style={{ flex: 1, minHeight: 0, overflow: 'auto' }}

--- a/packages/filigran-rich-text-editor/src/richTextEditor/TiptapEditorToolbar.tsx
+++ b/packages/filigran-rich-text-editor/src/richTextEditor/TiptapEditorToolbar.tsx
@@ -46,6 +46,7 @@ import {
   ToggleButtonGroup,
   Tooltip,
 } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
 import { SketchPicker } from 'react-color';
 import { TableGridPicker } from './TableGridPicker';
 
@@ -91,6 +92,7 @@ interface TiptapEditorToolbarProps {
   onOpenImagePopover?: () => void;
   isSourceMode?: boolean;
   onToggleSourceMode?: () => void;
+  variant?: 'standard' | 'outlined';
 }
 
 export const TiptapEditorToolbar: React.FC<TiptapEditorToolbarProps> = ({
@@ -100,6 +102,7 @@ export const TiptapEditorToolbar: React.FC<TiptapEditorToolbarProps> = ({
   onOpenImagePopover,
   isSourceMode = false,
   onToggleSourceMode,
+  variant = 'standard',
 }) => {
   const [, forceUpdate] = React.useReducer((x) => x + 1, 0);
   React.useEffect(() => {
@@ -265,7 +268,12 @@ export const TiptapEditorToolbar: React.FC<TiptapEditorToolbarProps> = ({
     return () => ro.disconnect();
   }, [itemIds, itemGroups]);
 
-  const toolbarItemStyles = {
+  const theme = useTheme();
+  const hoverBg = variant === 'outlined'
+    ? (theme.palette.mode === 'dark' ? 'rgb(1, 71, 141)' : 'rgb(178,178,178)')
+    : 'transparent';
+
+  const buildToolbarItemStyles = (hover: string) => ({
     '& .MuiToggleButtonGroup-root': {
       border: 'none',
       gap: '2px',
@@ -285,10 +293,10 @@ export const TiptapEditorToolbar: React.FC<TiptapEditorToolbarProps> = ({
         color: 'text.disabled',
       },
       '&:hover': {
-        backgroundColor: 'transparent',
+        backgroundColor: hoverBg,
       },
       '&:hover:not(.Mui-selected)': {
-        backgroundColor: 'transparent',
+        backgroundColor: hoverBg,
       },
       '&.Mui-selected': {
         backgroundColor: 'action.selected',
@@ -302,7 +310,10 @@ export const TiptapEditorToolbar: React.FC<TiptapEditorToolbarProps> = ({
         },
       },
     },
-  };
+  });
+
+  const toolbarItemStyles = buildToolbarItemStyles(hoverBg);
+  const overflowItemStyles = buildToolbarItemStyles('action.hover');
 
   return (
     <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
@@ -869,7 +880,7 @@ export const TiptapEditorToolbar: React.FC<TiptapEditorToolbarProps> = ({
             flexWrap: 'wrap',
             alignItems: 'center',
             gap: 0.5,
-            ...toolbarItemStyles,
+            ...overflowItemStyles,
           }}
         >
           {/* heading */}

--- a/packages/filigran-rich-text-editor/src/richTextEditor/TiptapEditorToolbar.tsx
+++ b/packages/filigran-rich-text-editor/src/richTextEditor/TiptapEditorToolbar.tsx
@@ -293,10 +293,10 @@ export const TiptapEditorToolbar: React.FC<TiptapEditorToolbarProps> = ({
         color: 'text.disabled',
       },
       '&:hover': {
-        backgroundColor: hoverBg,
+        backgroundColor: hover,
       },
       '&:hover:not(.Mui-selected)': {
-        backgroundColor: hoverBg,
+        backgroundColor: hover,
       },
       '&.Mui-selected': {
         backgroundColor: 'action.selected',

--- a/packages/filigran-rich-text-editor/src/styles/TiptapEditor.css
+++ b/packages/filigran-rich-text-editor/src/styles/TiptapEditor.css
@@ -6,6 +6,24 @@
   flex-direction: column;
 }
 
+/* Outlined variant - focus ring using CSS variable set inline for theme compatibility */
+.rich-text-editor-wrapper.rich-text-editor-outlined:focus-within {
+  border-color: var(--rte-primary-color);
+  border-width: 2px;
+  margin: -1px; /* compensate layout shift from extra border pixel */
+}
+
+/* Outlined variant - remove underlines from Select components in toolbar */
+.rich-text-editor-wrapper.rich-text-editor-outlined > div:first-of-type .MuiInput-underline::before,
+.rich-text-editor-wrapper.rich-text-editor-outlined > div:first-of-type .MuiInput-underline::after {
+  display: none;
+}
+
+/* Outlined variant - tighter content area padding */
+.rich-text-editor-wrapper.rich-text-editor-outlined .ProseMirror {
+  padding: 8px 12px;
+}
+
 .rich-text-editor-wrapper .ProseMirror {
   min-height: 100px;
   padding: 12px;

--- a/packages/filigran-rich-text-editor/src/styles/TiptapEditor.css
+++ b/packages/filigran-rich-text-editor/src/styles/TiptapEditor.css
@@ -7,16 +7,25 @@
 }
 
 /* Outlined variant - focus ring using CSS variable set inline for theme compatibility */
+.rich-text-editor-wrapper.rich-text-editor-outlined {
+  border: 1px solid var(--rte-border-color);
+  border-radius: var(--rte-border-radius);
+  overflow: hidden;
+}
+
 .rich-text-editor-wrapper.rich-text-editor-outlined:focus-within {
   border-color: var(--rte-primary-color);
-  border-width: 2px;
-  margin: -1px; /* compensate layout shift from extra border pixel */
 }
 
 /* Outlined variant - remove underlines from Select components in toolbar */
 .rich-text-editor-wrapper.rich-text-editor-outlined > div:first-of-type .MuiInput-underline::before,
 .rich-text-editor-wrapper.rich-text-editor-outlined > div:first-of-type .MuiInput-underline::after {
   display: none;
+}
+
+/* Outlined variant - padding for Select components in toolbar */
+.rich-text-editor-wrapper.rich-text-editor-outlined > div:first-of-type .MuiSelect-select {
+  padding-left: 8px;
 }
 
 /* Outlined variant - tighter content area padding */


### PR DESCRIPTION
### Proposed changes

* Add `variant` prop (`'standard' | 'outlined'`) to `RichTextEditorProps` — `'standard'` keeps the current borderless look (no breaking change), `'outlined'` renders a MUI-style border, focus ring, and styled toolbar
* Add `className` prop forwarded to the root wrapper `div`
* Implement `variant="outlined"` styling: border using `theme.palette.text.primary`, border radius, focus ring (`primary.main` on `:focus-within`), toolbar background (`background.accent`) with bottom divider, removal of `MuiInput` underlines on Select components, `paddingLeft` on `MuiSelect-select`, custom hover colors for toolbar buttons (theme-aware, separate for main toolbar vs overflow menu)
* Pass `variant` down to `TiptapEditorToolbar` so the overflow Popover (portal) also benefits from the correct hover color
* Add MUI module augmentation for `TypeBackground.accent` (used by OpenCTI and OpenAEV)

### Related issues

* Closes #345 

### How to test this PR

```tsx
// Standard (existing behavior — must be unchanged)
<RichTextEditor data="..." onChange={...} />

// Outlined
<RichTextEditor variant="outlined" data="..." onChange={...} />
```
Verify on variant="outlined":

- Border visible at rest (1px, text.primary color)
- Border color switches to primary.main when clicking inside the editor
- Toolbar has background.accent background with a bottom divider
- No underlines under Select dropdowns in the toolbar
- Hover on toolbar buttons applies the correct color (dark: #01478d, light: rgb(178,178,178))
- Hover in the overflow menu (⋮) applies action.hover
- className is forwarded to the root div

### Checklist

- [x]  The PR title follows the Conventional Commits convention type(scope?): description (#issue)
- [x]  I signed my commits
- [x]  This PR is linked to an issue
- [x]  I consider the submitted work as finished
- [x]  I tested the code for its functionality
- [ ]  I added/updated the relevant documentation
- [ ]  Where necessary, I refactored code to improve the overall quality

### Further comments

This change was motivated by OpenAEV's PR (OpenAEV-Platform/openaev#6392) which created a 54-line RichTextEditorWithStyles wrapper using GlobalStyles to achieve the outlined look. Absorbing it into the package eliminates the global CSS leak (styles were applied to all .rich-text-editor-wrapper instances on the page) and reduces the consumer code to a single variant="outlined" prop. 
