### PR TITLE
feat(rich-text-editor): extend RichTextEditorAdapter with setContent and scrollToBottom (#347)

### DIFF
--- a/packages/filigran-rich-text-editor/src/RichTextEditor.tsx
+++ b/packages/filigran-rich-text-editor/src/RichTextEditor.tsx
@@ -195,7 +195,7 @@ export const RichTextEditor: React.FC<RichTextEditorProps> = ({
   const editorWrapRef = useRef<HTMLDivElement | null>(null);
   const editorContentWrapRef = useRef<HTMLDivElement | null>(null);
 
-  const createAdapter = (editor: Editor): RichTextEditorAdapter => ({
+  const createAdapter = useCallback((editor: Editor): RichTextEditorAdapter => ({
     getData: () => editor.getHTML(),
     setContent: (html: string) => {
       editor.commands.setContent(html, {emitUpdate: true});
@@ -206,7 +206,7 @@ export const RichTextEditor: React.FC<RichTextEditorProps> = ({
         container.scrollTop = container.scrollHeight;
       }
     },
-  });
+  }), []);
   const imageEditPosRef = useRef<number | null>(null);
   const imageOptionsPopoverOpenRef = useRef(false);
   imageEditPosRef.current = imageEditButton?.pos ?? null;
@@ -701,8 +701,7 @@ export const RichTextEditor: React.FC<RichTextEditorProps> = ({
     if (editor && onReady) {
       onReady(createAdapter(editor));
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [editor, onReady]);
+  }, [editor, onReady, createAdapter]);
 
   useEffect(() => {
     if (!editor || editor.isDestroyed) return;

--- a/packages/filigran-rich-text-editor/src/RichTextEditor.tsx
+++ b/packages/filigran-rich-text-editor/src/RichTextEditor.tsx
@@ -53,15 +53,20 @@ declare module '@mui/material/styles' {
 export const TIPTAP_EDITOR_SELECTOR = '.tiptap-editor-content.ProseMirror';
 
 export interface RichTextEditorAdapter {
+  /** Returns the current HTML content */
   getData: () => string;
+  /** Replaces the entire editor content with the given HTML */
+  setContent: (html: string) => void;
+  /** Scrolls the editor content area to the bottom */
+  scrollToBottom: () => void;
 }
 
 export interface RichTextEditorProps {
   id?: string;
   data?: string;
   onChange?: (evt: unknown, editor: RichTextEditorAdapter) => void;
-  /** @deprecated Use onTextSelection instead */
-  onReady?: (editor: Editor) => void;
+  /** Called when the editor is mounted and ready. Provides an imperative adapter handle. */
+  onReady?: (adapter: RichTextEditorAdapter) => void;
   onTextSelection?: (text: string) => void;
   onBlur?: (evt: unknown, editor: RichTextEditorAdapter) => void;
   onFocus?: (evt: unknown) => void;
@@ -74,9 +79,7 @@ export interface RichTextEditorProps {
   className?: string;
 }
 
-const createEditorAdapter = (editor: Editor): RichTextEditorAdapter => ({
-  getData: () => editor.getHTML(),
-});
+
 
 export const RichTextEditor: React.FC<RichTextEditorProps> = ({
   id,
@@ -134,7 +137,7 @@ export const RichTextEditor: React.FC<RichTextEditorProps> = ({
     } else {
       // switching FROM source mode: apply textarea content back to editor
       editorRef.current.commands.setContent(sourceHtml);
-      onChangeRef.current?.(undefined, createEditorAdapter(editorRef.current));
+      onChangeRef.current?.(undefined, createAdapter(editorRef.current));
     }
     setSourceMode((prev) => !prev);
   }, [sourceMode, sourceHtml]);
@@ -191,6 +194,19 @@ export const RichTextEditor: React.FC<RichTextEditorProps> = ({
   } | null>(null);
   const editorWrapRef = useRef<HTMLDivElement | null>(null);
   const editorContentWrapRef = useRef<HTMLDivElement | null>(null);
+
+  const createAdapter = (editor: Editor): RichTextEditorAdapter => ({
+    getData: () => editor.getHTML(),
+    setContent: (html: string) => {
+      editor.commands.setContent(html, {emitUpdate: true});
+    },
+    scrollToBottom: () => {
+      const container = editorWrapRef.current;
+      if (container) {
+        container.scrollTop = container.scrollHeight;
+      }
+    },
+  });
   const imageEditPosRef = useRef<number | null>(null);
   const imageOptionsPopoverOpenRef = useRef(false);
   imageEditPosRef.current = imageEditButton?.pos ?? null;
@@ -520,7 +536,7 @@ export const RichTextEditor: React.FC<RichTextEditorProps> = ({
     // Force immediate upstream sync to avoid losing attrs on fast mode toggles
     // where blur/update listeners can race with unmount.
     if (onChangeRef.current) {
-      onChangeRef.current(null, createEditorAdapter(editor));
+      onChangeRef.current(null, createAdapter(editor));
     }
     closeImageOptionsPopover();
   }, [editor, imageOptionsPopover, closeImageOptionsPopover]);
@@ -683,8 +699,9 @@ export const RichTextEditor: React.FC<RichTextEditorProps> = ({
 
   useEffect(() => {
     if (editor && onReady) {
-      onReady(editor);
+      onReady(createAdapter(editor));
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [editor, onReady]);
 
   useEffect(() => {
@@ -702,7 +719,7 @@ export const RichTextEditor: React.FC<RichTextEditorProps> = ({
     if (!editor) return;
     const handler = () => {
       if (onChangeRef.current) {
-        onChangeRef.current(null, createEditorAdapter(editor));
+        onChangeRef.current(null, createAdapter(editor));
       }
     };
     editor.on('update', handler);
@@ -713,7 +730,7 @@ export const RichTextEditor: React.FC<RichTextEditorProps> = ({
 
   useEffect(() => {
     if (!editor || !onBlur) return;
-    const handler = ({ event }: { event: FocusEvent }) => onBlur(event, createEditorAdapter(editor));
+    const handler = ({ event }: { event: FocusEvent }) => onBlur(event, createAdapter(editor));
     editor.on('blur', handler);
     return () => {
       editor.off('blur', handler);


### PR DESCRIPTION
### Proposed changes

* Extend `RichTextEditorAdapter` with two new imperative methods: `setContent(html)` and `scrollToBottom()`
* Change `onReady` callback signature from `(editor: Editor) => void` to `(adapter: RichTextEditorAdapter) => void`, removing the TipTap type from the public API surface

### Related issues

* Closes #347

### How to test this PR

1. Mount `<RichTextEditor onReady={(adapter) => { ... }} />`
2. Call `adapter.setContent('<p>hello</p>')` — verify the editor content updates and `onChange` fires
3. Add enough content to make the editor scroll, then call `adapter.scrollToBottom()` — verify the content area scrolls to the bottom
4. Verify existing `onChange` and `onBlur` consumers receive an adapter with all three methods (`getData`, `setContent`, `scrollToBottom`)
5. Build the package (`yarn build:filigran-rich-text-editor`) and inspect `dist/index.d.ts` — confirm `Editor` from `@tiptap/react` does not appear in any exported type

### Checklist

- [x] The PR title follows the Conventional Commits convention `type(scope?): description (#issue)`
- [x] I signed my commits
- [x] This PR is linked to an issue
- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I added/updated the relevant documentation
- [ ] Where necessary, I refactored code to improve the overall quality

### Further comments

`createAdapter` is now defined inside the component body so that `scrollToBottom` can close over `editorWrapRef` (the scrollable container div) without passing it as an extra parameter. The alternative of DOM traversal from `editor.view.dom` was considered but rejected as fragile — the ref is already available in scope.

The `onReady` callback is no longer marked `@deprecated`; consumers that previously received a raw TipTap `Editor` instance will need to migrate to the adapter API. This is a breaking change for `onReady` callers but leaves `onChange` and `onBlur` signatures unchanged.