### PR TITLE
feat(chatbot): show context-window usage in the composer (#377)

### DIFF
--- a/packages/filigran-chatbot/README.md
+++ b/packages/filigran-chatbot/README.md
@@ -14,6 +14,7 @@ Filigran chat panel — a standalone React + Tailwind chatbot component with SSE
 - 🖼️ **Image Previews** — `data:image/*` charts and image attachments render inline, click to expand
 - 📋 **Copy & Rate** — Copy any answer; optional 👍/👎 feedback wired to the host
 - 🧰 **Composer Toolbar** — Prompt library and quota indicator, both driven by whether the host serves the route; plus a slot for the host's own controls
+- 🧠 **Context Gauge** — Ring + percentage showing how full the model's context window is, so a long chat's silent summarising is visible before it happens
 - 🎙️ **Dictation** — Speech-to-text via the browser's own Web Speech API; no endpoint, no key, hidden where unsupported
 - ✍️ **Draft Recovery** — Unsent composer text is kept per conversation and restored when the panel reopens
 - 🎨 **Customizable Theme** — Accent color and logo customization
@@ -81,6 +82,7 @@ import { ChatPanel } from '@filigran/chatbot';
 | `onResizeEnd`       | `() => void`                              | —            | Called when resize drag ends                                     |
 | `onMessageFeedback` | `(id, feedback, message) => void`         | —            | Enables 👍/👎 on completed assistant answers and receives each rating (`null` clears it). Omit to hide the affordance — the panel stores nothing itself. |
 | `disableImagePreviews` | `boolean`                              | `false`      | Render image attachments as download cards instead of inline previews |
+| `contextUsageEnabled` | `boolean`                               | `true`       | Show how full the model's context window is for the current conversation (ring + percentage in the composer toolbar). Data-driven, so it stays absent until the backend reports occupancy — see [Context usage](#context-usage). |
 | `composerToolbar`   | `React.ReactNode`                         | —            | Extra controls appended to the composer toolbar. The escape hatch for host-specific affordances (XTM One's session-tool picker) — the package never learns what they are. Pass nothing and the toolbar simply has none. |
 
 #### Resizable Sidebar Example
@@ -519,6 +521,60 @@ API, so the mic button appears wherever the API exists and is simply absent
 elsewhere. Finalised phrases are appended to the composer (never replacing a
 draft), interim words preview beside the button, and sending stops the mic so
 the next words cannot land in a composer the user just emptied.
+
+### Context usage
+
+The composer also carries a context gauge — a small ring plus percentage
+showing how full the model's context window is for the current conversation,
+the affordance Cursor popularised. It answers one question: *is this
+conversation about to get shorter than I think?* Long chats do not fail at the
+window, they get silently summarised, and a user who cannot see that coming
+reads the summary's gaps as the assistant forgetting.
+
+Clicking it opens a breakdown: one stacked bar over the window plus a colour
+legend, so "why is this chat 84 % full" has an answer the user can act on —
+usually "the tool results", sometimes "the MCP tools you wired up".
+
+Unlike the items above it needs no endpoint of its own. The backend reports the
+occupancy on the frames it already sends:
+
+| Frame | Extra keys | When |
+| --- | --- | --- |
+| `status: "thinking"` | `context_tokens`, `context_window`, `context_breakdown?` | Each agent-loop iteration, so the gauge climbs during a long turn |
+| `done` | same | Closing value for the turn — a turn whose last iteration compacted ends lower than it peaked |
+| Restored message (`POST /chat/sessions`) | same | On the newest assistant message, so a reload or conversation switch restores the gauge |
+
+`context_tokens` and `context_window` are required together and the window must
+be positive: a token count with no window to measure it against is not a ratio.
+Anything else is ignored, so a backend that reports nothing simply has no gauge —
+and a host on an older backend needs no configuration change.
+
+`context_breakdown` is optional and validated independently, so a malformed one
+costs the gauge its detail but never its number. Keys, all optional, in tokens:
+
+| Key | Legend row |
+| --- | --- |
+| `system` | System prompt |
+| `tools` | Tool definitions |
+| `dynamic_tools` | MCP & dynamic tools |
+| `summary` | Summarized conversation |
+| `tool_results` | Tool results |
+| `conversation` | Conversation |
+
+Only positive values are shown, so a chat with no digest yet simply has no
+"Summarized conversation" row. **The values must sum to `context_tokens`** — the
+popover shows the lines and the headline together, and a breakdown whose parts
+do not add up reads as broken numbers rather than as rounding. A producer doing
+per-bucket integer division has to distribute the remainder rather than drop it.
+
+Colours track the backend's own thresholds, not a design choice: neutral below
+80 % (where XTM One's agent loop starts distilling older turns into a summary),
+amber past it, red past 95 % (where it emergency-prunes). `used` is a
+char-derived estimate of what the next call will carry — deliberately a forecast
+rather than a receipt for the turn that just ended, which is why the figures are
+prefixed with `~`.
+
+Only the `rest` backend carries the figures today.
 
 Anything host-specific goes through `composerToolbar`:
 

--- a/packages/filigran-chatbot/src/components/ChatInput.tsx
+++ b/packages/filigran-chatbot/src/components/ChatInput.tsx
@@ -1,7 +1,8 @@
 import { useRef, type KeyboardEvent } from 'react';
-import type { ChatFile, ChatMode, ChatPromptTemplate, ChatQuotaStatus } from '../types';
+import type { ChatContextUsage, ChatFile, ChatMode, ChatPromptTemplate, ChatQuotaStatus } from '../types';
 import { AttachFileIcon, FileIcon, MicIcon, MicOffIcon, SendIcon, StopCircleIcon } from './icons';
 import { useDictation } from '../hooks/useDictation';
+import { ContextUsageIndicator } from './ContextUsageIndicator';
 import { PromptPicker } from './PromptPicker';
 import { QuotaIndicator } from './QuotaIndicator';
 import { Tooltip } from './Tooltip';
@@ -30,6 +31,8 @@ interface ChatInputProps {
   prompts?: ChatPromptTemplate[] | null;
   /** Agentic quota headroom; omitted entirely when the host serves none. */
   quota?: ChatQuotaStatus | null;
+  /** Context-window occupancy; omitted until the backend reports it. */
+  contextUsage?: ChatContextUsage | null;
   /** Host-supplied controls appended to the toolbar (see `composerToolbar`). */
   composerToolbar?: React.ReactNode;
 }
@@ -50,6 +53,7 @@ export const ChatInput = ({
   separatorColor,
   prompts,
   quota,
+  contextUsage,
   composerToolbar,
 }: ChatInputProps) => {
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -91,7 +95,7 @@ export const ChatInput = ({
 
   // The toolbar row costs vertical space, so it only exists when something
   // actually occupies it.
-  const hasToolbar = Boolean((prompts && prompts.length > 0) || quota || composerToolbar || dictation.supported);
+  const hasToolbar = Boolean((prompts && prompts.length > 0) || quota || contextUsage || composerToolbar || dictation.supported);
 
   const isFileManagementEnabled = Boolean(onFileAdd && onFileRemove && onPaste);
   const hasContent = inputValue.trim() || (isFileManagementEnabled && attachedFiles.length > 0);
@@ -234,9 +238,16 @@ export const ChatInput = ({
             <span className="text-[0.7rem] italic text-gray-400 dark:text-white/30 truncate max-w-[45%]">{dictation.interim}</span>
           )}
           {composerToolbar}
-          {/* Quota sits last and pushed right: it is a status readout, not a
-              control, so it should never sit between two clickable things. */}
-          {quota && <span className="ml-auto">{<QuotaIndicator quota={quota} t={t} />}</span>}
+          {/* Status readouts sit last and pushed right, together: they are not
+              controls, so neither should ever land between two clickable
+              things. Context before quota — "how full is this chat" is the one
+              the user can still act on by starting a new one. */}
+          {(contextUsage || quota) && (
+            <span className="ml-auto flex items-center gap-2.5">
+              {contextUsage && <ContextUsageIndicator usage={contextUsage} t={t} />}
+              {quota && <QuotaIndicator quota={quota} t={t} />}
+            </span>
+          )}
         </div>
       )}
 

--- a/packages/filigran-chatbot/src/components/ChatPanel.tsx
+++ b/packages/filigran-chatbot/src/components/ChatPanel.tsx
@@ -1,7 +1,7 @@
 import { type FunctionComponent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { ChatAttachment, ChatMessage, ChatPanelProps } from '../types';
 import { hexAlpha, identity } from '../utils';
-import { parseAttachments, parseToolCallTrace, parseTransferChain } from '../hooks/protocols/parseRestEvent';
+import { parseAttachments, parseContextUsage, parseToolCallTrace, parseTransferChain } from '../hooks/protocols/parseRestEvent';
 import { useChat } from '../hooks/useChat';
 import { useAgents } from '../hooks/useAgents';
 import { useConversations } from '../hooks/useConversations';
@@ -59,6 +59,7 @@ export const ChatPanel: FunctionComponent<ChatPanelProps> = ({
   onTaskComplete,
   onMessageFeedback,
   disableImagePreviews = false,
+  contextUsageEnabled = true,
   composerToolbar,
 }) => {
   const [modeMenuOpen, setModeMenuOpen] = useState(false);
@@ -78,6 +79,7 @@ export const ChatPanel: FunctionComponent<ChatPanelProps> = ({
     agentStatus,
     attachedFiles,
     conversationId,
+    contextUsage,
     transferredAgent,
     canSteer,
     historyLoadedRef,
@@ -89,6 +91,7 @@ export const ChatPanel: FunctionComponent<ChatPanelProps> = ({
     handleStopGenerating,
     setAttachedFiles,
     setMessages,
+    setContextUsage,
     updateConversationId,
     handleSwitchConversation,
   } = useChat({
@@ -439,6 +442,9 @@ export const ChatPanel: FunctionComponent<ChatPanelProps> = ({
               transfer_chain?: unknown;
               is_truncated?: unknown;
               agent_name?: unknown;
+              context_tokens?: unknown;
+              context_window?: unknown;
+              context_breakdown?: unknown;
             },
             i: number,
           ) => ({
@@ -471,6 +477,17 @@ export const ChatPanel: FunctionComponent<ChatPanelProps> = ({
           }),
         );
         setMessages(restored);
+        // The context gauge is conversation state, not per-message: the NEWEST
+        // entry that carries a reading is the current occupancy. Scanned from
+        // the end so a turn that predates the field (or a user message) falls
+        // through to the last one that has it, rather than blanking the gauge.
+        for (let i = data.messages.length - 1; i >= 0; i -= 1) {
+          const usage = parseContextUsage(data.messages[i] as Record<string, unknown>);
+          if (usage) {
+            setContextUsage(usage);
+            break;
+          }
+        }
       })
       .catch(() => {
         if (isStale()) return;
@@ -487,6 +504,7 @@ export const ChatPanel: FunctionComponent<ChatPanelProps> = ({
     isMountedRef,
     requestHeaders,
     setMessages,
+    setContextUsage,
     updateConversationId,
   ]);
 
@@ -623,6 +641,7 @@ export const ChatPanel: FunctionComponent<ChatPanelProps> = ({
         separatorColor={draftBorderColor}
         prompts={prompts}
         quota={quota}
+        contextUsage={contextUsageEnabled ? contextUsage : null}
         composerToolbar={composerToolbar}
       />
         </div>

--- a/packages/filigran-chatbot/src/components/ContextUsageIndicator.tsx
+++ b/packages/filigran-chatbot/src/components/ContextUsageIndicator.tsx
@@ -159,10 +159,15 @@ export const ContextUsageIndicator = ({ usage, t }: ContextUsageIndicatorProps) 
             own colours, so proportions are readable without matching numbers to
             rows. The trailing gap is the headroom left. */}
         <div className="px-3.5 pb-2.5 pt-1.5">
+          <span className="flex h-1.5 w-full gap-px rounded-full bg-gray-200 dark:bg-white/10 overflow-hidden">
             {rows.map((row) => (
               <span
                 key={row.field}
                 className="h-full first:rounded-l-full"
+                /* Scaled through the clamped total rather than straight over the
+                   window, so a producer that reports buckets summing past the
+                   limit fills the track instead of overflowing it. Identical to
+                   value/limit whenever the two agree, which is the normal case. */
                 style={{
                   width: `${((breakdown?.[row.field] ?? 0) / Math.max(used, 1)) * Math.min(used / limit, 1) * 100}%`,
                   backgroundColor: row.color,

--- a/packages/filigran-chatbot/src/components/ContextUsageIndicator.tsx
+++ b/packages/filigran-chatbot/src/components/ContextUsageIndicator.tsx
@@ -1,0 +1,194 @@
+import { useRef, useState } from 'react';
+import type { ChatContextBreakdown, ChatContextUsage } from '../types';
+import { compactCount } from '../utils';
+import { Dropdown } from './Dropdown';
+import { Tooltip } from './Tooltip';
+
+interface ContextUsageIndicatorProps {
+  usage: ChatContextUsage;
+  t: (key: string) => string;
+}
+
+// Thresholds are the agent loop's own gates, not design choices: at 80 %
+// utilization the backend compacts the session (older turns are distilled into
+// a summary), and past 95 % it emergency-prunes. Colouring anywhere else would
+// warn about a moment that never comes, or arrive after it has passed.
+const COMPACTION_RATIO = 0.8;
+const PRUNE_RATIO = 0.95;
+
+// Geometry of the ring. Kept at the text's own scale so the gauge reads as part
+// of the label rather than as an icon beside it.
+const SIZE = 14;
+const STROKE = 2;
+const RADIUS = (SIZE - STROKE) / 2;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+
+/**
+ * Rows of the detail popover, in a FIXED order that mirrors how the prompt is
+ * assembled — instructions, then tools, then the conversation and what the
+ * backend has done to it. Fixed rather than sorted by size so the same bucket
+ * stays in the same place as a chat grows: a legend whose rows reshuffle between
+ * two glances cannot be compared against itself.
+ *
+ * `color` is both the swatch and the stacked-bar segment, so the bar is readable
+ * without a legend lookup. Labels name what the user can act on, not the
+ * backend's internals: "Tool results" rather than "role=tool messages".
+ */
+const ROWS: ReadonlyArray<{ field: keyof ChatContextBreakdown; label: string; color: string }> = [
+  { field: 'system', label: 'System prompt', color: '#9ca3af' },
+  { field: 'tools', label: 'Tool definitions', color: '#a78bfa' },
+  { field: 'dynamicTools', label: 'MCP & dynamic tools', color: '#f0abfc' },
+  { field: 'summary', label: 'Summarized conversation', color: '#fb7185' },
+  { field: 'toolResults', label: 'Tool results', color: '#34d399' },
+  { field: 'conversation', label: 'Conversation', color: '#a1a1aa' },
+];
+
+/**
+ * Context-window occupancy for the current conversation, as a small ring plus
+ * percentage — the affordance Cursor popularised — opening a breakdown of where
+ * the context went.
+ *
+ * It answers one question: is this conversation about to get shorter than the
+ * user thinks? Long chats do not fail at the window, they get silently
+ * summarised, and a user who cannot see that coming reads the summary's gaps as
+ * the assistant forgetting. So the gauge is deliberately a *forecast* of the
+ * next turn, and its colours are the backend's real thresholds.
+ */
+export const ContextUsageIndicator = ({ usage, t }: ContextUsageIndicatorProps) => {
+  const { used, limit, breakdown } = usage;
+  const anchorRef = useRef<HTMLButtonElement>(null);
+  const [open, setOpen] = useState(false);
+
+  // The parser guarantees a positive limit; clamp anyway so a future producer
+  // cannot draw a ring past full or a negative arc.
+  const ratio = Math.min(Math.max(used / limit, 0), 1);
+  const pruning = ratio >= PRUNE_RATIO;
+  const compacting = ratio >= COMPACTION_RATIO;
+
+  const ringColor = pruning ? 'text-red-500' : compacting ? 'text-amber-500' : 'text-[var(--chat-accent)]';
+  const textColor = pruning
+    ? 'text-red-500 dark:text-red-400'
+    : compacting
+      ? 'text-amber-600 dark:text-amber-400'
+      : 'text-gray-400 dark:text-white/30';
+
+  const percent = Math.round(ratio * 100);
+  const counts = `${compactCount(used)}/${compactCount(limit)}`;
+  // Naming the consequence beats naming the state: "80 % full" leaves the user
+  // to guess what happens next, which is the whole reason the gauge exists.
+  const headline = pruning
+    ? t('Context full — older turns are being dropped')
+    : compacting
+      ? t('Context nearly full — older turns are being summarized')
+      : t('Context used');
+  const summary = `${headline} · ${counts} ${t('tokens')}`;
+
+  const rows = breakdown ? ROWS.filter((r) => (breakdown[r.field] ?? 0) > 0) : [];
+  // Without a breakdown there is nothing to open, so the readout stays inert
+  // rather than offering a click that does nothing.
+  const expandable = rows.length > 0;
+
+  const gauge = (
+    <span className="flex items-center gap-1.5">
+      <svg width={SIZE} height={SIZE} viewBox={`0 0 ${SIZE} ${SIZE}`} className={ringColor} aria-hidden="true">
+        <circle
+          cx={SIZE / 2}
+          cy={SIZE / 2}
+          r={RADIUS}
+          fill="none"
+          strokeWidth={STROKE}
+          className="stroke-gray-200 dark:stroke-white/15"
+        />
+        <circle
+          cx={SIZE / 2}
+          cy={SIZE / 2}
+          r={RADIUS}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={STROKE}
+          strokeLinecap="round"
+          strokeDasharray={CIRCUMFERENCE}
+          strokeDashoffset={CIRCUMFERENCE * (1 - ratio)}
+          /* Start at twelve o'clock: a gauge that fills from the side reads
+             as a spinner. */
+          transform={`rotate(-90 ${SIZE / 2} ${SIZE / 2})`}
+          className="transition-[stroke-dashoffset] duration-500"
+        />
+      </svg>
+      <span className={`text-[0.68rem] tabular-nums ${textColor}`}>{percent}%</span>
+    </span>
+  );
+
+  if (!expandable) {
+    return (
+      <Tooltip title={summary}>
+        <span className="flex items-center" role="img" aria-label={`${summary} (${percent}%)`}>
+          {gauge}
+        </span>
+      </Tooltip>
+    );
+  }
+
+  return (
+    <>
+      <Tooltip title={open ? '' : `${summary} — ${t('click for details')}`}>
+        <button
+          ref={anchorRef}
+          type="button"
+          onClick={() => setOpen((prev) => !prev)}
+          aria-label={`${summary} (${percent}%)`}
+          aria-haspopup="dialog"
+          aria-expanded={open}
+          className="flex items-center rounded-md px-1 -mx-1 py-0.5 transition-colors hover:bg-gray-100 dark:hover:bg-white/10"
+        >
+          {gauge}
+        </button>
+      </Tooltip>
+
+      <Dropdown open={open} onClose={() => setOpen(false)} anchorRef={anchorRef} placement="bottom-end" width={296}>
+        <div className="px-3.5 pt-3 pb-1 flex items-baseline justify-between gap-3">
+          <span className={`text-[0.8125rem] tabular-nums ${textColor}`}>{t('{percent}% full').replace('{percent}', String(percent))}</span>
+          {/* The tilde is load-bearing: these are char-derived estimates, and a
+              bare "168k/200k" would read as a measured count. */}
+          <span className="text-[0.7rem] tabular-nums text-gray-400 dark:text-white/40 shrink-0">
+            ~{counts} {t('tokens')}
+          </span>
+        </div>
+
+        {/* One stacked bar over the whole window: the segments are the legend's
+            own colours, so proportions are readable without matching numbers to
+            rows. The trailing gap is the headroom left. */}
+        <div className="px-3.5 pb-2.5 pt-1.5">
+          <span className="flex h-1.5 w-full gap-px rounded-full bg-gray-200 dark:bg-white/10 overflow-hidden">
+            {rows.map((row) => (
+              <span
+                key={row.field}
+                className="h-full first:rounded-l-full"
+                style={{ width: `${((breakdown?.[row.field] ?? 0) / limit) * 100}%`, backgroundColor: row.color }}
+              />
+            ))}
+          </span>
+        </div>
+
+        <div className="px-3.5 pb-1">
+          {rows.map((row) => (
+            <div key={row.field} className="flex items-center gap-2 py-[3px]">
+              {/* Radius set inline: the panel's reset rounds small spans to a
+                  pill, which turns the swatches into dots that read as bullets
+                  rather than as keys to the bar's segments. */}
+              <span className="h-2 w-2 shrink-0" style={{ backgroundColor: row.color, borderRadius: 2 }} aria-hidden="true" />
+              <span className="text-[0.75rem] text-gray-700 dark:text-white/70 truncate">{t(row.label)}</span>
+              <span className="ml-auto text-[0.7rem] tabular-nums text-gray-500 dark:text-white/40 shrink-0">{compactCount(breakdown?.[row.field] ?? 0)}</span>
+            </div>
+          ))}
+        </div>
+
+        {compacting && (
+          // The one line that turns a readout into something actionable: at this
+          // point the backend is already dropping detail from older turns.
+          <p className={`px-3.5 pt-1 pb-3 text-[0.68rem] leading-snug ${textColor}`}>{headline}</p>
+        )}
+      </Dropdown>
+    </>
+  );
+};

--- a/packages/filigran-chatbot/src/components/ContextUsageIndicator.tsx
+++ b/packages/filigran-chatbot/src/components/ContextUsageIndicator.tsx
@@ -159,12 +159,14 @@ export const ContextUsageIndicator = ({ usage, t }: ContextUsageIndicatorProps) 
             own colours, so proportions are readable without matching numbers to
             rows. The trailing gap is the headroom left. */}
         <div className="px-3.5 pb-2.5 pt-1.5">
-          <span className="flex h-1.5 w-full gap-px rounded-full bg-gray-200 dark:bg-white/10 overflow-hidden">
             {rows.map((row) => (
               <span
                 key={row.field}
                 className="h-full first:rounded-l-full"
-                style={{ width: `${((breakdown?.[row.field] ?? 0) / limit) * 100}%`, backgroundColor: row.color }}
+                style={{
+                  width: `${((breakdown?.[row.field] ?? 0) / Math.max(used, 1)) * Math.min(used / limit, 1) * 100}%`,
+                  backgroundColor: row.color,
+                }}
               />
             ))}
           </span>

--- a/packages/filigran-chatbot/src/components/QuotaIndicator.tsx
+++ b/packages/filigran-chatbot/src/components/QuotaIndicator.tsx
@@ -1,16 +1,10 @@
 import type { ChatQuotaStatus } from '../types';
+import { compactCount as compact } from '../utils';
 import { Tooltip } from './Tooltip';
 
 interface QuotaIndicatorProps {
   quota: ChatQuotaStatus;
   t: (key: string) => string;
-}
-
-/** Compact count: 1200 → 1.2k, so the indicator never widens the toolbar. */
-function compact(n: number): string {
-  if (n < 1000) return `${n}`;
-  if (n < 1_000_000) return `${(n / 1000).toFixed(n < 10_000 ? 1 : 0).replace(/\.0$/, '')}k`;
-  return `${(n / 1_000_000).toFixed(1).replace(/\.0$/, '')}M`;
 }
 
 /**

--- a/packages/filigran-chatbot/src/hooks/protocols/parseRestEvent.ts
+++ b/packages/filigran-chatbot/src/hooks/protocols/parseRestEvent.ts
@@ -1,5 +1,55 @@
-import type { ChatAttachment, ToolCallTraceEntry, TransferChainEntry } from '../../types';
+import type { ChatAttachment, ChatContextBreakdown, ChatContextUsage, ToolCallTraceEntry, TransferChainEntry } from '../../types';
 import type { ParsedAction, ProtocolContext } from './types';
+
+/** Wire key → the breakdown field it populates. */
+const BREAKDOWN_KEYS: ReadonlyArray<[string, keyof ChatContextBreakdown]> = [
+  ['system', 'system'],
+  ['tools', 'tools'],
+  ['dynamic_tools', 'dynamicTools'],
+  ['summary', 'summary'],
+  ['conversation', 'conversation'],
+  ['tool_results', 'toolResults'],
+];
+
+/**
+ * Normalize the optional `context_breakdown` object.
+ *
+ * Only positive numbers for keys we know how to label survive: an unlabelled
+ * bucket cannot be rendered, and a zero one is noise in a list meant to show
+ * where the context actually went. Returns `undefined` when nothing usable is
+ * left, so the gauge keeps its number and simply has no detail to open.
+ */
+function parseBreakdown(raw: unknown): ChatContextBreakdown | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const src = raw as Record<string, unknown>;
+  const out: ChatContextBreakdown = {};
+  let any = false;
+  for (const [wireKey, field] of BREAKDOWN_KEYS) {
+    const value = src[wireKey];
+    if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+      out[field] = value;
+      any = true;
+    }
+  }
+  return any ? out : undefined;
+}
+
+/**
+ * Read the context-window occupancy carried by a progress or `done` frame.
+ *
+ * Both halves are required and the window must be positive: a token count with
+ * no window to measure it against is not a ratio, and a zero window would make
+ * one out of a division by zero. Returns `undefined` for anything else, so a
+ * backend that reports nothing simply leaves the gauge as it was.
+ */
+export function parseContextUsage(evt: Record<string, unknown>): ChatContextUsage | undefined {
+  const used = evt.context_tokens;
+  const limit = evt.context_window;
+  if (typeof used !== 'number' || typeof limit !== 'number') return undefined;
+  if (!Number.isFinite(used) || !Number.isFinite(limit) || limit <= 0 || used < 0) return undefined;
+  const breakdown = parseBreakdown(evt.context_breakdown);
+  return breakdown ? { used, limit, breakdown } : { used, limit };
+}
 
 /**
  * Normalize the raw `attachments` array from a backend `done` event into
@@ -107,10 +157,14 @@ export function parseRestEvent(evt: Record<string, unknown>, ctx: ProtocolContex
         elapsedS: typeof evt.elapsed_s === 'number' ? evt.elapsed_s : undefined,
       };
     }
+    // Context occupancy rides on the per-iteration `thinking` frame, so the
+    // gauge climbs during a long turn. Read before the `analyzing` relabel
+    // below, which rewrites the status but not what the frame carries.
+    const contextUsage = parseContextUsage(evt);
     if (st === 'thinking' && ctx.hasUsedTools) {
-      return { action: 'status', status: 'analyzing' };
+      return { action: 'status', status: 'analyzing', contextUsage };
     }
-    return { action: 'status', status: st, tools: evt.tools as string[] | undefined };
+    return { action: 'status', status: st, tools: evt.tools as string[] | undefined, contextUsage };
   }
 
   if (type === 'stream') {
@@ -132,6 +186,7 @@ export function parseRestEvent(evt: Record<string, unknown>, ctx: ProtocolContex
       toolCallTrace: parseToolCallTrace(evt.tool_call_trace),
       transferChain: parseTransferChain(evt.transfer_chain),
       isTruncated: evt.is_truncated === true || undefined,
+      contextUsage: parseContextUsage(evt),
     };
   }
 

--- a/packages/filigran-chatbot/src/hooks/protocols/types.ts
+++ b/packages/filigran-chatbot/src/hooks/protocols/types.ts
@@ -1,11 +1,24 @@
-import type { ChatAttachment, ToolCallTraceEntry, TransferChainEntry } from '../../types';
+import type { ChatAttachment, ChatContextUsage, ToolCallTraceEntry, TransferChainEntry } from '../../types';
 
 /**
  * Normalized action produced by all protocol parsers.
  * The SSE read loop is protocol-agnostic — only the JSON-to-action mapping differs.
  */
 export type ParsedAction =
-  | { action: 'status'; status: string; tools?: string[]; thinkingContent?: string; elapsedS?: number }
+  | {
+      action: 'status';
+      status: string;
+      tools?: string[];
+      thinkingContent?: string;
+      elapsedS?: number;
+      /**
+       * Context-window occupancy reported alongside a progress event, so the
+       * composer gauge climbs during a long turn instead of only at the end.
+       * Orthogonal to `status` — the consumer updates the gauge and applies the
+       * status label independently.
+       */
+      contextUsage?: ChatContextUsage;
+    }
   | { action: 'stream'; content: string }
   | {
       action: 'done';
@@ -25,6 +38,8 @@ export type ParsedAction =
       transferChain?: TransferChainEntry[];
       /** True when the agent's iteration budget was exhausted. */
       isTruncated?: boolean;
+      /** Closing context-window occupancy for the turn. */
+      contextUsage?: ChatContextUsage;
     }
   | { action: 'error'; content: string }
   | { action: 'set_chat_id'; chatId: string }

--- a/packages/filigran-chatbot/src/hooks/useChat.ts
+++ b/packages/filigran-chatbot/src/hooks/useChat.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import type { AgentStatusState, ApiEndpoints, BackendType, ChatFile, ChatMessage } from '../types';
+import type { AgentStatusState, ApiEndpoints, BackendType, ChatContextUsage, ChatFile, ChatMessage } from '../types';
 import type { ParsedAction, ProtocolContext } from './protocols';
 import { parseAgUiEvent, parseLegacyEvent, parseRestEvent } from './protocols';
 
@@ -70,6 +70,13 @@ interface UseChatReturn {
   agentStatus: AgentStatusState | null;
   attachedFiles: ChatFile[];
   conversationId: string | null;
+  /**
+   * Context-window occupancy for the active conversation, or `null` while the
+   * backend has reported none (a fresh chat, or a backend that does not carry
+   * the figures at all). Tracked live off the per-iteration progress frames and
+   * finalised on `done`.
+   */
+  contextUsage: ChatContextUsage | null;
   transferredAgent: TransferredAgent | null;
   /**
    * True while a response is streaming AND the typed text can be dispatched
@@ -95,6 +102,11 @@ interface UseChatReturn {
   handleStopGenerating: () => void;
   setAttachedFiles: React.Dispatch<React.SetStateAction<ChatFile[]>>;
   setMessages: React.Dispatch<React.SetStateAction<ChatMessage[]>>;
+  /**
+   * Seed the context gauge from outside a live turn — the history-restore path,
+   * which reads the newest restored assistant message's figures.
+   */
+  setContextUsage: React.Dispatch<React.SetStateAction<ChatContextUsage | null>>;
   /**
    * Set (or clear) the active conversation id, keeping React state, the
    * cross-async-boundary ref mirror, and localStorage all in sync. Pass
@@ -195,6 +207,10 @@ export function useChat({
   const [inputValue, setInputValue] = useState(() => loadDraft(typeof window === 'undefined' ? null : localStorage.getItem(STORAGE_KEY)));
   const [attachedFiles, setAttachedFiles] = useState<ChatFile[]>([]);
   const [transferredAgent, setTransferredAgent] = useState<TransferredAgent | null>(null);
+  // How full the model's context window is for this conversation. Conversation
+  // state rather than per-message: it describes what the NEXT turn will carry,
+  // which is the only thing the user can still act on.
+  const [contextUsage, setContextUsage] = useState<ChatContextUsage | null>(null);
   const [legacyChatId, setLegacyChatId] = useState<string | null>(() => {
     if (typeof window === 'undefined') return null;
     return localStorage.getItem(LEGACY_CHAT_ID_KEY);
@@ -581,6 +597,9 @@ export function useChat({
               case 'status': {
                 ensureSegment();
                 const segId = currentAssistantId;
+                // Orthogonal to the status label below: a progress frame can
+                // carry a fresh context reading whatever phase it announces.
+                if (parsed.contextUsage) setContextUsage(parsed.contextUsage);
                 if (parsed.status === 'tool_start') hasUsedToolsRef.current = true;
                 if (parsed.status === 'stream_retract') {
                   // Rare: text that streamed as a provisional answer turned
@@ -640,6 +659,9 @@ export function useChat({
                 if (parsed.conversationId) {
                   updateConversationId(parsed.conversationId);
                 }
+                // Closing reading wins: a turn whose last iteration compacted
+                // ends lower than it peaked mid-run.
+                if (parsed.contextUsage) setContextUsage(parsed.contextUsage);
                 if (parsed.transferAgentId && parsed.transferAgentName) {
                   setTransferredAgent({ id: parsed.transferAgentId, name: parsed.transferAgentName });
                 }
@@ -723,6 +745,10 @@ export function useChat({
     setIsLoading(false);
     setAgentStatus(null);
     setTransferredAgent(null);
+    // A fresh (or newly selected) conversation starts with no known occupancy;
+    // the restore or the first turn fills it back in. Carrying the previous
+    // conversation's reading over would be a plain lie.
+    setContextUsage(null);
     hasUsedToolsRef.current = false;
     historyLoadedRef.current = false;
     if (isLegacy) {
@@ -792,6 +818,7 @@ export function useChat({
     agentStatus,
     attachedFiles,
     conversationId,
+    contextUsage,
     transferredAgent,
     canSteer,
     historyLoadedRef,
@@ -803,6 +830,7 @@ export function useChat({
     handleStopGenerating,
     setAttachedFiles,
     setMessages,
+    setContextUsage,
     updateConversationId,
     handleSwitchConversation,
   };

--- a/packages/filigran-chatbot/src/index.ts
+++ b/packages/filigran-chatbot/src/index.ts
@@ -8,6 +8,8 @@ export type {
   ChatToggleButtonProps,
   ChatMessage,
   ChatAttachment,
+  ChatContextBreakdown,
+  ChatContextUsage,
   ChatConversationSummary,
   ChatFile,
   ChatPromptTemplate,

--- a/packages/filigran-chatbot/src/types.ts
+++ b/packages/filigran-chatbot/src/types.ts
@@ -101,6 +101,52 @@ export interface ChatQuotaStatus {
   period: string;
 }
 
+/**
+ * How full the model's context window is for the current conversation, as the
+ * composer gauge needs it — a ratio, so both halves are required.
+ *
+ * `used` is the backend's own estimate of what the next turn will carry, not a
+ * billed token count: it is the figure the agent loop budgets its compaction
+ * against, which is what makes the gauge predictive of the summarising the user
+ * is about to see rather than a receipt for the turn that just ended.
+ */
+export interface ChatContextUsage {
+  /** Estimated tokens currently occupying the window. */
+  used: number;
+  /** The model's context window, in tokens. Always > 0. */
+  limit: number;
+  /** Where those tokens went, when the backend reports it. */
+  breakdown?: ChatContextBreakdown;
+}
+
+/**
+ * What the context is being spent on, in tokens.
+ *
+ * Buckets are grouped by what the user can *do* about each: they can start a new
+ * chat (`conversation`), they cannot shrink the agent's persona (`system`), and
+ * the two the backend manages on their behalf (`summary`, `toolResults`) are
+ * what explain a long chat that seems to have forgotten things.
+ *
+ * Every key is optional and only non-zero ones are reported, so a backend that
+ * measures a different set — or none — still renders. Tool *definitions* are
+ * absent on purpose: XTM One's loop does not count them against the window it
+ * budgets, so a line for them would not add up to the total.
+ */
+export interface ChatContextBreakdown {
+  /** The agent's system prompt and any in-run instructions. */
+  system?: number;
+  /** Schemas of the platform's built-in tools. */
+  tools?: number;
+  /** Schemas of the agent's own integrations, MCP servers and custom tools. */
+  dynamicTools?: number;
+  /** Digests of earlier turns produced by the backend's compaction. */
+  summary?: number;
+  /** The user's and assistant's own messages. */
+  conversation?: number;
+  /** Output of tool calls still held verbatim in the context. */
+  toolResults?: number;
+}
+
 export interface ChatPanelProps {
   mode: ChatMode;
   onClose: () => void;
@@ -210,6 +256,18 @@ export interface ChatPanelProps {
    * Default: false.
    */
   disableImagePreviews?: boolean;
+  /**
+   * Show how full the model's context window is for the current conversation
+   * — a small ring plus percentage in the composer toolbar, so the user can
+   * see a long chat approaching the point where the agent starts summarising
+   * older turns and decide to split the work instead. Default: true.
+   *
+   * A host-level master switch, not a mode flag: the gauge is data-driven and
+   * simply absent until the backend reports occupancy (only the XTM One REST
+   * backend does today), so leaving this on costs nothing on a backend that
+   * says nothing.
+   */
+  contextUsageEnabled?: boolean;
   /**
    * Rendered into the composer toolbar, after the built-in controls.
    *

--- a/packages/filigran-chatbot/src/types.ts
+++ b/packages/filigran-chatbot/src/types.ts
@@ -128,9 +128,9 @@ export interface ChatContextUsage {
  * what explain a long chat that seems to have forgotten things.
  *
  * Every key is optional and only non-zero ones are reported, so a backend that
- * measures a different set — or none — still renders. Tool *definitions* are
- * absent on purpose: XTM One's loop does not count them against the window it
- * budgets, so a line for them would not add up to the total.
+ * measures a different set — or none — still renders. Tool definitions are
+ * included even though some backends may not count them in their compaction
+ * gate; the gauge is meant to reflect what the prompt actually carries.
  */
 export interface ChatContextBreakdown {
   /** The agent's system prompt and any in-run instructions. */

--- a/packages/filigran-chatbot/src/utils/index.ts
+++ b/packages/filigran-chatbot/src/utils/index.ts
@@ -261,6 +261,16 @@ export function findChatbotRoot(el: HTMLElement | null): HTMLElement {
 }
 
 /**
+ * Compact count for the composer's status readouts: 1200 → "1.2k", so neither
+ * the quota nor the context gauge can widen the toolbar as the numbers grow.
+ */
+export function compactCount(n: number): string {
+  if (n < 1000) return `${n}`;
+  if (n < 1_000_000) return `${(n / 1000).toFixed(n < 10_000 ? 1 : 0).replace(/\.0$/, '')}k`;
+  return `${(n / 1_000_000).toFixed(1).replace(/\.0$/, '')}M`;
+}
+
+/**
  * Compact relative-time label for the conversation history menu
  * ("just now", "5m ago", "3h ago", "2d ago", then a short date).
  * Returns an empty string for missing/unparseable timestamps so the row

--- a/projects/filigran-chat-playground/README.md
+++ b/projects/filigran-chat-playground/README.md
@@ -13,8 +13,9 @@ yarn workspace @filigran/chat-playground dev
 
 Open <http://localhost:3020> and **sign in with an XTM One account**. From then
 on the agents, conversations and answers are real — see
-[Connected to XTM One](#connected-to-xtm-one). No backend to hand? Use the
-[mock](#mock-backend).
+[Connected to XTM One](#connected-to-xtm-one). No backend to hand? **Skip** on
+that screen and the [mock](#mock-backend) answers instead; nothing is required
+to start.
 
 The package is aliased to its **source**, so edits under
 `packages/filigran-chatbot/src` hot-reload straight into the panel.
@@ -45,6 +46,7 @@ exercised outside a full product deployment.
 | `PLATFORM_REGISTRATION_TOKEN` | `xtm-default-registration-token` | Must match XTM One's own |
 | `CHAT_API_PREFIX` | `/api/v1/platform` | `/api/v1/chat` for the native router |
 | `CHAT_PLAYGROUND_ISSUER` | auto | Only if XTM One cannot reach the playground at the URL it picks |
+| `CHAT_API_MOCK=1` | off | Skip the real backend entirely — mock only, no sign-in |
 | `CHAT_PLAYGROUND_AUDIENCE` | discovered | Overrides XTM One's `base_url`, read from its OAuth discovery document |
 
 Three things the dev server handles for you (see [`real-api.ts`](./real-api.ts)):
@@ -70,9 +72,12 @@ the playground spends the credentials once against XTM One's ordinary
 away, along with the local JWT that login returns. Everything afterwards is
 signed with the playground's own platform key.
 
-Sign-in is a hard gate: with no identity there is nothing to make requests as,
-and an unauthenticated panel would render an empty agent list indistinguishable
-from a real one.
+Sign-in is the default path but not a wall: **Skip — explore with mock data**
+hands the chat API back to the built-in mock, so the panel still works with no
+XTM One in sight. The page then says so in as many words, because mock agents
+that look real are worse than none. What the panel never does is mount with
+neither identity nor mock and render an empty agent list as if that were the
+answer.
 
 Being signed in survives a dev-server restart. That is not a nicety: this file,
 `real-api.ts` and `xtm-auth.ts` are all imported by `vite.config.ts`, which
@@ -85,19 +90,23 @@ Anything you are tempted to cache in that closure has the same problem.
 
 #### A real agent that stresses the renderer
 
-Add `CHAT_PLAYGROUND_AGENT=1` and the dev server creates (or refreshes) a
-**Rendering Playground** agent on the instance you are pointed at, whose persona
-tells it to weave the renderer-breaking shapes into every reply: a mis-delimited
-table, a fence with no language, nested fences, an inert `javascript:` link,
-soft breaks. Pick it from the agent menu.
+Signed in, the page offers **Install on this instance**: a **Rendering
+Playground** agent whose persona tells it to weave the renderer-breaking shapes
+into every reply — a mis-delimited table, a fence with no language, nested
+fences, an inert `javascript:` link, soft breaks. Pick it from the agent menu.
+
+A button rather than the old `CHAT_PLAYGROUND_AGENT=1` bootstrap, which in
+practice never ran — nobody sets an env var they have not read about — and
+reported its failures to a terminal instead of to the person waiting for an
+agent to appear.
 
 Being a real agent, it exercises the real path — token pacing, tool statuses,
 transfers — which the mock can only imitate.
 
 It is created through the ordinary API rather than added to XTM One's seeded
 built-ins on purpose: agents have no per-agent platform gating, so a seeded
-entry would ship to every deployment. Opt-in, because it writes to whichever
-instance you chose.
+entry would ship to every deployment. Behind a button, because it writes to
+whichever instance you chose.
 
 ## Mock backend
 

--- a/projects/filigran-chat-playground/mock-api.ts
+++ b/projects/filigran-chat-playground/mock-api.ts
@@ -112,7 +112,12 @@ interface Conversation {
   id: string;
   title: string;
   updatedAt: string;
-  messages: { role: 'user' | 'assistant'; content: string }[];
+  /**
+   * `meta` is whatever the turn's `done` frame carried (tool names, reasoning,
+   * trace, attachments, context figures). Stored so a restore can re-surface
+   * it exactly as the real backend does — see the note at the `done` frame.
+   */
+  messages: { role: 'user' | 'assistant'; content: string; meta?: Record<string, unknown> }[];
   /** Context tokens the next turn would carry — drives the composer gauge. */
   contextTokens: number;
 }
@@ -266,15 +271,15 @@ export function mockChatApi(): Plugin {
           if (existing) {
             return json(res, {
               conversation_id: existing.id,
-              // The real backend persists the occupancy on each assistant
-              // message; the panel reads the newest one that carries it, so
-              // the gauge survives a reload. Only the last one needs it here.
-              messages: existing.messages.map((m, i) => ({
+              // Each assistant message comes back with the metadata its turn
+              // produced, exactly as the real backend re-surfaces it — so a
+              // restored turn keeps its reasoning-details button, download
+              // cards, tool trace and context reading instead of degrading to
+              // bare prose.
+              messages: existing.messages.map((m) => ({
                 role: m.role,
                 content: m.content,
-                ...(m.role === 'assistant' && i === existing.messages.length - 1 && existing.contextTokens > 0
-                  ? { context_tokens: existing.contextTokens, context_window: CONTEXT_WINDOW, context_breakdown: mockContextBreakdown(existing.contextTokens) }
-                  : {}),
+                ...(m.meta ?? {}),
               })),
             });
           }
@@ -348,13 +353,19 @@ export function mockChatApi(): Plugin {
 
           quotaUsed += 17;
           const answer = `${text}\n\n[[FILE:file-${seq}]]`;
-          conv.messages.push({ role: 'assistant', content: answer });
-          conv.updatedAt = new Date().toISOString();
 
-          send({
-            type: 'done',
-            content: answer,
-            conversation_id: convId,
+          // The turn's metadata, built ONCE and both streamed and stored.
+          //
+          // Storing it is not optional detail: the panel re-fetches the session
+          // the moment the first turn hands it a conversation id, and replaces
+          // the live transcript with what comes back. A restore that returns
+          // only role+content therefore ERASES the reasoning-details button, the
+          // download cards and the tool trace seconds after they appear — which
+          // is a mock artefact, since the real backend re-surfaces these keys
+          // (``_restored_assistant_meta_keys`` in XTM One's platform.py). Kept
+          // as one object so the two paths cannot drift apart and re-introduce
+          // that phantom regression.
+          const turnMeta: Record<string, unknown> = {
             tool_names: ['search_entities'],
             tool_call_count: 1,
             iterations: 2,
@@ -367,7 +378,12 @@ export function mockChatApi(): Plugin {
               { file_id: `file-${seq}`, filename: 'coverage.png', type: 'png', size: 4096, content_type: 'image/png', file_tag: 'download_file' },
               { file_id: `scratch-${seq}`, filename: 'notes.txt', type: 'txt', size: 512, content_type: 'text/plain', file_tag: 'working_file' },
             ],
-          });
+          };
+
+          conv.messages.push({ role: 'assistant', content: answer, meta: turnMeta });
+          conv.updatedAt = new Date().toISOString();
+
+          send({ type: 'done', content: answer, conversation_id: convId, ...turnMeta });
           return res.end();
         }
 

--- a/projects/filigran-chat-playground/mock-api.ts
+++ b/projects/filigran-chat-playground/mock-api.ts
@@ -113,6 +113,34 @@ interface Conversation {
   title: string;
   updatedAt: string;
   messages: { role: 'user' | 'assistant'; content: string }[];
+  /** Context tokens the next turn would carry — drives the composer gauge. */
+  contextTokens: number;
+}
+
+/**
+ * Plausible composition of a context of *total* tokens, for the gauge's detail
+ * popover. Buckets sum to `total` exactly — the popover shows both the lines and
+ * the headline, so a breakdown that does not add up reads as a bug in the
+ * numbers. The `summary` line only appears past the compaction gate, which is
+ * where a real backend would first have a digest to show.
+ */
+function mockContextBreakdown(total: number): Record<string, number> {
+  // Fixed overheads first: the persona and the tool schemas do not grow with
+  // the thread, which is exactly what makes them worth showing separately.
+  const system = Math.min(6_000, total);
+  const tools = Math.min(14_000, total - system);
+  const dynamicTools = Math.min(9_000, total - system - tools);
+  const rest = total - system - tools - dynamicTools;
+  const toolResults = Math.round(rest * 0.45);
+  const summary = total >= CONTEXT_WINDOW * 0.8 ? Math.round(rest * 0.18) : 0;
+  return {
+    system,
+    tools,
+    dynamic_tools: dynamicTools,
+    conversation: rest - toolResults - summary,
+    tool_results: toolResults,
+    ...(summary ? { summary } : {}),
+  };
 }
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
@@ -170,6 +198,14 @@ const SUGGESTIONS: Record<string, string[]> = {
 };
 
 const QUOTA_LIMIT = 500;
+
+// Context gauge: a 200k window filled 21 % per turn, so five turns land on
+// 21 / 42 / 63 / 84 / 100 % — deliberately stepped to hit every band the
+// indicator has, including the amber one between 80 % and 95 % (where the real
+// backend starts summarising older turns) that a coarser step jumps straight
+// over.
+const CONTEXT_WINDOW = 200_000;
+const CONTEXT_PER_TURN = 42_000;
 
 export function mockChatApi(): Plugin {
   const conversations = new Map<string, Conversation>();
@@ -230,12 +266,21 @@ export function mockChatApi(): Plugin {
           if (existing) {
             return json(res, {
               conversation_id: existing.id,
-              messages: existing.messages.map((m) => ({ role: m.role, content: m.content })),
+              // The real backend persists the occupancy on each assistant
+              // message; the panel reads the newest one that carries it, so
+              // the gauge survives a reload. Only the last one needs it here.
+              messages: existing.messages.map((m, i) => ({
+                role: m.role,
+                content: m.content,
+                ...(m.role === 'assistant' && i === existing.messages.length - 1 && existing.contextTokens > 0
+                  ? { context_tokens: existing.contextTokens, context_window: CONTEXT_WINDOW, context_breakdown: mockContextBreakdown(existing.contextTokens) }
+                  : {}),
+              })),
             });
           }
           // Mirror the real backend: a stale id transparently becomes a new one.
           const id = `conv-${++seq}`;
-          conversations.set(id, { id, title: 'New conversation', updatedAt: new Date().toISOString(), messages: [] });
+          conversations.set(id, { id, title: 'New conversation', updatedAt: new Date().toISOString(), messages: [], contextTokens: 0 });
           return json(res, { conversation_id: id, messages: [] });
         }
 
@@ -262,7 +307,7 @@ export function mockChatApi(): Plugin {
           let convId = typeof body.conversation_id === 'string' ? body.conversation_id : '';
           if (!convId || !conversations.has(convId)) {
             convId = `conv-${++seq}`;
-            conversations.set(convId, { id: convId, title: 'New conversation', updatedAt: new Date().toISOString(), messages: [] });
+            conversations.set(convId, { id: convId, title: 'New conversation', updatedAt: new Date().toISOString(), messages: [], contextTokens: 0 });
           }
           const conv = conversations.get(convId)!;
           // Backends rewrite the title from the first message.
@@ -281,7 +326,11 @@ export function mockChatApi(): Plugin {
           res.setHeader('Connection', 'keep-alive');
           const send = (obj: unknown) => res.write(`data: ${JSON.stringify(obj)}\n\n`);
 
-          send({ type: 'status', status: 'thinking' });
+          // The window fills as the thread grows. The real backend hangs these
+          // on the per-iteration `thinking` frame, so the gauge climbs during
+          // the turn rather than jumping at the end.
+          conv.contextTokens = Math.min(conv.contextTokens + CONTEXT_PER_TURN, CONTEXT_WINDOW);
+          send({ type: 'status', status: 'thinking', iteration: 1, context_tokens: conv.contextTokens, context_window: CONTEXT_WINDOW, context_breakdown: mockContextBreakdown(conv.contextTokens) });
           await sleep(300);
           send({ type: 'status', status: 'thinking_text', content: 'Working out what the user wants, then checking how the answer will render.' });
           await sleep(400);
@@ -309,6 +358,9 @@ export function mockChatApi(): Plugin {
             tool_names: ['search_entities'],
             tool_call_count: 1,
             iterations: 2,
+            context_tokens: conv.contextTokens,
+            context_window: CONTEXT_WINDOW,
+            context_breakdown: mockContextBreakdown(conv.contextTokens),
             reasoning: 'Checked the rendering pipeline end to end, then wrote the answer.',
             tool_call_trace: [{ name: 'search_entities', input: '{"q":"apt"}', output: '{"hits":3}', success: true }],
             attachments: [

--- a/projects/filigran-chat-playground/playground-agent.ts
+++ b/projects/filigran-chat-playground/playground-agent.ts
@@ -9,10 +9,12 @@
  * This gets both: a genuine agent, created through the normal API, told by its
  * persona to emit the shapes that have broken the renderer before.
  *
- * Opt-in, because it writes to whichever instance you are pointed at:
- *
- *   CHAT_API_PROXY=… CHAT_API_EMAIL=… CHAT_API_PASSWORD=… \
- *   CHAT_PLAYGROUND_AGENT=1 yarn dev
+ * Installed on demand, from a button on the page. It used to run itself at
+ * start-up behind `CHAT_PLAYGROUND_AGENT=1`, which meant it effectively never
+ * ran — nobody sets an env var they have not read about, and when it did fail
+ * the reason went to the terminal rather than to the person looking at the
+ * screen. Writing to whichever instance you are pointed at should be a
+ * deliberate click anyway.
  *
  * Deliberately created through `POST /agents` rather than added to XTM One's
  * seeded built-ins: agents have no per-agent platform gating, so a seeded entry
@@ -82,58 +84,76 @@ const PAYLOAD: AgentPayload = {
   tags: ['playground', 'development'],
 };
 
+export type AgentState = 'installed' | 'absent' | 'unknown';
+
+export interface AgentOutcome {
+  /** What the page should show once the dust settles. */
+  state: AgentState;
+  /** Plain sentence for the person looking at the screen, not a log line. */
+  message: string;
+}
+
+/** Is the agent already on the instance? Drives the button's label. */
+export async function playgroundAgentState(config: AgentBootstrapConfig): Promise<AgentOutcome> {
+  const found = await findAgent(config);
+  if (typeof found === 'string') return { state: 'unknown', message: found };
+  return found
+    ? { state: 'installed', message: `"${PAYLOAD.name}" is on this instance — pick it in the agent menu.` }
+    : { state: 'absent', message: `"${PAYLOAD.name}" is not on this instance yet.` };
+}
+
+/** The existing agent, `null` if absent, or a human-readable reason we cannot tell. */
+async function findAgent(config: AgentBootstrapConfig): Promise<Record<string, unknown> | null | string> {
+  const token = await config.resolveToken();
+  if (!token) return 'Sign in first — the agent is created as you.';
+  try {
+    const res = await fetch(`${config.target}/api/v1/agents`, {
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) return `Could not list agents (HTTP ${res.status}).`;
+    const raw = (await res.json()) as unknown;
+    const list = Array.isArray(raw) ? raw : ((raw as Record<string, unknown>)?.agents as unknown[]) ?? [];
+    return (list.find((a) => (a as Record<string, unknown>)?.slug === AGENT_SLUG) as Record<string, unknown>) ?? null;
+  } catch (err) {
+    return `Could not reach ${config.target} — ${(err as Error).message}`;
+  }
+}
+
 /**
  * Create the agent, or refresh its persona if it is already there.
  *
- * Failure is reported and swallowed: the playground is perfectly usable
- * against the other agents, and an instance where agent creation is gated
- * (no licence, no permission) should not stop the dev server from starting.
+ * Never throws: an instance where agent creation is gated (no licence, no
+ * permission) should get a sentence explaining that, not a broken page.
  */
-export async function ensurePlaygroundAgent(config: AgentBootstrapConfig): Promise<void> {
+export async function ensurePlaygroundAgent(config: AgentBootstrapConfig): Promise<AgentOutcome> {
   const token = await config.resolveToken();
-  if (!token) {
-    console.warn('  [playground-agent] no token — skipping');
-    return;
-  }
+  if (!token) return { state: 'unknown', message: 'Sign in first — the agent is created as you.' };
   const headers = { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` };
 
-  try {
-    const listRes = await fetch(`${config.target}/api/v1/agents`, { headers });
-    if (!listRes.ok) {
-      console.warn(`  [playground-agent] cannot list agents (${listRes.status}) — skipping`);
-      return;
-    }
-    const raw = (await listRes.json()) as unknown;
-    const list = Array.isArray(raw) ? raw : ((raw as Record<string, unknown>)?.agents as unknown[]) ?? [];
-    const existing = list.find((a) => (a as Record<string, unknown>)?.slug === AGENT_SLUG) as Record<string, unknown> | undefined;
+  const existing = await findAgent(config);
+  if (typeof existing === 'string') return { state: 'unknown', message: existing };
 
+  try {
     if (existing?.id) {
       // Refresh rather than skip: the persona is the part being iterated on,
       // so a stale one would quietly defeat the whole exercise.
+      // PUT, not PATCH: XTM One exposes no PATCH on this route and answered
+      // 405. Every field of UpdateAgentRequest is optional, so a PUT carrying
+      // just these two is still a partial update.
       const res = await fetch(`${config.target}/api/v1/agents/${existing.id}`, {
-        method: 'PATCH',
+        method: 'PUT',
         headers,
         body: JSON.stringify({ persona: PERSONA, description: PAYLOAD.description }),
       });
-      console.log(
-        res.ok
-          ? `  [playground-agent] refreshed "${PAYLOAD.name}"`
-          : `  [playground-agent] could not refresh (${res.status})`,
-      );
-      return;
+      return res.ok
+        ? { state: 'installed', message: `Refreshed "${PAYLOAD.name}" with the current persona.` }
+        : { state: 'installed', message: `It is already there, but the persona could not be refreshed (HTTP ${res.status}).` };
     }
 
-    const res = await fetch(`${config.target}/api/v1/agents`, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify(PAYLOAD),
-    });
-    if (res.ok) {
-      console.log(`  [playground-agent] created "${PAYLOAD.name}" — pick it in the agent menu`);
-    } else {
-      console.warn(`  [playground-agent] creation failed (${res.status}): ${(await res.text()).slice(0, 200)}`);
-    }
+    const res = await fetch(`${config.target}/api/v1/agents`, { method: 'POST', headers, body: JSON.stringify(PAYLOAD) });
+    if (res.ok) return { state: 'installed', message: `Created "${PAYLOAD.name}" — pick it in the agent menu.` };
+    return { state: 'absent', message: `Creation failed (HTTP ${res.status}): ${(await res.text()).slice(0, 200)}` };
   } catch (err) {
-    console.warn(`  [playground-agent] ${(err as Error).message}`);
+    return { state: 'unknown', message: `Could not reach ${config.target} — ${(err as Error).message}` };
   }
 }

--- a/projects/filigran-chat-playground/real-api.ts
+++ b/projects/filigran-chat-playground/real-api.ts
@@ -1,6 +1,6 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { Plugin } from 'vite';
-import { ensurePlaygroundAgent } from './playground-agent';
+import { ensurePlaygroundAgent, playgroundAgentState } from './playground-agent';
 import { createIdentity, establishTrust, type TrustSetup } from './xtm-auth';
 import { createSessionStore, readCookie, sendJson, verifyAccountExists, SESSION_COOKIE } from './playground-session';
 
@@ -46,8 +46,6 @@ interface RealApiConfig {
   issuer?: string;
   audience?: string;
   port: number;
-  /** Create/refresh the renderer-stressing agent on the target instance. */
-  bootstrapAgent: boolean;
 }
 
 /** Where XTM One listens under `./dev-podman.sh`. */
@@ -66,8 +64,6 @@ export function readRealApiConfig(env: NodeJS.ProcessEnv, port: number): RealApi
     issuer: env.CHAT_PLAYGROUND_ISSUER,
     audience: env.CHAT_PLAYGROUND_AUDIENCE,
     port,
-    // Opt-in: it writes to whichever instance you are pointed at.
-    bootstrapAgent: env.CHAT_PLAYGROUND_AGENT === '1' || env.CHAT_PLAYGROUND_AGENT === 'true',
   };
 }
 
@@ -124,7 +120,6 @@ export function realChatApi(config: RealApiConfig): Plugin {
   let trust: TrustSetup | null = null;
   let trustError: string | null = null;
   let inFlight: Promise<TrustSetup | null> | null = null;
-  let agentBootstrapped = false;
 
   function ensureTrust(probeEmail: string): Promise<TrustSetup | null> {
     if (trust) return Promise.resolve(trust);
@@ -194,17 +189,20 @@ export function realChatApi(config: RealApiConfig): Plugin {
           if (!established) return sendJson(res, 502, { error: trustError ?? 'Could not establish platform trust.' });
 
           const cookie = sessions.create(email);
-
-          if (config.bootstrapAgent && !agentBootstrapped) {
-            agentBootstrapped = true;
-            void ensurePlaygroundAgent({
-              target: config.target,
-              resolveToken: async () => sessions.tokenFor(cookie, established),
-            });
-          }
-
           console.log(`  [real-api] signed in as ${email}`);
           return sendJson(res, 200, { email, connected: true }, { 'Set-Cookie': `${SESSION_COOKIE}=${cookie}; Path=/; HttpOnly; SameSite=Lax` });
+        }
+
+        // ── The renderer-stressing agent, installed from a button ─────────
+        if (path === `${AUTH_PREFIX}/agent`) {
+          const email = sessions.emailFor(sessionId);
+          const established = email ? await ensureTrust(email) : null;
+          if (!established) {
+            return sendJson(res, 200, { state: 'unknown', message: trustError ?? 'Sign in first — the agent is created as you.' });
+          }
+          const agentConfig = { target: config.target, resolveToken: async () => sessions.tokenFor(sessionId, established) };
+          const outcome = req.method === 'POST' ? await ensurePlaygroundAgent(agentConfig) : await playgroundAgentState(agentConfig);
+          return sendJson(res, 200, outcome);
         }
 
         // ── Everything else the panel calls ────────────────────────────────
@@ -218,10 +216,12 @@ export function realChatApi(config: RealApiConfig): Plugin {
 
         const token = established && sessions.tokenFor(sessionId, established);
         if (!token) {
-          // A real 401 rather than an unauthenticated pass-through: the panel
-          // then reports "could not reach the assistant service" instead of
-          // rendering an empty agent list as if that were the truth.
-          return sendJson(res, 401, { error: 'Not signed in to the playground.' });
+          // Hand the request to the mock rather than refusing it. Requiring a
+          // reachable XTM One just to look at the panel made the playground
+          // unusable exactly when you most want it — no backend, or none of
+          // your business. The page states plainly that the data is mock, and
+          // the panel only mounts here once someone has chosen that.
+          return next();
         }
 
         const upstream = `${config.target}${config.prefix}${rawUrl.slice(PATH_PREFIX.length)}`;

--- a/projects/filigran-chat-playground/src/App.tsx
+++ b/projects/filigran-chat-playground/src/App.tsx
@@ -390,6 +390,7 @@ const App = () => {
                       'File attachment via button click and paste',
                       'New chat clears state; conversation history lists and restores past chats',
                       'Context gauge: absent before the first turn, then 21/42/63/84/100% over five turns (mock) — amber at 84%, red at 100%; reload restores it, "New conversation" clears it',
+                  'Context gauge detail: click it — stacked bar + legend, rows sum to the headline, "Summarized conversation" only appears past 80%',
                       'Dark/light mode toggle works correctly in both themes',
                     ].map((item) => (
                       <li key={item} className="flex items-start gap-2">

--- a/projects/filigran-chat-playground/src/App.tsx
+++ b/projects/filigran-chat-playground/src/App.tsx
@@ -69,7 +69,7 @@ const useSession = () => {
  * that looks like data. The password is spent once against XTM One to prove
  * the account exists — see `playground-session.ts`.
  */
-const SignIn = ({ target, onSignedIn }: { target: string; onSignedIn: () => void }) => {
+const SignIn = ({ target, onSignedIn, onSkip }: { target: string; onSignedIn: () => void; onSkip: () => void }) => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
@@ -120,18 +120,89 @@ const SignIn = ({ target, onSignedIn }: { target: string; onSignedIn: () => void
           {error}
         </p>
       )}
-      <button
-        type="submit"
-        disabled={busy}
-        className="rounded-md bg-[#7b5cff] px-4 py-2 text-sm text-white transition-colors hover:bg-[#6a4de0] disabled:opacity-50"
-      >
-        {busy ? 'Signing in…' : 'Sign in'}
-      </button>
+      <div className="flex flex-wrap items-center gap-3">
+        <button
+          type="submit"
+          disabled={busy}
+          className="rounded-md bg-[#7b5cff] px-4 py-2 text-sm text-white transition-colors hover:bg-[#6a4de0] disabled:opacity-50"
+        >
+          {busy ? 'Signing in…' : 'Sign in'}
+        </button>
+        {/*
+          The way out. Signing in is what the playground is for, but requiring a
+          reachable XTM One before you may even look at the panel makes it
+          useless offline — which is when a component playground earns its keep.
+        */}
+        <button
+          type="button"
+          onClick={onSkip}
+          className="rounded-md border border-gray-300 dark:border-white/20 px-4 py-2 text-sm text-gray-700 dark:text-white/70 transition-colors hover:bg-gray-100 dark:hover:bg-white/10"
+        >
+          Skip — explore with mock data
+        </button>
+      </div>
       <p className="text-xs text-gray-500 dark:text-white/40">
-        Start XTM One with <code className="font-mono">./dev-podman.sh</code>, or run the playground offline with{' '}
-        <code className="font-mono">CHAT_API_MOCK=1 yarn dev</code>.
+        No XTM One running? Start it with <code className="font-mono">./dev-podman.sh</code>, or just skip — the dev server answers the chat
+        API itself.
       </p>
     </form>
+  );
+};
+
+/**
+ * Install the renderer-stressing agent, on demand.
+ *
+ * This used to happen by itself at start-up behind `CHAT_PLAYGROUND_AGENT=1`,
+ * which meant it never happened: nobody sets an env var they have not read
+ * about, and when it failed the reason went to the terminal rather than to the
+ * person waiting for an agent to appear. A button also makes the write
+ * deliberate — it lands on whichever instance you are pointed at.
+ */
+const PlaygroundAgentCard = ({ className }: { className: string }) => {
+  const [state, setState] = useState<'installed' | 'absent' | 'unknown' | 'loading'>('loading');
+  const [message, setMessage] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const load = useCallback(async (method: 'GET' | 'POST') => {
+    setBusy(true);
+    try {
+      const res = await fetch('/api/playground/agent', { method });
+      const body = (await res.json()) as { state?: typeof state; message?: string };
+      setState(body.state ?? 'unknown');
+      setMessage(body.message ?? null);
+    } catch (err) {
+      setState('unknown');
+      setMessage((err as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load('GET');
+  }, [load]);
+
+  return (
+    <div className={className}>
+      <h2 className="text-xl font-semibold mb-1 text-gray-900 dark:text-white">Rendering Playground agent</h2>
+      <p className="text-sm text-gray-600 dark:text-white/50 mb-4">
+        A real agent whose persona tells it to weave the shapes that have broken the renderer before into every reply — a mis-delimited table,
+        a fence with no language, nested fences, an inert <code className="font-mono text-xs">javascript:</code> link, soft breaks. Being real,
+        it exercises token pacing and tool statuses the mock can only imitate.
+      </p>
+      <div className="flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          onClick={() => void load('POST')}
+          disabled={busy || state === 'loading'}
+          className="rounded-md bg-[#7b5cff] px-4 py-2 text-sm text-white transition-colors hover:bg-[#6a4de0] disabled:opacity-50"
+        >
+          {busy ? 'Working…' : state === 'installed' ? 'Refresh persona' : 'Install on this instance'}
+        </button>
+        {state === 'installed' && <span className="text-xs text-emerald-500 dark:text-emerald-400">Installed</span>}
+      </div>
+      {message && <p className="mt-3 text-xs text-gray-500 dark:text-white/40">{message}</p>}
+    </div>
   );
 };
 
@@ -163,11 +234,17 @@ const App = () => {
   const [log, setLog] = useState<LogEntry[]>([]);
   const [hostToolActive, setHostToolActive] = useState(false);
   const { session, refresh } = useSession();
+  // Chose to look around without signing in. The dev server then answers the
+  // chat API itself, so the panel works — against mock data, which the page
+  // says out loud, because mock agents that look real are worse than none.
+  const [skippedSignIn, setSkippedSignIn] = useState(false);
 
-  // The panel may only mount once there is an identity behind it: against a
-  // real backend an unauthenticated panel renders an empty agent list that is
-  // indistinguishable from a real one.
-  const canChat = session.state === 'signed-in' || session.state === 'mock';
+  const usingMock = session.state === 'mock' || (skippedSignIn && session.state !== 'signed-in');
+  // The panel needs *something* behind it: a signed-in identity, or the mock.
+  // What it must never do is mount with neither and render an empty agent list
+  // as though that were the answer.
+  const canChat = session.state === 'signed-in' || usingMock;
+  const showWorkbench = session.state !== 'loading' && (session.state !== 'anonymous' || skippedSignIn);
 
   // Put dark class on <html> so portal-based elements (tooltips, dropdowns) also get dark: styles
   // This one may need adaptation to work with any app
@@ -266,12 +343,28 @@ const App = () => {
               flashing the sign-in card at someone who turns out to be signed in
               already.
             */}
-            {session.state === 'loading' ? null : session.state === 'anonymous' ? (
+            {session.state === 'loading' ? null : !showWorkbench && session.state === 'anonymous' ? (
               <div className={card}>
-                <SignIn target={session.target} onSignedIn={refresh} />
+                <SignIn target={session.target} onSignedIn={refresh} onSkip={() => setSkippedSignIn(true)} />
               </div>
             ) : (
               <>
+                {skippedSignIn && session.state === 'anonymous' && (
+                  <div className={`${card} border-amber-400/40`}>
+                    <h2 className="text-xl font-semibold mb-1 text-gray-900 dark:text-white">Mock data</h2>
+                    <p className="text-sm text-gray-600 dark:text-white/50">
+                      You skipped signing in, so the dev server is answering the chat API itself. The agents and answers below are invented —
+                      good for renderer work, worthless for judging the real contract.
+                    </p>
+                    <button
+                      type="button"
+                      onClick={() => setSkippedSignIn(false)}
+                      className="mt-3 rounded-md border border-gray-300 dark:border-white/20 px-3 py-1.5 text-sm text-gray-700 dark:text-white/70 transition-colors hover:bg-gray-100 dark:hover:bg-white/10"
+                    >
+                      Sign in to XTM One instead
+                    </button>
+                  </div>
+                )}
                 <div className={card}>
                   <h2 className="text-xl font-semibold mb-4 text-gray-900 dark:text-white">Test Controls</h2>
 
@@ -312,7 +405,7 @@ const App = () => {
                 </div>
 
                 {/* Scenarios understood by the built-in mock backend */}
-                {session.state === 'mock' && (
+                {usingMock && (
                   <div className={card}>
                     <h2 className="text-xl font-semibold mb-1 text-gray-900 dark:text-white">Scenarios</h2>
                     <p className="text-sm text-gray-600 dark:text-white/50 mb-4">
@@ -341,12 +434,10 @@ const App = () => {
                       playground signs its own EdDSA tokens as a registered platform, exactly as an embedded product does. Nothing here is mocked, so what
                       another user sees may legitimately differ.
                     </p>
-                    <p className="mt-3 text-xs text-gray-500 dark:text-white/40">
-                      Add <code className="font-mono">CHAT_PLAYGROUND_AGENT=1</code> for a “Rendering Playground” agent whose persona emits the markdown
-                      shapes that have broken the renderer before.
-                    </p>
                   </div>
                 )}
+
+                {session.state === 'signed-in' && <PlaygroundAgentCard className={card} />}
 
                 {/* Host callbacks — proof the panel actually calls them */}
                 <div className={card}>
@@ -418,7 +509,7 @@ const App = () => {
             accentColor="#7b5cff"
             // Only the mock understands these; against a real backend the
             // agent's own suggestions are the ones worth exercising.
-            promptSuggestions={session.state === 'mock' ? SCENARIOS.map((s) => s.prompt) : undefined}
+            promptSuggestions={usingMock ? SCENARIOS.map((s) => s.prompt) : undefined}
             // Sidebar mode is only half-implemented without these two: the
             // panel must push the page aside, and be draggable to resize.
             pushContentSelector="#app-content"

--- a/projects/filigran-chat-playground/vite.config.ts
+++ b/projects/filigran-chat-playground/vite.config.ts
@@ -14,7 +14,12 @@ const PORT = 3020;
 const realApi = process.env.CHAT_API_MOCK === '1' ? null : readRealApiConfig(process.env, PORT);
 
 export default defineConfig({
-  plugins: [react(), realApi ? realChatApi(realApi) : mockChatApi()],
+  // The mock is registered *behind* the real API rather than instead of it.
+  // Signed in, the real one answers and the mock is never reached; signed out,
+  // it hands the request on, so the panel still works with nothing running.
+  // Making a reachable XTM One mandatory just to look at the panel defeated the
+  // point of a playground.
+  plugins: [react(), ...(realApi ? [realChatApi(realApi)] : []), mockChatApi()],
   resolve: {
     // Order matters: string aliases match by prefix, so the subpath must come
     // before the bare package name or it would resolve to `…/index.ts/markdown`.


### PR DESCRIPTION
### Proposed changes

* `ContextUsageIndicator` — a ring + percentage in the composer toolbar showing how full the model's context window is, opening a breakdown of where the context went (stacked bar + colour legend).
* Wiring: `context_tokens` / `context_window` / `context_breakdown` parsed off the `thinking` and `done` frames and off restored assistant messages; `contextUsage` tracked in `useChat`; `contextUsageEnabled` prop (default `true`).
* `QuotaIndicator`'s compact-count formatter extracted to `utils.compactCount`, now that two status readouts share it.
* Playground mock serves the new fields, stepped 21 % per turn so five turns hit every colour band.

> [!IMPORTANT]
> **Stacked on #376** — based on `rds/chatbot-markdown-parity`, not `main`. `QuotaIndicator` and the composer toolbar row it sits in do not exist on `main` yet, and the popover relies on that branch's "flip dropdowns above their anchor" fix (the composer is at the bottom of the panel, so its menus would otherwise open off-screen). Merge #376 first; this diff is only the context-usage work.

### Related issues

* Closes #377
* Backend half: XTM-One-Platform/xtm-one#2825 (reports the figures). Nothing renders until both land.

### How to test this PR

```bash
CHAT_API_MOCK=1 yarn workspace @filigran/chat-playground dev
```

Open the panel (fullscreen gives the widest composer) and send five turns. The mock steps occupancy 21 % per turn:

1. **Before the first turn** — no gauge at all. It is data-driven; nothing is reported yet.
2. **Turns 1–3** — 21 / 42 / 63 %, neutral.
3. **Turn 4** — 84 %, amber, tooltip reads "Context nearly full — older turns are being summarized".
4. **Turn 5** — 100 %, red, "older turns are being dropped".
5. **Click the gauge** — stacked bar + legend. The rows must sum to the headline. "Summarized conversation" only appears past 80 %, where a real backend would first have a digest.
6. **Reload the page** — the gauge comes back from the restored history.
7. **"New conversation"** — it clears rather than carrying the previous reading over.
8. Toggle **Light mode** and re-check.

Against a real XTM One, the same flow works once the backend PR is deployed; on an older backend the gauge is simply absent, which is the intended degradation.

### Checklist

- [x] The PR title follows the Conventional Commits convention `type(scope?): description (#issue)`
- [x] I signed my commits
- [x] This PR is linked to an issue
- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I added/updated the relevant documentation
- [x] Where necessary, I refactored code to improve the overall quality

### Further comments

**Why these design choices** (each is a decision that could reasonably have gone the other way):

* **Colours are the backend's gates, not a palette.** Neutral below 80 %, amber past it, red past 95 % — the exact points at which XTM One's loop compacts and then emergency-prunes. Any other threshold would warn about a moment that never comes, or arrive after it has passed.
* **The tooltip names the consequence, not the state.** "80 % full" leaves the user to guess what happens next; "older turns are being summarized" is the thing they can act on.
* **Legend rows are in fixed order**, mirroring how the prompt is assembled, rather than sorted by size — a legend whose rows reshuffle between two glances cannot be compared against itself.
* **Figures carry a `~`.** They are char-derived estimates of what the *next* call will carry: deliberately a forecast, not a receipt for the turn that just ended. That is what makes the gauge predictive of the summarising the user is about to see.
* **Breakdown rows must sum to the headline.** The popover shows both, and parts that do not add up read as broken numbers rather than as rounding — so the producer distributes its rounding remainder rather than dropping it. Documented in the README as part of the contract.
* **No endpoint of its own.** The figures ride on frames the panel already reads. `context_breakdown` is validated independently of the two required keys, so a malformed breakdown costs the detail but never the number.

**Known gap, deliberate:** the breakdown counts tool schemas, but XTM One's compaction gate does not, so the gauge reads higher than the gate by that amount. The gauge is the honest one — the prompt really does carry those schemas. Closing the gap belongs in the backend gate and is called out in the companion PR.

**Buckets not implemented:** the reference design also shows `Rules`, `Skills` and `Subagent definitions`. Those blocks are folded into XTM One's system prompt with no provenance tracked, so reporting them would mean fabricating numbers. The type is all-optional, so they can be added without a breaking change once the backend can measure them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)