### PR TITLE
ci(release): split the release into prepare and publish workflows (#380)

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -1,0 +1,153 @@
+name: Release — prepare version bump
+
+# Stage 1 of 2. Bumps the selected package(s) and opens a PR; merging that PR
+# is what publishes (see release-publish.yml).
+#
+# Why this is a PR and not a push
+# -------------------------------
+# The `main` ruleset requires every commit to be signed AND every change to
+# arrive through a pull request. A bot pushing straight to `main` violates both
+# at once, which is exactly how the single-workflow release died:
+#
+#   remote: - Commits must have verified signatures.
+#   remote: - Changes must be made through a pull request.
+#   remote: ! [remote rejected] main -> main
+#
+# Pushing a *branch* is unconstrained (the ruleset targets ~DEFAULT_BRANCH
+# only), and the commit that ultimately lands on `main` is the squash commit
+# GitHub itself creates and signs with its web-flow key — so the signature
+# requirement is satisfied without ever handing a GPG key to the bot.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_type:
+        description: 'Version type (patch/minor/major)'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      package:
+        description: 'Package to release'
+        required: true
+        default: '@filigran/ui'
+        type: choice
+        options:
+          - '@filigran/chatbot'
+          - '@filigran/icon'
+          - '@filigran/rich-text-editor'
+          - '@filigran/ui'
+          - all
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ vars.FILIGRANHQ_PROJECT_APP_ID }}
+          private-key: ${{ secrets.FILIGRANHQ_PROJECT_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+      - name: Enable Corepack
+        run: npm install -g corepack
+      - name: Configure Git
+        run: |
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Update version for @filigran/chatbot
+        if: github.event.inputs.package == '@filigran/chatbot' || github.event.inputs.package == 'all'
+        working-directory: ./packages/filigran-chatbot
+        run: |
+          yarn version ${{ github.event.inputs.version_type }}
+          echo "FILIGRAN_CHATBOT_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_ENV
+      - name: Update version for @filigran/icon
+        if: github.event.inputs.package == '@filigran/icon' || github.event.inputs.package == 'all'
+        working-directory: ./packages/filigran-icon
+        run: |
+          yarn version ${{ github.event.inputs.version_type }}
+          echo "FILIGRAN_ICON_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_ENV
+      - name: Update version for @filigran/rich-text-editor
+        if: github.event.inputs.package == '@filigran/rich-text-editor' || github.event.inputs.package == 'all'
+        working-directory: ./packages/filigran-rich-text-editor
+        run: |
+          yarn version ${{ github.event.inputs.version_type }}
+          echo "FILIGRAN_RTE_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_ENV
+      - name: Update version for @filigran/ui
+        if: github.event.inputs.package == '@filigran/ui' || github.event.inputs.package == 'all'
+        working-directory: ./packages/filigran-ui
+        run: |
+          yarn version ${{ github.event.inputs.version_type }}
+          echo "FILIGRAN_UI_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_ENV
+
+      - name: Open the release pull request
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+
+          PARTS=""
+          BODY_LINES=""
+          add() {
+            [ -n "$PARTS" ] && PARTS="$PARTS, "
+            PARTS="${PARTS}$1 to v$2"
+            BODY_LINES="${BODY_LINES}- \`$1\` → **v$2**"$'\n'
+          }
+          [ -n "${FILIGRAN_CHATBOT_VERSION:-}" ] && add "@filigran/chatbot" "$FILIGRAN_CHATBOT_VERSION"
+          [ -n "${FILIGRAN_UI_VERSION:-}" ] && add "@filigran/ui" "$FILIGRAN_UI_VERSION"
+          [ -n "${FILIGRAN_ICON_VERSION:-}" ] && add "@filigran/icon" "$FILIGRAN_ICON_VERSION"
+          [ -n "${FILIGRAN_RTE_VERSION:-}" ] && add "@filigran/rich-text-editor" "$FILIGRAN_RTE_VERSION"
+
+          if [ -z "$PARTS" ]; then
+            echo "::error::No version was bumped — nothing to release."
+            exit 1
+          fi
+
+          # The run id keeps concurrent or retried dispatches from colliding on
+          # one branch name; `release/` is the prefix release-publish.yml keys on.
+          BRANCH="release/${{ github.run_id }}"
+          git checkout -b "$BRANCH"
+          git add .
+          git commit -m "chore(release): bump $PARTS"
+          git push origin "$BRANCH"
+
+          # No issue reference in the title on purpose: a release is mechanical
+          # and closes nothing. validate-pr-title.yml exempts `release/*` heads
+          # from the "(#123)" requirement for exactly this reason.
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "chore(release): bump $PARTS" \
+            --label release \
+            --body "$(printf '%s\n' \
+              "Automated release preparation." \
+              "" \
+              "$BODY_LINES" \
+              "Merging this PR publishes the package(s) to npm, creates the git tag(s) and the GitHub Release(s) — see \`release-publish.yml\`. Closing it without merging releases nothing." \
+              "" \
+              "Triggered by @${{ github.actor }} via \`release-prepare.yml\` (\`${{ github.event.inputs.version_type }}\`, \`${{ github.event.inputs.package }}\`).")"
+
+      - name: Summary
+        run: |
+          echo "## Release prepared" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "A pull request was opened. **Merging it publishes.**" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- [Open pull requests](https://github.com/${{ github.repository }}/pulls?q=is%3Apr+is%3Aopen+label%3Arelease)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,35 +1,24 @@
-name: Release and Publish to NPM
+name: Release — publish on merge
+
+# Stage 2 of 2. Runs when a `release/*` pull request opened by
+# release-prepare.yml is MERGED, and does everything the old single-workflow
+# release did after the version bump: tag, build, publish to npm, cut the
+# GitHub Releases, and close the issues the release ships.
+#
+# Keyed on the merge rather than on a pushed tag: the tag cannot exist before
+# the PR is merged (nothing may be pushed to `main` directly), and keying on the
+# merge means a release PR that gets closed instead of merged leaves no orphan
+# tag behind. The versions are read back from `main` after the merge, so what is
+# published is exactly what the repository says.
 
 on:
-  workflow_dispatch:
-    inputs:
-      version_type:
-        description: 'Version type (patch/minor/major)'
-        required: true
-        default: 'patch'
-        type: choice
-        options:
-          - patch
-          - minor
-          - major
-      package:
-        description: 'Package to release'
-        required: true
-        default: '@filigran/ui'
-        type: choice
-        options:
-          - '@filigran/chatbot'
-          - '@filigran/icon'
-          - '@filigran/rich-text-editor'
-          - '@filigran/ui'
-          - all
-
-env:
-  ORGANIZATION: 'FiligranHQ'
-  PROJECT_NUMBER: 30
+  pull_request:
+    types: [closed]
 
 jobs:
-  release:
+  publish:
+    # `merged == true` is what distinguishes a merge from a plain close.
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -47,10 +36,15 @@ jobs:
         uses: actions/checkout@v6
         with:
           token: ${{ steps.app-token.outputs.token }}
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          # Tags and full history are needed to compute "commits since the last
+          # release" for the changelog below.
+          fetch-depth: 0
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
       - name: Enable Corepack
         run: npm install -g corepack
       - name: Configure Git
@@ -59,44 +53,43 @@ jobs:
           git config --global user.name "github-actions[bot]"
       - name: Install dependencies
         run: yarn install --immutable
-      - name: Get current versions
+
+      - name: Resolve released packages
+        # Which packages to publish is derived from the merge itself — the
+        # `package.json` files the release PR touched — rather than from an input
+        # this workflow never saw. That keeps the two stages from disagreeing,
+        # and makes a hand-edited release PR behave exactly as it reads.
         run: |
-          if [[ "${{ github.event.inputs.package }}" == "@filigran/chatbot" ]] || [[ "${{ github.event.inputs.package }}" == "all" ]]; then
-            echo "FILIGRAN_CHATBOT_CURRENT_VERSION=$(node -p "require('./packages/filigran-chatbot/package.json').version")" >> $GITHUB_ENV
+          set -euo pipefail
+          CHANGED=$(git diff --name-only \
+            ${{ github.event.pull_request.base.sha }} \
+            ${{ github.event.pull_request.merge_commit_sha }} \
+            -- 'packages/*/package.json')
+          echo "Changed manifests:"
+          echo "$CHANGED"
+
+          version_of() { node -p "require('./$1/package.json').version"; }
+
+          for f in $CHANGED; do
+            case "$f" in
+              packages/filigran-chatbot/package.json)
+                echo "FILIGRAN_CHATBOT_VERSION=$(version_of packages/filigran-chatbot)" >> $GITHUB_ENV ;;
+              packages/filigran-icon/package.json)
+                echo "FILIGRAN_ICON_VERSION=$(version_of packages/filigran-icon)" >> $GITHUB_ENV ;;
+              packages/filigran-rich-text-editor/package.json)
+                echo "FILIGRAN_RTE_VERSION=$(version_of packages/filigran-rich-text-editor)" >> $GITHUB_ENV ;;
+              packages/filigran-ui/package.json)
+                echo "FILIGRAN_UI_VERSION=$(version_of packages/filigran-ui)" >> $GITHUB_ENV ;;
+            esac
+          done
+
+      - name: Fail if nothing was released
+        run: |
+          if [ -z "${FILIGRAN_CHATBOT_VERSION:-}${FILIGRAN_ICON_VERSION:-}${FILIGRAN_RTE_VERSION:-}${FILIGRAN_UI_VERSION:-}" ]; then
+            echo "::error::A release/* PR was merged but no package manifest changed — nothing to publish."
+            exit 1
           fi
-          if [[ "${{ github.event.inputs.package }}" == "@filigran/icon" ]] || [[ "${{ github.event.inputs.package }}" == "all" ]]; then
-            echo "FILIGRAN_ICON_CURRENT_VERSION=$(node -p "require('./packages/filigran-icon/package.json').version")" >> $GITHUB_ENV
-          fi
-          if [[ "${{ github.event.inputs.package }}" == "@filigran/rich-text-editor" ]] || [[ "${{ github.event.inputs.package }}" == "all" ]]; then
-            echo "FILIGRAN_RTE_CURRENT_VERSION=$(node -p "require('./packages/filigran-rich-text-editor/package.json').version")" >> $GITHUB_ENV
-          fi
-          if [[ "${{ github.event.inputs.package }}" == "@filigran/ui" ]] || [[ "${{ github.event.inputs.package }}" == "all" ]]; then
-            echo "FILIGRAN_UI_CURRENT_VERSION=$(node -p "require('./packages/filigran-ui/package.json').version")" >> $GITHUB_ENV
-          fi
-      - name: Update version for @filigran/chatbot
-        if: github.event.inputs.package == '@filigran/chatbot' || github.event.inputs.package == 'all'
-        working-directory: ./packages/filigran-chatbot
-        run: |
-          yarn version ${{ github.event.inputs.version_type }}
-          echo "FILIGRAN_CHATBOT_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_ENV
-      - name: Update version for @filigran/icon
-        if: github.event.inputs.package == '@filigran/icon' || github.event.inputs.package == 'all'
-        working-directory: ./packages/filigran-icon
-        run: |
-          yarn version ${{ github.event.inputs.version_type }}
-          echo "FILIGRAN_ICON_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_ENV
-      - name: Update version for @filigran/rich-text-editor
-        if: github.event.inputs.package == '@filigran/rich-text-editor' || github.event.inputs.package == 'all'
-        working-directory: ./packages/filigran-rich-text-editor
-        run: |
-          yarn version ${{ github.event.inputs.version_type }}
-          echo "FILIGRAN_RTE_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_ENV
-      - name: Update version for @filigran/ui
-        if: github.event.inputs.package == '@filigran/ui' || github.event.inputs.package == 'all'
-        working-directory: ./packages/filigran-ui
-        run: |
-          yarn version ${{ github.event.inputs.version_type }}
-          echo "FILIGRAN_UI_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_ENV
+
       - name: Collect commits and issues for changelog
         id: changelog
         run: |
@@ -104,23 +97,24 @@ jobs:
           CHANGELOG=""
           UI_ISSUES=""
           ICON_ISSUES=""
-          
+          CHATBOT_ISSUES=""
+
           # Function to extract issue numbers from text
           extract_issues() {
             echo "$1" | grep -oE '#[0-9]+|[Cc]loses? #[0-9]+|[Ff]ixes? #[0-9]+|[Rr]esolves? #[0-9]+' | grep -oE '[0-9]+' | sort -u
           }
-          
+
           # Get commits since last tag for each package
-          if [ -n "$FILIGRAN_UI_VERSION" ]; then
+          if [ -n "${FILIGRAN_UI_VERSION:-}" ]; then
             echo "Processing @filigran/ui commits..."
             LAST_UI_TAG=$(git tag -l "@filigran/ui-v*" | sort -V | tail -n 1)
             if [ -z "$LAST_UI_TAG" ]; then
               LAST_UI_TAG=$(git rev-list --max-parents=0 HEAD)
             fi
-          
+
             UI_COMMITS=$(git log $LAST_UI_TAG..HEAD --pretty=format:"%h %s" -- packages/filigran-ui/)
             UI_CHANGELOG="### Filigran UI Changes\n"
-          
+
             while IFS= read -r commit; do
               if [ -n "$commit" ]; then
                 UI_CHANGELOG="$UI_CHANGELOG- $commit\n"
@@ -130,23 +124,23 @@ jobs:
                 done
               fi
             done <<< "$UI_COMMITS"
-          
+
             CHANGELOG="$CHANGELOG$UI_CHANGELOG\n"
-          
+
             # Remove duplicates from UI issues list
             UI_ISSUES=$(echo $UI_ISSUES | tr ' ' '\n' | sort -u | tr '\n' ' ')
           fi
-          
-          if [ -n "$FILIGRAN_ICON_VERSION" ]; then
+
+          if [ -n "${FILIGRAN_ICON_VERSION:-}" ]; then
             echo "Processing @filigran/icon commits..."
             LAST_ICON_TAG=$(git tag -l "@filigran/icon-v*" | sort -V | tail -n 1)
             if [ -z "$LAST_ICON_TAG" ]; then
               LAST_ICON_TAG=$(git rev-list --max-parents=0 HEAD)
             fi
-          
+
             ICON_COMMITS=$(git log $LAST_ICON_TAG..HEAD --pretty=format:"%h %s" -- packages/filigran-icon/)
             ICON_CHANGELOG="### Filigran Icon Changes\n"
-          
+
             while IFS= read -r commit; do
               if [ -n "$commit" ]; then
                 ICON_CHANGELOG="$ICON_CHANGELOG- $commit\n"
@@ -156,118 +150,129 @@ jobs:
                 done
               fi
             done <<< "$ICON_COMMITS"
-          
+
             CHANGELOG="$CHANGELOG$ICON_CHANGELOG\n"
-          
+
             # Remove duplicates from ICON issues list
             ICON_ISSUES=$(echo $ICON_ISSUES | tr ' ' '\n' | sort -u | tr '\n' ' ')
           fi
-          
+
+          # The chatbot had no changelog at all: its GitHub Release shipped a
+          # bare install snippet while ui/icon got a commit list.
+          if [ -n "${FILIGRAN_CHATBOT_VERSION:-}" ]; then
+            echo "Processing @filigran/chatbot commits..."
+            LAST_CHATBOT_TAG=$(git tag -l "@filigran/chatbot-v*" | sort -V | tail -n 1)
+            if [ -z "$LAST_CHATBOT_TAG" ]; then
+              LAST_CHATBOT_TAG=$(git rev-list --max-parents=0 HEAD)
+            fi
+
+            CHATBOT_COMMITS=$(git log $LAST_CHATBOT_TAG..HEAD --pretty=format:"%h %s" -- packages/filigran-chatbot/)
+            CHATBOT_CHANGELOG="### Filigran Chatbot Changes\n"
+
+            while IFS= read -r commit; do
+              if [ -n "$commit" ]; then
+                CHATBOT_CHANGELOG="$CHATBOT_CHANGELOG- $commit\n"
+                ISSUES=$(extract_issues "$commit")
+                for issue in $ISSUES; do
+                  CHATBOT_ISSUES="$CHATBOT_ISSUES $issue"
+                done
+              fi
+            done <<< "$CHATBOT_COMMITS"
+
+            CHANGELOG="$CHANGELOG$CHATBOT_CHANGELOG\n"
+            CHATBOT_ISSUES=$(echo $CHATBOT_ISSUES | tr ' ' '\n' | sort -u | tr '\n' ' ')
+
+            echo "chatbot_changelog<<EOF" >> $GITHUB_OUTPUT
+            echo -e "$CHATBOT_CHANGELOG" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+          fi
+
           # Export for use in next steps
           echo "changelog<<EOF" >> $GITHUB_OUTPUT
           echo -e "$CHANGELOG" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
           echo "ui_issues=$UI_ISSUES" >> $GITHUB_OUTPUT
           echo "icon_issues=$ICON_ISSUES" >> $GITHUB_OUTPUT
-          
+          echo "chatbot_issues=$CHATBOT_ISSUES" >> $GITHUB_OUTPUT
+
           # Also save to environment for debugging
           echo "UI_ISSUES_TO_CLOSE=$UI_ISSUES" >> $GITHUB_ENV
           echo "ICON_ISSUES_TO_CLOSE=$ICON_ISSUES" >> $GITHUB_ENV
-      - name: Commit version changes
-        run: |
-          git add .
-          
-          PARTS=""
-          if [ -n "$FILIGRAN_CHATBOT_VERSION" ]; then
-            PARTS="@filigran/chatbot to v$FILIGRAN_CHATBOT_VERSION"
-          fi
-          if [ -n "$FILIGRAN_UI_VERSION" ]; then
-            [ -n "$PARTS" ] && PARTS="$PARTS, "
-            PARTS="${PARTS}@filigran/ui to v$FILIGRAN_UI_VERSION"
-          fi
-          if [ -n "$FILIGRAN_ICON_VERSION" ]; then
-            [ -n "$PARTS" ] && PARTS="$PARTS, "
-            PARTS="${PARTS}@filigran/icon to v$FILIGRAN_ICON_VERSION"
-          fi
-          if [ -n "$FILIGRAN_RTE_VERSION" ]; then
-            [ -n "$PARTS" ] && PARTS="$PARTS, "
-            PARTS="${PARTS}@filigran/rich-text-editor to v$FILIGRAN_RTE_VERSION"
-          fi
-          
-          if [ -z "$PARTS" ]; then
-            echo "No version changes to commit"
-            exit 0
-          fi
-          
-          git commit -m "chore: bump $PARTS"
-          git push
+          echo "CHATBOT_ISSUES_TO_CLOSE=$CHATBOT_ISSUES" >> $GITHUB_ENV
+
       - name: Create Git tags
         run: |
-          if [ -n "$FILIGRAN_CHATBOT_VERSION" ]; then
-            git tag "@filigran/chatbot-$FILIGRAN_CHATBOT_VERSION"
-            echo "Created tag: @filigran/chatbot-$FILIGRAN_CHATBOT_VERSION"
+          # NOTE: the chatbot tag carries the `v` prefix, like every other
+          # package and like every chatbot tag already in the repo
+          # (@filigran/chatbot-v3.7.4). It used to be created without it, which
+          # disagreed with the tag its own GitHub Release step referenced — the
+          # release would have ended up with two tags for one version.
+          if [ -n "${FILIGRAN_CHATBOT_VERSION:-}" ]; then
+            git tag "@filigran/chatbot-v$FILIGRAN_CHATBOT_VERSION"
+            echo "Created tag: @filigran/chatbot-v$FILIGRAN_CHATBOT_VERSION"
           fi
-          if [ -n "$FILIGRAN_ICON_VERSION" ]; then
+          if [ -n "${FILIGRAN_ICON_VERSION:-}" ]; then
             git tag "@filigran/icon-v$FILIGRAN_ICON_VERSION"
             echo "Created tag: @filigran/icon-v$FILIGRAN_ICON_VERSION"
           fi
-          if [ -n "$FILIGRAN_RTE_VERSION" ]; then
+          if [ -n "${FILIGRAN_RTE_VERSION:-}" ]; then
             git tag "@filigran/rich-text-editor-v$FILIGRAN_RTE_VERSION"
             echo "Created tag: @filigran/rich-text-editor-v$FILIGRAN_RTE_VERSION"
           fi
-          if [ -n "$FILIGRAN_UI_VERSION" ]; then
+          if [ -n "${FILIGRAN_UI_VERSION:-}" ]; then
             git tag "@filigran/ui-v$FILIGRAN_UI_VERSION"
             echo "Created tag: @filigran/ui-v$FILIGRAN_UI_VERSION"
           fi
           git push --tags
+
       - name: Build packages
         run: |
-          if [ -n "$FILIGRAN_CHATBOT_VERSION" ]; then
+          if [ -n "${FILIGRAN_CHATBOT_VERSION:-}" ]; then
             echo "Building @filigran/chatbot..."
             yarn workspace @filigran/chatbot run build
           fi
-          if [ -n "$FILIGRAN_ICON_VERSION" ]; then
+          if [ -n "${FILIGRAN_ICON_VERSION:-}" ]; then
             echo "Building @filigran/icon..."
             yarn workspace @filigran/icon run build
           fi
-          if [ -n "$FILIGRAN_RTE_VERSION" ]; then
+          if [ -n "${FILIGRAN_RTE_VERSION:-}" ]; then
             echo "Building @filigran/rich-text-editor..."
             yarn workspace @filigran/rich-text-editor run build
           fi
-          if [ -n "$FILIGRAN_UI_VERSION" ]; then
+          if [ -n "${FILIGRAN_UI_VERSION:-}" ]; then
             echo "Building @filigran/ui..."
             yarn workspace @filigran/ui run build
           fi
       - name: Publish @filigran/chatbot to NPM
-        if: (github.event.inputs.package == '@filigran/chatbot' || github.event.inputs.package == 'all') && env.FILIGRAN_CHATBOT_VERSION != ''
+        if: env.FILIGRAN_CHATBOT_VERSION != ''
         working-directory: ./packages/filigran-chatbot
         run: yarn npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Publish @filigran/icon to NPM
-        if: (github.event.inputs.package == '@filigran/icon' || github.event.inputs.package == 'all') && env.FILIGRAN_ICON_VERSION != ''
+        if: env.FILIGRAN_ICON_VERSION != ''
         working-directory: ./packages/filigran-icon
         run: yarn npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Publish @filigran/rich-text-editor to NPM
-        if: (github.event.inputs.package == '@filigran/rich-text-editor' || github.event.inputs.package == 'all') && env.FILIGRAN_RTE_VERSION != ''
+        if: env.FILIGRAN_RTE_VERSION != ''
         working-directory: ./packages/filigran-rich-text-editor
         run: yarn npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Publish @filigran/ui to NPM
-        if: (github.event.inputs.package == '@filigran/ui' || github.event.inputs.package == 'all') && env.FILIGRAN_UI_VERSION != ''
+        if: env.FILIGRAN_UI_VERSION != ''
         working-directory: ./packages/filigran-ui
         run: yarn npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Create GitHub Release for @filigran/icon
-        if: (github.event.inputs.package == '@filigran/icon' || github.event.inputs.package == 'all') && env.FILIGRAN_ICON_VERSION != ''
+        if: env.FILIGRAN_ICON_VERSION != ''
         uses: softprops/action-gh-release@v3
         with:
           tag_name: '@filigran/icon-v${{ env.FILIGRAN_ICON_VERSION }}'
@@ -289,7 +294,7 @@ jobs:
           draft: false
           prerelease: false
       - name: Create GitHub Release for @filigran/rich-text-editor
-        if: (github.event.inputs.package == '@filigran/rich-text-editor' || github.event.inputs.package == 'all') && env.FILIGRAN_RTE_VERSION != ''
+        if: env.FILIGRAN_RTE_VERSION != ''
         uses: softprops/action-gh-release@v3
         with:
           tag_name: '@filigran/rich-text-editor-v${{ env.FILIGRAN_RTE_VERSION }}'
@@ -304,7 +309,7 @@ jobs:
           draft: false
           prerelease: false
       - name: Create GitHub Release for @filigran/ui
-        if: (github.event.inputs.package == '@filigran/ui' || github.event.inputs.package == 'all') && env.FILIGRAN_UI_VERSION != ''
+        if: env.FILIGRAN_UI_VERSION != ''
         uses: softprops/action-gh-release@v3
         with:
           tag_name: '@filigran/ui-v${{ env.FILIGRAN_UI_VERSION }}'
@@ -326,13 +331,15 @@ jobs:
           draft: false
           prerelease: false
       - name: Create GitHub Release for @filigran/chatbot
-        if: (github.event.inputs.package == '@filigran/chatbot' || github.event.inputs.package == 'all') && env.FILIGRAN_CHATBOT_VERSION != ''
+        if: env.FILIGRAN_CHATBOT_VERSION != ''
         uses: softprops/action-gh-release@v3
         with:
           tag_name: '@filigran/chatbot-v${{ env.FILIGRAN_CHATBOT_VERSION }}'
           name: 'Filigran Chatbot v${{ env.FILIGRAN_CHATBOT_VERSION }}'
           body: |
             ## Filigran Chatbot v${{ env.FILIGRAN_CHATBOT_VERSION }}
+            
+            ${{ steps.changelog.outputs.chatbot_changelog }}
             
             ### Installation
             ```bash

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -11,7 +11,15 @@ jobs:
   validate-pr-title:
     name: Validate Conventional PR title
     runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login != 'renovate[bot]' && !startsWith(github.event.pull_request.title, '[Snyk]')
+    # `release/*` heads are the automated version bumps opened by
+    # release-prepare.yml. Their titles are conventional but carry no issue
+    # reference, because a release closes nothing — it ships what is already
+    # merged. Without this exemption the release PR can never be merged, and
+    # nothing can ever be published.
+    if: >-
+      github.event.pull_request.user.login != 'renovate[bot]'
+      && !startsWith(github.event.pull_request.title, '[Snyk]')
+      && !startsWith(github.event.pull_request.head.ref, 'release/')
     steps:
       - name: Check Conventional Commit title
         env:

--- a/deployment-package.md
+++ b/deployment-package.md
@@ -1,15 +1,22 @@
 # Deploying a new package version
 
-Releases for all Filigran packages are handled via the GitHub Actions workflow [**Release and Publish to NPM**](.github/workflows/release-version.yml).  
-It is triggered **manually** from the GitHub Actions tab — no push or tag is required to start it.
+Releases run in **two stages**, because `main` accepts neither unsigned commits
+nor direct pushes:
+
+1. [**Release — prepare version bump**](.github/workflows/release-prepare.yml) — triggered manually. Bumps the version and opens a pull request.
+2. [**Release — publish on merge**](.github/workflows/release-publish.yml) — triggered by **merging** that pull request. Tags, builds, publishes to npm and cuts the GitHub Release.
+
+Nothing is published until the release pull request is merged. Closing it
+instead releases nothing and leaves no tag behind.
 
 ---
 
 ## How to trigger a release
 
-1. Go to **Actions → Release and Publish to NPM** in the GitHub repository.
+1. Go to **Actions → Release — prepare version bump** in the GitHub repository.
 2. Click **Run workflow**.
 3. Fill in the two inputs described below, then click **Run workflow**.
+4. **Review and merge the pull request it opens.** That merge is what publishes.
 
 ---
 
@@ -49,14 +56,43 @@ The workflow follows [Semantic Versioning](https://semver.org/) (`MAJOR.MINOR.PA
 
 ---
 
-## What the workflow does
+## What the workflows do
+
+**Stage 1 — prepare** (`release-prepare.yml`)
 
 1. Bumps the version in the relevant `package.json` with `yarn version <type>`.
-2. Commits and pushes the change (`chore: bump <package> to vX.Y.Z`).
-3. Creates a Git tag (`<package>-vX.Y.Z`).
-4. Builds the package (`yarn workspace <package> run build`).
-5. Publishes to **NPM** (`yarn npm publish --access public`).
-6. Creates a **GitHub Release** with installation instructions.
+2. Commits it to a `release/<run-id>` branch and opens a pull request labelled `release`.
+
+**Stage 2 — publish** (`release-publish.yml`, on merge of that pull request)
+
+3. Works out which packages were released from the `package.json` files the pull request touched.
+4. Creates a Git tag (`<package>-vX.Y.Z`).
+5. Builds the package (`yarn workspace <package> run build`).
+6. Publishes to **NPM** (`yarn npm publish --access public`).
+7. Creates a **GitHub Release** with the changelog and installation instructions.
+8. Closes the issues shipped by the release and updates their project status.
+
+---
+
+## Publishing from a local checkout
+
+Only for the rare case where CI cannot do it. Use `release:<package>`, **not**
+`publish:<package>` — the latter passes `--provenance`, which npm can only
+generate inside GitHub Actions or GitLab CI and which fails locally with
+`YN0091`:
+
+```bash
+yarn release:filigran-chatbot     # from the repository root
+```
+
+Two caveats. It publishes the version already in `package.json` **as-is** — it
+does not bump — and it creates no tag, no GitHub Release and no provenance
+attestation. Tag it by hand afterwards so the next changelog has a starting
+point:
+
+```bash
+git tag "@filigran/chatbot-v<version>" <commit> && git push origin "@filigran/chatbot-v<version>"
+```
 
 ---
 


### PR DESCRIPTION
### Proposed changes

* **`release-prepare.yml`** (new, manual) — bumps the selected package(s) and opens a `release/<run-id>` pull request labelled `release`. Same two inputs as before.
* **`release-publish.yml`** (new, on merge of that PR) — tags, builds, publishes to npm, cuts the GitHub Releases, closes the shipped issues. Everything the old workflow did after the bump.
* **`release-version.yml`** — removed, replaced by the two above.
* **`validate-pr-title.yml`** — exempts `release/*` heads from the mandatory `(#123)` suffix.
* **`deployment-package.md`** — documents the two stages and fixes the local-publish instructions.

### Related issues

* Closes #380

### How to test this PR

It cannot be exercised before it is on `main` — `workflow_dispatch` and `pull_request: closed` both only run from the default branch. So the honest test plan is a real release once merged:

1. **Actions → Release — prepare version bump**, pick `@filigran/chatbot` + `minor`. It should open a PR titled `chore(release): bump @filigran/chatbot to v3.10.0`.
2. Confirm **Validate Conventional PR title** is skipped on it (no `(#123)` in the title).
3. Merge it. **Release — publish on merge** should fire and produce: tag `@filigran/chatbot-v3.10.0`, `@filigran/chatbot@3.10.0` on npm, and a GitHub Release whose body now contains a commit list.
4. Close a release PR instead of merging it, once, to confirm nothing is published and no tag is left behind.

If step 1 fails on permissions, the App token needs `pull-requests: write` — that is declared in the workflow, but the App installation has to grant it.

### Checklist

- [x] The PR title follows the Conventional Commits convention `type(scope?): description (#issue)`
- [x] I signed my commits
- [x] This PR is linked to an issue
- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [x] I added/updated the relevant documentation
- [x] Where necessary, I refactored code to improve the overall quality

### Further comments

**Why this is the fix.** The release is dead in the water — it pushes the bump commit straight to `main` and the ruleset refuses it twice over:

```
remote: - Commits must have verified signatures.
remote: - Changes must be made through a pull request.
```

Both violations say the same thing, so one change answers both. And the signature requirement is satisfied *without* giving the bot a GPG key: pushing a branch is unconstrained (the `Org ruleset` targets `~DEFAULT_BRANCH` only), and the commit that ends up on `main` is the squash commit GitHub creates and signs with its web-flow key. Every merge commit already on `main` is `verified=true` for exactly that reason.

**Why on merge and not on a pushed tag.** The tag cannot exist before the PR is merged, since nothing may be pushed to `main` directly. Keying on the merge also means a release PR that gets closed rather than merged leaves no orphan tag. The published version is read back from `main` after the merge, so it is exactly what the repository says.

**Which packages get published** is derived from the `package.json` files the release PR touched, not from an input the second workflow never saw. The two stages therefore cannot disagree, and a hand-edited release PR behaves as it reads.

**Two bugs fixed in passing**, both latent because the release never got far enough to hit them:

- the chatbot tag was created without the `v` its own Release step expects — a successful run would have left two tags for one version;
- the chatbot had no changelog, so its Release shipped only an install snippet.

**The trade-off you are accepting:** releasing is no longer one click. It is dispatch → review → merge → publish. The alternative — adding the release App to `bypass_actors` — is one admin setting and keeps the single click, and is worth doing instead if that is the preference. This PR is the version that needs no admin rights.

**What I could not verify:** GitHub Actions workflows cannot be run locally. I validated that every workflow file parses, that the preserved blocks (project status, issue closing, releases) were copied rather than retyped, and that no reference to the deleted workflow survives. The behaviour itself is unproven until a real release runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)