### PR TITLE
feat(chatbot): collect human approval for gated tool calls (#385)

### DIFF
--- a/packages/filigran-chatbot/README.md
+++ b/packages/filigran-chatbot/README.md
@@ -6,6 +6,7 @@ Filigran chat panel — a standalone React + Tailwind chatbot component with SSE
 
 - 🔄 **SSE Message Streaming** — Real-time response streaming with status indicators
 - ⚡ **Mid-Run Steering** — Send messages while the agent is generating; they are injected into the running agentic loop instead of waiting for the turn to finish
+- ✋ **Tool Approval** — When the agent stops at a tool that needs a human's consent, the turn pauses mid-answer and the reviewer approves, declines with a reason, or approves always — opt-in per host, see [Tool approval](#post-apibaseurlapiendpointsapprove)
 - 🗂️ **Conversation History** — Switch between (and delete) past conversations from a header menu, or from a permanent sidebar in fullscreen mode (collapsible, searchable past 7 entries, rename in place)
 - 🤖 **Multi-Agent Support** — Switch between different AI agents
 - 📎 **File Attachments** — Upload and paste files (PDF, TXT, images)
@@ -394,6 +395,134 @@ data: {"type": "stream", "content": "Follow-up answer to the steering message"}
 data: {"type": "done", "content": "Follow-up answer to the steering message", "conversation_id": "uuid"}
 ```
 
+### `POST {apiBaseUrl}{apiEndpoints.approve}`
+
+Answers a turn that paused because the agent proposed a tool call requiring a
+human's consent. **Opt-in: there is no default path.** The widget advertises
+approval support to the backend only when `apiEndpoints.approve` is set, and
+that flag is a promise — a backend that pauses a turn waits indefinitely for a
+decision, with no timeout. A host that names a path it cannot route would
+receive the pause, POST the decision into a 404, and hang the turn with the
+user watching a spinner. Leave it unset and the backend degrades to an ordinary
+assistant message explaining what it could not run, so an un-updated host keeps
+working untouched.
+
+When set, `supports_tool_approval: true` is sent on every `rest` message body.
+
+**Server → client**, on the existing SSE stream, alongside `stream` / `status` /
+`done`:
+
+```
+data: {"type": "approval_required", "conversation_id": "uuid-here", "proposals": [
+  {
+    "tool_call_id": "call_abc123",
+    "tool_name": "opencti_delete_entity",
+    "tool_description": "Permanently delete an entity from the platform.",
+    "arguments": {"entity_id": "e-123", "cascade": true},
+    "input_schema": {"type": "object", "properties": {
+      "entity_id": {"type": "string", "description": "Entity to delete"},
+      "cascade": {"type": "boolean", "description": "Also delete linked entities"}
+    }},
+    "source": "integration:opencti"
+  }
+]}
+```
+
+The turn is **not** over: no `done` arrives, the stream stays open and silent
+(kept alive by SSE `: keepalive` comment lines, which the reader drops), and the
+rest of the turn continues on it once a decision is sent. The progress bubble is
+replaced by the prompt, which renders each argument next to its description from
+`input_schema` — `cascade: true` is unjudgeable on its own, so a prompt showing
+only names and values would be a rubber stamp.
+
+**Client → server**, one decision per proposed call:
+
+```json
+{
+  "conversation_id": "uuid-here",
+  "decisions": [
+    { "tool_call_id": "call_abc123", "decision": "approve" },
+    { "tool_call_id": "call_ghi789", "decision": "reject", "rejection_reason": "Wrong target environment." },
+    { "tool_call_id": "call_jkl012", "decision": "approve_always" }
+  ]
+}
+```
+
+| `decision`       | Effect                                                              |
+| ---------------- | ------------------------------------------------------------------- |
+| `approve`        | Runs with the arguments exactly as proposed                          |
+| `reject`         | Does not run; the agent receives `rejection_reason` and can adapt    |
+| `approve_always` | Runs, **and** saves a standing approval for this user                |
+
+Every proposed `tool_call_id` must appear exactly once — the backend refuses a
+partial set, because resuming with an undecided call leaves a `tool_use` block
+without its `tool_result`, which the model providers reject outright. The prompt
+therefore submits itself once the last card is decided. A set containing
+`approve_always` waits for an explicit Confirm instead: it is the only verdict
+whose reach outlives the turn (it applies to the user's unattended scheduled
+runs too), so the warning has to be read before it is committed.
+
+A decision carries no arguments. Correcting a wrong proposal is what
+`reject` with a reason is for — rewriting a call under the agent's name would
+leave a transcript crediting it with arguments it never chose.
+
+On a non-2xx the prompt stays on screen with the failure noted and the controls
+re-armed: the turn is still paused either way, so clearing the prompt would
+strand it with nothing able to answer. A `409` means nothing is waiting any more
+(the turn finished, was cancelled, or was answered elsewhere); the stream ending
+then clears the prompt on its own. Stopping the turn also dismisses it — the
+backend waits indefinitely by design, so abandoning the stream is the reviewer's
+only other way out.
+
+**Proxied hosts:** the decision goes through the same fetch path as every other
+endpoint — relative to `apiBaseUrl` and honouring `requestHeaders` — so CSRF
+wrappers and per-request context headers keep working. A proxy in front of the
+chat must forward the request body whole (a proxy rebuilding it from a fixed
+field list silently drops `supports_tool_approval`), never time out the
+streaming turn, and pass SSE keepalives through untouched.
+
+#### Recovering a prompt after a page reload
+
+`approval_required` is a single event on a stream, so a reload loses it —
+including the `tool_call_id`s a decision has to name — while the turn goes on
+waiting for an answer that can no longer be given. To the user that is a chat
+which simply stopped replying.
+
+Set `apiEndpoints.pendingApprovals` (XTM One: `/chat/conversations`) and the
+panel asks once per conversation, on mount and on every conversation switch:
+
+```
+GET {apiBaseUrl}{apiEndpoints.pendingApprovals}/{conversation_id}/pending-approvals
+→ {
+    "conversation_id": "uuid-here",
+    "proposals": [ /* as the event carried */ ],
+    "turn": "running" | "idle"
+  }
+```
+
+An empty `proposals` is the ordinary answer. A non-empty one re-renders the same
+prompt, and the decision is POSTed exactly as before. Like `approve` this has no
+default and is skipped when unset, leaving the live flow untouched.
+
+The recovered turn resumes with the reasoning and tool results it had already
+produced — but **not on a stream**: the one it would have reported on died with
+the old page, so the backend persists the answer and suppresses the live `done`
+frame. So after a decision on a recovered prompt the panel shows its ordinary
+working indicator and polls this route every 5s, using `turn` as the stop
+condition: while it reads `running` it keeps waiting, and the moment it reads
+`idle` it re-reads the conversation once — the answer is there. A resumed turn
+that pauses *again* on a second gated call is picked up by the same poll, which
+is the only way that prompt could reach the user with no stream open.
+
+One bound applies server-side: after 30 minutes with **no sign of a client** and
+no decision, the turn stops waiting and the pause is discarded. Any request about
+the conversation counts as a sign, so while a recovered prompt is displayed the
+panel re-reads this route every 10 minutes purely to say someone is still there —
+a tab left open makes no requests of its own, and the bound is meant to limit
+abandonment, never the person deciding.
+
+REST backend only: `legacy` and `ag-ui` never meet this gate.
+
 ## Customization
 
 ### Custom Logo
@@ -480,6 +609,17 @@ function App() {
 - `'Uses AI. Verify results.'`
 - `'How can I help you, '`
 - `'Suggestions'`
+- `'Waiting for your approval…'`
+- `'The agent needs your approval to run a tool:'` / `'The agent needs your approval to run these tools:'`
+- `'Yes'` / `'No'` / `'Yes, always'` / `'Back'` / `'Confirm'` / `'Sending…'` / `'decided'`
+- `'Approved'` / `'Declined'` / `'Always allowed'`
+- `'Decline this call'`
+- `'Why not? The agent sees this and can adapt (optional)'`
+- `'e.g. wrong environment — use staging instead'`
+- `'Also applies to your scheduled runs, until you revoke it'`
+- `'“Yes, always” saves a preference for you. That tool will then run without asking — including on scheduled runs nobody is watching — until you revoke it.'`
+- `'This turn is no longer waiting for a decision.'`
+- `'Could not send your decision. Please try again.'`
 - `'Floating'`
 - `'Sidebar'`
 - `'Full screen'`

--- a/packages/filigran-chatbot/README.md
+++ b/packages/filigran-chatbot/README.md
@@ -620,6 +620,7 @@ function App() {
 - `'“Yes, always” saves a preference for you. That tool will then run without asking — including on scheduled runs nobody is watching — until you revoke it.'`
 - `'This turn is no longer waiting for a decision.'`
 - `'Could not send your decision. Please try again.'`
+- `'This decision could not be sent. Reload the chat and try again.'`
 - `'Floating'`
 - `'Sidebar'`
 - `'Full screen'`

--- a/packages/filigran-chatbot/src/components/ChatApprovalPrompt.tsx
+++ b/packages/filigran-chatbot/src/components/ChatApprovalPrompt.tsx
@@ -1,0 +1,334 @@
+import { useEffect, useRef, useState } from 'react';
+import type { ToolApprovalDecision, ToolApprovalProposal, ToolApprovalVerdict } from '../types';
+import { AlertTriangleIcon, CheckIcon, WrenchIcon, XCircleIcon } from './icons';
+
+interface ChatApprovalPromptProps {
+  proposals: ToolApprovalProposal[];
+  /** Sends one decision per proposal — the backend refuses a partial set. */
+  onSubmit: (decisions: ToolApprovalDecision[]) => void;
+  isSubmitting?: boolean;
+  /** Why the last submission failed. Non-null re-arms the controls for a retry. */
+  error?: string | null;
+  t: (key: string) => string;
+}
+
+/** Shape of one argument as described by the tool's own JSON Schema. */
+interface ArgumentSchema {
+  description?: string;
+  type?: string;
+}
+
+/**
+ * Pull `{ description, type }` for one argument out of a JSON Schema, tolerating
+ * a schema that is absent or shaped unexpectedly — an unlabelled argument still
+ * renders, it just carries less.
+ */
+function argumentSchema(inputSchema: Record<string, unknown> | undefined, name: string): ArgumentSchema {
+  const properties = inputSchema?.properties;
+  if (!properties || typeof properties !== 'object') return {};
+  const entry = (properties as Record<string, unknown>)[name];
+  if (!entry || typeof entry !== 'object') return {};
+  const e = entry as Record<string, unknown>;
+  return {
+    description: typeof e.description === 'string' ? e.description : undefined,
+    type: typeof e.type === 'string' ? e.type : undefined,
+  };
+}
+
+/** Render an argument value as something a person can read. */
+function formatValue(value: unknown): string {
+  if (typeof value === 'string') return value;
+  try {
+    return JSON.stringify(value, null, 2) ?? String(value);
+  } catch {
+    // Cyclic or otherwise unstringifiable — the reviewer still needs to see
+    // that the argument is there, so degrade rather than blank the card.
+    return String(value);
+  }
+}
+
+/**
+ * Scroll `ref` into view when `active` becomes true, and on each later
+ * transition into it.
+ *
+ * Every control here is revealed rather than always present: the prompt itself
+ * arrives at the bottom of a thread that has just grown by a whole turn, "No"
+ * opens a reason box under the card, and "Yes, always" opens a warning under the
+ * list. In each case the click can look like it did nothing — and on a *paused*
+ * turn a stalled reviewer stalls the agent too. rAF because the revealed node
+ * must be laid out before it can be scrolled to.
+ */
+function useRevealIntoView<T extends HTMLElement>(active: boolean) {
+  const ref = useRef<T>(null);
+  useEffect(() => {
+    if (!active) return;
+    const raf = requestAnimationFrame(() => {
+      ref.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'nearest' });
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [active]);
+  return ref;
+}
+
+const BUTTON_BASE =
+  'inline-flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50';
+
+interface ApprovalCardProps {
+  proposal: ToolApprovalProposal;
+  decision: ToolApprovalDecision | undefined;
+  onDecide: (decision: ToolApprovalDecision) => void;
+  disabled?: boolean;
+  t: (key: string) => string;
+}
+
+/**
+ * One proposed call: what the agent wants to run, what it does, and every
+ * argument labelled with the tool's own description of it.
+ *
+ * Those descriptions are the difference between a control and a rubber stamp.
+ * `cascade: true` is unjudgeable; "cascade — also delete linked entities" is a
+ * decision someone can actually make.
+ */
+const ApprovalCard = ({ proposal, decision, onDecide, disabled, t }: ApprovalCardProps) => {
+  // Declining asks why before it sends. With argument editing deliberately
+  // absent, a rejection IS the correction channel — it is the agent's only
+  // signal to adapt. Optional, so a reviewer with nothing to add just confirms.
+  const [rejecting, setRejecting] = useState(false);
+  const [reason, setReason] = useState('');
+  const rejectPanelRef = useRevealIntoView<HTMLDivElement>(rejecting);
+
+  const verdict = decision?.verdict;
+  const argumentNames = Object.keys(proposal.arguments ?? {});
+
+  const decide = (next: ToolApprovalVerdict) => {
+    onDecide({
+      toolCallId: proposal.toolCallId,
+      verdict: next,
+      ...(next === 'reject' && reason.trim() ? { rejectionReason: reason.trim() } : {}),
+    });
+  };
+
+  return (
+    <div className="rounded-lg border border-amber-500/25 bg-amber-500/[0.04] p-3 flex flex-col gap-2">
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0 flex items-start gap-2">
+          <WrenchIcon size={13} className="mt-0.5 shrink-0 text-amber-600 dark:text-amber-400" />
+          <div className="min-w-0">
+            <p className="truncate font-mono text-xs text-gray-800 dark:text-white/85">{proposal.toolName}</p>
+            {proposal.toolDescription && <p className="mt-0.5 text-[0.7rem] text-gray-600 dark:text-white/60">{proposal.toolDescription}</p>}
+            {proposal.source && <p className="mt-0.5 text-[0.65rem] text-gray-400 dark:text-white/35">{proposal.source}</p>}
+          </div>
+        </div>
+        {verdict && (
+          <span
+            className={
+              'shrink-0 rounded px-1.5 py-0.5 text-[0.65rem] font-medium ' +
+              (verdict === 'reject' ? 'bg-red-500/15 text-red-600 dark:text-red-300' : 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-300')
+            }
+          >
+            {verdict === 'reject' ? t('Declined') : verdict === 'approve_always' ? t('Always allowed') : t('Approved')}
+          </span>
+        )}
+      </div>
+
+      {argumentNames.length > 0 && (
+        <div className="flex flex-col gap-1.5">
+          {argumentNames.map((name) => {
+            const schema = argumentSchema(proposal.inputSchema, name);
+            return (
+              <div key={name} className="text-[0.7rem]">
+                <div className="flex flex-wrap items-baseline gap-1.5">
+                  <span className="font-mono text-gray-700 dark:text-white/75">{name}</span>
+                  {schema.description && <span className="text-gray-500 dark:text-white/45">— {schema.description}</span>}
+                </div>
+                <pre className="mt-0.5 whitespace-pre-wrap break-all font-mono text-gray-600 dark:text-white/60">
+                  {formatValue(proposal.arguments?.[name])}
+                </pre>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {!verdict && rejecting && (
+        <div ref={rejectPanelRef} className="flex flex-col gap-1.5">
+          <label className="text-[0.7rem] text-gray-500 dark:text-white/45">{t('Why not? The agent sees this and can adapt (optional)')}</label>
+          <textarea
+            autoFocus
+            rows={2}
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            placeholder={t('e.g. wrong environment — use staging instead')}
+            className="w-full resize-none rounded-md border border-gray-200 bg-white px-2 py-1 text-[0.7rem] text-gray-800 outline-none focus:border-[var(--chat-accent)]/50 dark:border-white/10 dark:bg-white/[0.03] dark:text-white/85"
+          />
+          <div className="flex items-center gap-1.5">
+            <button
+              type="button"
+              disabled={disabled}
+              onClick={() => decide('reject')}
+              className={`${BUTTON_BASE} bg-red-500/10 text-red-600 hover:bg-red-500/20 dark:text-red-300`}
+            >
+              <XCircleIcon size={13} />
+              {t('Decline this call')}
+            </button>
+            <button
+              type="button"
+              disabled={disabled}
+              onClick={() => {
+                setRejecting(false);
+                setReason('');
+              }}
+              className={`${BUTTON_BASE} text-gray-500 hover:bg-gray-100 dark:text-white/50 dark:hover:bg-white/5`}
+            >
+              {t('Back')}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {!verdict && !rejecting && (
+        <div className="flex flex-wrap items-center gap-1.5">
+          <button
+            type="button"
+            disabled={disabled}
+            onClick={() => setRejecting(true)}
+            className={`${BUTTON_BASE} text-red-600 hover:bg-red-500/10 dark:text-red-300`}
+          >
+            <XCircleIcon size={13} />
+            {t('No')}
+          </button>
+          <button
+            type="button"
+            disabled={disabled}
+            onClick={() => decide('approve')}
+            className={`${BUTTON_BASE} bg-[var(--chat-accent)] text-white hover:opacity-90`}
+          >
+            <CheckIcon size={13} />
+            {t('Yes')}
+          </button>
+          <button
+            type="button"
+            disabled={disabled}
+            onClick={() => decide('approve_always')}
+            /* Disclosed on the control itself rather than buried in a tooltip:
+               this is the one verdict whose effect outlives the turn. */
+            title={t('Also applies to your scheduled runs, until you revoke it')}
+            className={`${BUTTON_BASE} border border-gray-200 text-gray-700 hover:bg-gray-100 dark:border-white/15 dark:text-white/70 dark:hover:bg-white/5`}
+          >
+            {t('Yes, always')}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+/**
+ * Collects a verdict for every call a paused turn is waiting on.
+ *
+ * Submission is all-or-nothing because the backend requires it: resuming with
+ * an undecided call would leave its `tool_use` block without a `tool_result`,
+ * which the model providers reject outright. That condition is met the moment
+ * the last card is decided, so the set submits itself there — a verdict is
+ * final once clicked (a decided card shows a badge, not buttons), so a separate
+ * confirm would gate work already committed to.
+ *
+ * "Yes, always" is the exception and the only click that earns a confirm step:
+ * it saves a standing preference for this user that applies to unattended runs
+ * too, and that has to be read before it is committed.
+ */
+export const ChatApprovalPrompt = ({ proposals, onSubmit, isSubmitting, error, t }: ChatApprovalPromptProps) => {
+  const [decisions, setDecisions] = useState<Record<string, ToolApprovalDecision>>({});
+  // Guards the auto-submit against a double fire: React may re-render between
+  // the last verdict and the parent flipping `isSubmitting`, and answering the
+  // same pause twice would decide a turn that is already resuming.
+  const submitted = useRef(false);
+  // The same fact as state, because a ref cannot re-render the footer button.
+  const [sent, setSent] = useState(false);
+
+  // A failed submission is the one case where the prompt survives its own send:
+  // the turn is still paused, so the controls have to come back for a retry.
+  useEffect(() => {
+    if (!error) return;
+    submitted.current = false;
+    setSent(false);
+  }, [error]);
+
+  const busy = isSubmitting || sent;
+
+  const submit = (all: ToolApprovalDecision[]) => {
+    if (submitted.current || isSubmitting) return;
+    submitted.current = true;
+    setSent(true);
+    onSubmit(all);
+  };
+
+  const decidedCount = proposals.filter((p) => decisions[p.toolCallId]).length;
+  const allDecided = decidedCount === proposals.length && proposals.length > 0;
+  const willRunAlways = Object.values(decisions).some((d) => d.verdict === 'approve_always');
+
+  // The warning and the confirm sit *below* the cards, so an "always" click can
+  // push them past the fold — exactly what must be read before confirming.
+  const footerRef = useRevealIntoView<HTMLDivElement>(willRunAlways);
+  // The prompt arrives at the bottom of a thread that just grew by a whole
+  // turn. Always true: the mount is the reveal.
+  const rootRef = useRevealIntoView<HTMLDivElement>(true);
+
+  return (
+    <div ref={rootRef} className="flex flex-col gap-2 rounded-lg border border-amber-500/20 bg-amber-500/[0.02] p-3">
+      <p className="flex items-start gap-1.5 text-xs font-medium text-amber-700 dark:text-amber-300">
+        <AlertTriangleIcon size={13} className="mt-0.5 shrink-0" />
+        {proposals.length === 1 ? t('The agent needs your approval to run a tool:') : t('The agent needs your approval to run these tools:')}
+      </p>
+
+      {proposals.map((proposal) => (
+        <ApprovalCard
+          key={proposal.toolCallId}
+          proposal={proposal}
+          decision={decisions[proposal.toolCallId]}
+          disabled={busy}
+          t={t}
+          onDecide={(decision) => {
+            const next = { ...decisions, [decision.toolCallId]: decision };
+            setDecisions(next);
+            // Safe to read `decisions` from the closure: each verdict is its
+            // own click, so this handler always sees the state the previous
+            // one set.
+            const all = proposals.map((p) => next[p.toolCallId]);
+            if (all.every(Boolean) && !all.some((d) => d.verdict === 'approve_always')) {
+              submit(all);
+            }
+          }}
+        />
+      ))}
+
+      {willRunAlways && (
+        <p className="flex items-start gap-1.5 text-[0.7rem] text-amber-700 dark:text-amber-300/90">
+          <AlertTriangleIcon size={13} className="mt-0.5 shrink-0" />
+          {t(
+            '“Yes, always” saves a preference for you. That tool will then run without asking — including on scheduled runs nobody is watching — until you revoke it.',
+          )}
+        </p>
+      )}
+
+      {error && <p className="text-[0.7rem] text-red-600 dark:text-red-300">{error}</p>}
+
+      <div ref={footerRef} className="flex items-center justify-between gap-2">
+        {/* The counter earns its place only when there is more than one thing
+            to count; on a single proposal it reads as a progress bar for a
+            one-step process. */}
+        <span className="text-[0.7rem] text-gray-500 dark:text-white/40">
+          {proposals.length > 1 ? `${decidedCount}/${proposals.length} ${t('decided')}` : ''}
+        </span>
+        <button
+          type="button"
+          disabled={!allDecided || busy}
+          onClick={() => submit(proposals.map((p) => decisions[p.toolCallId]))}
+          className={`${BUTTON_BASE} bg-[var(--chat-accent)] text-white hover:opacity-90`}
+        >
+          {busy ? t('Sending…') : t('Confirm')}
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/packages/filigran-chatbot/src/components/ChatApprovalPrompt.tsx
+++ b/packages/filigran-chatbot/src/components/ChatApprovalPrompt.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useId, useRef, useState } from 'react';
 import type { ToolApprovalDecision, ToolApprovalProposal, ToolApprovalVerdict } from '../types';
 import { AlertTriangleIcon, CheckIcon, WrenchIcon, XCircleIcon } from './icons';
 
@@ -95,6 +95,9 @@ const ApprovalCard = ({ proposal, decision, onDecide, disabled, t }: ApprovalCar
   // signal to adapt. Optional, so a reviewer with nothing to add just confirms.
   const [rejecting, setRejecting] = useState(false);
   const [reason, setReason] = useState('');
+  // Every proposal in a batch renders its own reason box, so the association
+  // needs an id unique to this card rather than a constant.
+  const reasonId = useId();
   const rejectPanelRef = useRevealIntoView<HTMLDivElement>(rejecting);
 
   const verdict = decision?.verdict;
@@ -152,8 +155,11 @@ const ApprovalCard = ({ proposal, decision, onDecide, disabled, t }: ApprovalCar
 
       {!verdict && rejecting && (
         <div ref={rejectPanelRef} className="flex flex-col gap-1.5">
-          <label className="text-[0.7rem] text-gray-500 dark:text-white/45">{t('Why not? The agent sees this and can adapt (optional)')}</label>
+          <label htmlFor={reasonId} className="text-[0.7rem] text-gray-500 dark:text-white/45">
+            {t('Why not? The agent sees this and can adapt (optional)')}
+          </label>
           <textarea
+            id={reasonId}
             autoFocus
             rows={2}
             value={reason}

--- a/packages/filigran-chatbot/src/components/ChatMessages.tsx
+++ b/packages/filigran-chatbot/src/components/ChatMessages.tsx
@@ -1,7 +1,15 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import type { AgentStatusState, ChatAttachment, ChatMessage, MessageFeedback } from '../types';
+import type {
+  AgentStatusState,
+  ChatAttachment,
+  ChatMessage,
+  MessageFeedback,
+  ToolApprovalDecision,
+  ToolApprovalProposal,
+} from '../types';
 import { splitFileMarkers, stripFileMarkers } from '../utils';
 import { AlertTriangleIcon, CheckIcon, ChevronDownIcon, CopyIcon, DownloadIcon, FileIcon, InfoIcon, ThumbsDownIcon, ThumbsUpIcon } from './icons';
+import { ChatApprovalPrompt } from './ChatApprovalPrompt';
 import { ChatImage } from './ChatImage';
 import { ChatThinking } from './ChatThinking';
 import { MarkdownMessage } from './MarkdownMessage';
@@ -39,6 +47,22 @@ interface ChatMessagesProps {
   miniGameEnabled?: boolean;
   /** Enables the 👍/👎 affordance on completed assistant messages. */
   onMessageFeedback?: (messageId: string, feedback: MessageFeedback | null, message: ChatMessage) => void;
+  /**
+   * Tool calls the running turn has paused on, awaiting a decision. Rendered
+   * below the transcript, since the pause belongs to the turn rather than to
+   * any one bubble.
+   */
+  /**
+   * True while a turn answered after a reload is finishing without a stream.
+   * Rendered as the ordinary working indicator: from the user's side nothing
+   * about it is unusual, and a decision that visibly leads nowhere reads as a
+   * broken button.
+   */
+  isResumingAfterDecision?: boolean;
+  pendingApprovals?: ToolApprovalProposal[] | null;
+  onSubmitApprovalDecisions?: (decisions: ToolApprovalDecision[]) => void;
+  isSubmittingApproval?: boolean;
+  approvalError?: string | null;
   t: (key: string) => string;
 }
 
@@ -419,6 +443,11 @@ export const ChatMessages = ({
   requestHeaders,
   miniGameEnabled = true,
   onMessageFeedback,
+  isResumingAfterDecision,
+  pendingApprovals,
+  onSubmitApprovalDecisions,
+  isSubmittingApproval,
+  approvalError,
   t,
 }: ChatMessagesProps) => {
   const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -484,6 +513,10 @@ export const ChatMessages = ({
     }
   }
 
+  // Only a prompt something can actually answer counts: without a submit
+  // handler the controls would collect verdicts with nowhere to send them.
+  const awaitingApproval = !!pendingApprovals?.length && !!onSubmitApprovalDecisions;
+
   return (
     <div className="flex-1 overflow-y-auto px-4 py-3 flex flex-col gap-4 filigran-chat-scrollable">
       {hasEarlierMessages && (
@@ -504,6 +537,10 @@ export const ChatMessages = ({
         // An assistant message with no content yet is the "agent is working"
         // placeholder, replaced by the live status bubble.
         if (msg.role === 'assistant' && !msg.content && isStreamingMessage) {
+          // A turn paused for approval is not working, it is waiting on the
+          // person reading it — so the progress bubble (and the waiting game
+          // it grows into) gives way to the prompt rendered below.
+          if (awaitingApproval) return null;
           return (
             <div key={msg.id}>
               <ChatThinking agentStatus={agentStatus} logoIcon={logoIcon} t={t} miniGameEnabled={miniGameEnabled} />
@@ -528,6 +565,25 @@ export const ChatMessages = ({
           />
         );
       })}
+      {/* Not tied to a placeholder message like the streaming indicator: a
+          restore replaces the whole transcript on every poll, so there is no
+          bubble of ours left to hang it on. */}
+      {isResumingAfterDecision && !awaitingApproval && (
+        <ChatThinking agentStatus={agentStatus} logoIcon={logoIcon} t={t} miniGameEnabled={miniGameEnabled} />
+      )}
+      {awaitingApproval && (
+        <ChatApprovalPrompt
+          // A second pause in the same turn is a new question, not a continuation
+          // of the answered one: remounting drops the verdicts and the
+          // already-submitted guard the previous set left behind.
+          key={pendingApprovals!.map((p) => p.toolCallId).join('|')}
+          proposals={pendingApprovals!}
+          onSubmit={onSubmitApprovalDecisions!}
+          isSubmitting={isSubmittingApproval}
+          error={approvalError}
+          t={t}
+        />
+      )}
       <div ref={messagesEndRef} />
     </div>
   );

--- a/packages/filigran-chatbot/src/components/ChatMessages.tsx
+++ b/packages/filigran-chatbot/src/components/ChatMessages.tsx
@@ -48,17 +48,17 @@ interface ChatMessagesProps {
   /** Enables the 👍/👎 affordance on completed assistant messages. */
   onMessageFeedback?: (messageId: string, feedback: MessageFeedback | null, message: ChatMessage) => void;
   /**
-   * Tool calls the running turn has paused on, awaiting a decision. Rendered
-   * below the transcript, since the pause belongs to the turn rather than to
-   * any one bubble.
-   */
-  /**
    * True while a turn answered after a reload is finishing without a stream.
    * Rendered as the ordinary working indicator: from the user's side nothing
    * about it is unusual, and a decision that visibly leads nowhere reads as a
    * broken button.
    */
   isResumingAfterDecision?: boolean;
+  /**
+   * Tool calls the running turn has paused on, awaiting a decision. Rendered
+   * below the transcript, since the pause belongs to the turn rather than to
+   * any one bubble.
+   */
   pendingApprovals?: ToolApprovalProposal[] | null;
   onSubmitApprovalDecisions?: (decisions: ToolApprovalDecision[]) => void;
   isSubmittingApproval?: boolean;

--- a/packages/filigran-chatbot/src/components/ChatPanel.tsx
+++ b/packages/filigran-chatbot/src/components/ChatPanel.tsx
@@ -82,6 +82,12 @@ export const ChatPanel: FunctionComponent<ChatPanelProps> = ({
     contextUsage,
     transferredAgent,
     canSteer,
+    pendingApprovals,
+    isSubmittingApproval,
+    approvalError,
+    submitApprovalDecisions,
+    isResumingAfterDecision,
+    historyReloadNonce,
     historyLoadedRef,
     conversationIdRef,
     handleFileAdd,
@@ -499,6 +505,9 @@ export const ChatPanel: FunctionComponent<ChatPanelProps> = ({
     apiBaseUrl,
     apiEndpoints,
     backendType,
+    // Re-runs the restore when the hook asks for one — the only way a turn
+    // resumed without a stream can ever show its answer.
+    historyReloadNonce,
     historyLoadedRef,
     conversationIdRef,
     isMountedRef,
@@ -622,6 +631,11 @@ export const ChatPanel: FunctionComponent<ChatPanelProps> = ({
           requestHeaders={requestHeaders}
           miniGameEnabled={miniGameEnabled}
           onMessageFeedback={onMessageFeedback}
+          isResumingAfterDecision={isResumingAfterDecision}
+          pendingApprovals={pendingApprovals}
+          onSubmitApprovalDecisions={submitApprovalDecisions}
+          isSubmittingApproval={isSubmittingApproval}
+          approvalError={approvalError}
           t={t}
         />
       )}

--- a/packages/filigran-chatbot/src/components/ChatThinking.tsx
+++ b/packages/filigran-chatbot/src/components/ChatThinking.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import type { AgentStatusState, IconProps } from '../types';
 import {
+  AlertTriangleIcon,
   BrainIcon,
   DatabaseIcon,
   ExternalLinkIcon,
@@ -78,6 +79,12 @@ function resolveStatusVisual(agentStatus: AgentStatusState | null, t: (key: stri
       }
       return { label, StatusIcon, showDots: false };
     }
+    case 'awaiting_approval':
+      // Not progress: the turn has stopped and the stream is held open while a
+      // person decides. Shown only when the prompt itself is not rendered (a
+      // host wiring `ChatMessages` without a decision handler) — otherwise the
+      // prompt replaces this bubble entirely.
+      return { label: t('Waiting for your approval…'), StatusIcon: AlertTriangleIcon, showDots: false };
     case 'analyzing':
       return { label: t('Analyzing results…'), StatusIcon: SparklesIcon, showDots: false };
     case 'steering':

--- a/packages/filigran-chatbot/src/components/index.ts
+++ b/packages/filigran-chatbot/src/components/index.ts
@@ -1,4 +1,5 @@
 export { ChatPanel } from './ChatPanel';
+export { ChatApprovalPrompt } from './ChatApprovalPrompt';
 export { ChatToggleButton } from './ChatToggleButton';
 export { ChatHeader } from './ChatHeader';
 export { ChatInput } from './ChatInput';

--- a/packages/filigran-chatbot/src/hooks/protocols/parseRestEvent.ts
+++ b/packages/filigran-chatbot/src/hooks/protocols/parseRestEvent.ts
@@ -1,4 +1,11 @@
-import type { ChatAttachment, ChatContextBreakdown, ChatContextUsage, ToolCallTraceEntry, TransferChainEntry } from '../../types';
+import type {
+  ChatAttachment,
+  ChatContextBreakdown,
+  ChatContextUsage,
+  ToolApprovalProposal,
+  ToolCallTraceEntry,
+  TransferChainEntry,
+} from '../../types';
 import type { ParsedAction, ProtocolContext } from './types';
 
 /** Wire key → the breakdown field it populates. */
@@ -122,6 +129,40 @@ export function parseTransferChain(raw: unknown): TransferChainEntry[] | undefin
 }
 
 /**
+ * Normalize the `proposals` array of an `approval_required` event.
+ *
+ * Only `tool_call_id` is load-bearing — it is what a decision is keyed on, so
+ * an entry without one could never be answered and is dropped. Everything else
+ * degrades: a proposal with no name still renders under a placeholder rather
+ * than vanishing, because a call silently hidden from the reviewer is a call
+ * that stalls the turn with nothing on screen to explain it.
+ *
+ * Returns `undefined` when nothing decidable is left, so the consumer can treat
+ * an unusable pause as one it must not claim to have prompted for.
+ */
+export function parseToolApprovalProposals(raw: unknown): ToolApprovalProposal[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const out: ToolApprovalProposal[] = [];
+  for (const item of raw) {
+    if (!item || typeof item !== 'object') continue;
+    const p = item as Record<string, unknown>;
+    const toolCallId = p.tool_call_id;
+    if (typeof toolCallId !== 'string' || !toolCallId) continue;
+    const args = p.arguments;
+    const schema = p.input_schema;
+    out.push({
+      toolCallId,
+      toolName: typeof p.tool_name === 'string' && p.tool_name ? p.tool_name : 'unknown tool',
+      toolDescription: typeof p.tool_description === 'string' ? p.tool_description : undefined,
+      arguments: args && typeof args === 'object' && !Array.isArray(args) ? (args as Record<string, unknown>) : {},
+      inputSchema: schema && typeof schema === 'object' && !Array.isArray(schema) ? (schema as Record<string, unknown>) : undefined,
+      source: typeof p.source === 'string' ? p.source : undefined,
+    });
+  }
+  return out.length > 0 ? out : undefined;
+}
+
+/**
  * Parse an XTM One (REST) SSE event into a normalized action.
  */
 export function parseRestEvent(evt: Record<string, unknown>, ctx: ProtocolContext): ParsedAction {
@@ -165,6 +206,20 @@ export function parseRestEvent(evt: Record<string, unknown>, ctx: ProtocolContex
       return { action: 'status', status: 'analyzing', contextUsage };
     }
     return { action: 'status', status: st, tools: evt.tools as string[] | undefined, contextUsage };
+  }
+
+  // The turn has paused on a gated tool call. Deliberately NOT terminal: the
+  // stream stays open (kept warm by SSE `: keepalive` comment lines, which the
+  // reader below drops as non-`data:` lines) and the rest of the turn arrives
+  // on it once a decision is POSTed back.
+  if (type === 'approval_required') {
+    const proposals = parseToolApprovalProposals(evt.proposals);
+    if (!proposals) return { action: 'noop' };
+    return {
+      action: 'approval_required',
+      proposals,
+      conversationId: typeof evt.conversation_id === 'string' ? evt.conversation_id : undefined,
+    };
   }
 
   if (type === 'stream') {

--- a/packages/filigran-chatbot/src/hooks/protocols/types.ts
+++ b/packages/filigran-chatbot/src/hooks/protocols/types.ts
@@ -1,4 +1,4 @@
-import type { ChatAttachment, ChatContextUsage, ToolCallTraceEntry, TransferChainEntry } from '../../types';
+import type { ChatAttachment, ChatContextUsage, ToolApprovalProposal, ToolCallTraceEntry, TransferChainEntry } from '../../types';
 
 /**
  * Normalized action produced by all protocol parsers.
@@ -40,6 +40,22 @@ export type ParsedAction =
       isTruncated?: boolean;
       /** Closing context-window occupancy for the turn. */
       contextUsage?: ChatContextUsage;
+    }
+  | {
+      /**
+       * The turn has stopped at a gated tool call and is holding the stream
+       * open, silent, until a decision is POSTed back. Not a terminal action:
+       * the same stream carries the rest of the turn once the answer arrives.
+       */
+      action: 'approval_required';
+      proposals: ToolApprovalProposal[];
+      /**
+       * The conversation the paused turn belongs to, as the backend knows it.
+       * Carried on the event because the very first turn of a fresh
+       * conversation has not yet learned its own id — that normally arrives on
+       * `done`, which a paused turn has not reached.
+       */
+      conversationId?: string;
     }
   | { action: 'error'; content: string }
   | { action: 'set_chat_id'; chatId: string }

--- a/packages/filigran-chatbot/src/hooks/useChat.ts
+++ b/packages/filigran-chatbot/src/hooks/useChat.ts
@@ -1,7 +1,17 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import type { AgentStatusState, ApiEndpoints, BackendType, ChatContextUsage, ChatFile, ChatMessage } from '../types';
+import type {
+  AgentStatusState,
+  ApiEndpoints,
+  BackendType,
+  ChatContextUsage,
+  ChatFile,
+  ChatMessage,
+  ToolApprovalDecision,
+  ToolApprovalProposal,
+} from '../types';
 import type { ParsedAction, ProtocolContext } from './protocols';
 import { parseAgUiEvent, parseLegacyEvent, parseRestEvent } from './protocols';
+import { parseToolApprovalProposals } from './protocols/parseRestEvent';
 
 const STORAGE_KEY = 'filigranChatConversationId';
 const LEGACY_CHAT_ID_KEY = 'filigranChatLegacyChatId';
@@ -38,6 +48,34 @@ function persistDraft(conversationId: string | null, value: string): void {
     /* ignore — see loadDraft */
   }
 }
+
+/**
+ * How often to check on a turn resumed by a decision made on a recovered
+ * (streamless) prompt, and the backstop that ends the watch regardless.
+ *
+ * Such a turn has no stream left to write to — the backend persists the answer
+ * and suppresses the live `done` frame — so the panel watches the pause-recovery
+ * route instead, which reports whether the turn is still running. That is a
+ * definite stop condition rather than a guess at how long an agent might take,
+ * and each poll doubles as the sign of life that keeps the turn from being
+ * abandoned. The deadline is only a backstop against a turn-state marker that
+ * somehow never clears; the ordinary end is the turn reporting itself idle.
+ */
+const RESUME_POLL_MS = 5000;
+const RESUME_WATCH_MS = 900000;
+
+/**
+ * How often to re-assert that somebody is still here while a recovered prompt
+ * is on screen.
+ *
+ * A paused turn gives up after 30 minutes with no sign of a client, and after a
+ * reload the stream that would have vouched for the reviewer is gone for good —
+ * so presence is inferred from requests about the conversation instead. A tab
+ * left open on the prompt IS a client present, but it makes no requests, so
+ * without this the turn would abandon a reviewer who is simply taking their
+ * time. Well inside the server's window, since missing it costs the whole turn.
+ */
+const APPROVAL_PRESENCE_INTERVAL_MS = 600000;
 
 /** Maximum number of files that can be attached to a single message. */
 const DEFAULT_MAX_FILE_COUNT = 10;
@@ -85,6 +123,39 @@ interface UseChatReturn {
    * the composer (accent Send next to Stop, "Enter to send now" copy).
    */
   canSteer: boolean;
+  /**
+   * Tool calls the running turn has stopped on, or `null` when nothing is
+   * waiting. While set, the turn is paused mid-answer: the stream is open and
+   * silent, and only a decision (or aborting the turn) moves it on.
+   */
+  pendingApprovals: ToolApprovalProposal[] | null;
+  /** True while a decision set is in flight to the approve endpoint. */
+  isSubmittingApproval: boolean;
+  /**
+   * Why the last decision submission failed, or `null`. Kept alongside the
+   * still-visible prompt rather than replacing it: the turn is paused either
+   * way, so the reviewer needs the retry as much as the explanation.
+   */
+  approvalError: string | null;
+  /**
+   * Answer a paused turn. Every proposed call must appear exactly once — the
+   * backend refuses a partial set, because resuming with an undecided call
+   * leaves a `tool_use` block without its `tool_result`, which the model
+   * providers reject outright.
+   */
+  submitApprovalDecisions: (decisions: ToolApprovalDecision[]) => Promise<void>;
+  /**
+   * True while waiting for the answer to a decision made on a recovered prompt.
+   * The turn resumed without a stream to report on, so the panel shows the
+   * working indicator itself and re-reads the conversation until the answer
+   * lands.
+   */
+  isResumingAfterDecision: boolean;
+  /**
+   * Bumped whenever the conversation must be re-read from the server. The panel
+   * owns the restore, so this is how the hook asks for one.
+   */
+  historyReloadNonce: number;
   historyLoadedRef: React.MutableRefObject<boolean>;
   /**
    * Ref mirror of {@link conversationId}, always current across async
@@ -143,6 +214,8 @@ function buildRequestBody(
     conversationId: string | null;
     agentSlug: string | null | undefined;
     pageContext?: Record<string, unknown>;
+    /** See {@link ApiEndpoints.approve} — derived, never a prop of its own. */
+    supportsToolApproval?: boolean;
   },
 ): Record<string, unknown> {
   switch (backendType) {
@@ -160,6 +233,15 @@ function buildRequestBody(
       };
     default: {
       const body: Record<string, unknown> = { content, conversation_id: opts.conversationId, agent_slug: opts.agentSlug };
+      // Tell the backend this turn may pause on a gated tool call and that we
+      // will answer. Sent only when the host named an approve path, because
+      // the flag is a promise: a backend that pauses waits indefinitely, so a
+      // client that cannot answer must never claim it can. Omitted rather than
+      // sent false, so a proxy that rebuilds the body from a fixed field list
+      // drops nothing meaningful.
+      if (opts.supportsToolApproval) {
+        body.supports_tool_approval = true;
+      }
       // Forward arbitrary host page context (e.g. current URL) so the agent
       // knows where the user is. Omitted when empty to keep payloads lean.
       // Guard serialization: the whole body is later JSON.stringify'd, so a
@@ -211,6 +293,18 @@ export function useChat({
   // state rather than per-message: it describes what the NEXT turn will carry,
   // which is the only thing the user can still act on.
   const [contextUsage, setContextUsage] = useState<ChatContextUsage | null>(null);
+  // Tool calls the running turn is paused on. Conversation-level rather than
+  // per-message: the pause belongs to the turn, not to any one bubble, and the
+  // prompt outlives the segment that was streaming when it arrived.
+  const [pendingApprovals, setPendingApprovals] = useState<ToolApprovalProposal[] | null>(null);
+  const [isSubmittingApproval, setIsSubmittingApproval] = useState(false);
+  const [approvalError, setApprovalError] = useState<string | null>(null);
+  // A prompt recovered after a reload is answered the same way, but resumes
+  // differently: there is no stream left to carry the rest of the turn.
+  const [isResumingAfterDecision, setIsResumingAfterDecision] = useState(false);
+  const [historyReloadNonce, setHistoryReloadNonce] = useState(0);
+  // Drives the resume watch's next poll: each tick re-arms the effect.
+  const [resumeTick, setResumeTick] = useState(0);
   const [legacyChatId, setLegacyChatId] = useState<string | null>(() => {
     if (typeof window === 'undefined') return null;
     return localStorage.getItem(LEGACY_CHAT_ID_KEY);
@@ -221,10 +315,29 @@ export function useChat({
   const hasUsedToolsRef = useRef(false);
   // Ref mirror of conversationId — always current across async boundaries
   const conversationIdRef = useRef(conversationId);
+  // Ref mirror of isLoading, so the recovery probe can tell at apply time
+  // whether a live turn has started owning the prompt since it was issued.
+  const isLoadingRef = useRef(isLoading);
+  isLoadingRef.current = isLoading;
   // Ref mirror of pageContext so the value sent reflects the page the user is
   // on at send time, regardless of when the send handler closure was created.
   const pageContextRef = useRef(pageContext);
   pageContextRef.current = pageContext;
+  // Conversation id as the paused turn itself reported it. The decision POST
+  // needs an id, and the first turn of a fresh conversation has none yet —
+  // `conversationId` is normally learned from `done`, which a paused turn has
+  // by definition not reached. Kept separate from `conversationIdRef` rather
+  // than adopted into it: a pause should not quietly switch on the affordances
+  // (steering, history) that having an id unlocks.
+  const approvalConversationIdRef = useRef<string | null>(null);
+  // True when the pending prompt was recovered from the server rather than read
+  // off a live stream — the turn is running, but nothing is listening to it.
+  const approvalDetachedRef = useRef(false);
+  // Conversations already asked about a pause, so the recovery probe runs once
+  // per conversation instead of on every render that settles.
+  const probedConversationRef = useRef<string | null>(null);
+  // When the resume watch stops regardless of what the turn reports.
+  const resumeDeadlineRef = useRef(0);
   // Mutex to prevent concurrent session creation
   const creatingSessionRef = useRef<Promise<string | null> | null>(null);
   // Abort controller for in-flight file uploads (cancelled on new chat)
@@ -249,6 +362,73 @@ export function useChat({
     }
     return `${apiBaseUrl}${apiEndpoints?.steer ?? '/chat/messages/steer'}`;
   };
+
+  /**
+   * Determine the tool-approval endpoint URL, or null when this host has not
+   * opted in.
+   *
+   * Unlike its siblings there is no default path — see {@link ApiEndpoints.approve}.
+   * Whether this returns a URL is exactly what decides if the widget advertises
+   * `supports_tool_approval`, so "configured" and "able to answer" are the same
+   * fact rather than two that can drift apart.
+   */
+  const getApproveUrl = (): string | null => {
+    if (isLegacy || backendType === 'ag-ui' || apiEndpoints?.singleEndpoint) return null;
+    const path = apiEndpoints?.approve;
+    if (!path) return null;
+    return `${apiBaseUrl}${path}`;
+  };
+
+  /**
+   * Determine the pause-recovery URL for one conversation, or null when the
+   * host has not exposed the route. See {@link ApiEndpoints.pendingApprovals}.
+   */
+  const getPendingApprovalsUrl = (convId: string): string | null => {
+    if (isLegacy || backendType === 'ag-ui' || apiEndpoints?.singleEndpoint) return null;
+    const base = apiEndpoints?.pendingApprovals;
+    if (!base) return null;
+    return `${apiBaseUrl}${base}/${convId}/pending-approvals`;
+  };
+
+  /**
+   * Read what a conversation is paused on, and whether its turn is still going.
+   *
+   * One request serves three purposes: recovering a prompt the page never saw,
+   * telling a resumed turn's watcher when to stop, and counting as the sign of
+   * life that keeps a paused turn from being abandoned. Returns null on any
+   * failure — every caller treats that as "learned nothing" and tries again or
+   * leaves the panel as it was.
+   */
+  const readPendingApprovals = async (convId: string): Promise<{ proposals?: ToolApprovalProposal[]; turnRunning: boolean } | null> => {
+    const url = getPendingApprovalsUrl(convId);
+    if (!url) return null;
+    try {
+      const res = await fetch(url, { headers: { ...(requestHeaders ?? {}) } });
+      if (!res.ok) return null;
+      const data = await res.json();
+      return {
+        proposals: parseToolApprovalProposals(data?.proposals),
+        // Anything but an explicit `running` ends the watch. A backend that
+        // omits the field is one that cannot say, and waiting forever on a
+        // turn nobody can report on is the worse failure.
+        turnRunning: data?.turn === 'running',
+      };
+    } catch {
+      return null;
+    }
+  };
+
+  /**
+   * Ask the panel to re-read the conversation from the server.
+   *
+   * Clearing the guard alone would not do it — the restore effect lives in the
+   * panel and only re-runs when something in its dependencies changes, which is
+   * what the nonce is for.
+   */
+  const reloadHistory = useCallback(() => {
+    historyLoadedRef.current = false;
+    setHistoryReloadNonce((n) => n + 1);
+  }, []);
 
   // Determine upload endpoint URL (null disables file upload proxying)
   const getUploadUrl = (): string | null => {
@@ -473,6 +653,77 @@ export function useChat({
     }
   };
 
+  /**
+   * Answer a turn that paused on a gated tool call.
+   *
+   * The decision travels the same way a steering message does — a POST beside
+   * the open stream — and for the same reason: the turn is still running, so
+   * the answer cannot ride on a new one. The paused turn is polling for it and
+   * resumes on the stream that is already open, with no lost context.
+   *
+   * Deliberately not carried on the turn's own AbortController: the two are
+   * independent requests, and aborting the turn must not look like a decision.
+   *
+   * A failure leaves the prompt on screen. The alternative — clearing it —
+   * would strand the turn paused with nothing to answer it, which is the exact
+   * state this whole opt-in exists to avoid.
+   */
+  const submitApprovalDecisions = async (decisions: ToolApprovalDecision[]) => {
+    const approveUrl = getApproveUrl();
+    const convId = approvalConversationIdRef.current ?? conversationIdRef.current;
+    if (!approveUrl || !convId || decisions.length === 0) return;
+
+    setApprovalError(null);
+    setIsSubmittingApproval(true);
+    try {
+      const res = await fetch(approveUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...(requestHeaders ?? {}) },
+        body: JSON.stringify({
+          conversation_id: convId,
+          decisions: decisions.map((d) => ({
+            tool_call_id: d.toolCallId,
+            decision: d.verdict,
+            // Only ever sent with a rejection, and only when the reviewer
+            // actually wrote something — an empty string reaches the agent as
+            // a reason that says nothing.
+            ...(d.verdict === 'reject' && d.rejectionReason ? { rejection_reason: d.rejectionReason } : {}),
+          })),
+        }),
+      });
+      if (res.ok) {
+        setPendingApprovals(null);
+        if (approvalDetachedRef.current) {
+          // Answered after a reload: the turn resumes, but the stream it would
+          // have reported on died with the old page. The backend persists the
+          // answer and suppresses the live `done`, so re-reading the
+          // conversation is the only way it can ever appear — and without this
+          // the click would look like it did nothing at all.
+          approvalDetachedRef.current = false;
+          resumeDeadlineRef.current = Date.now() + RESUME_WATCH_MS;
+          setIsResumingAfterDecision(true);
+          return;
+        }
+        // The turn is moving again; show that immediately rather than leaving
+        // the composer looking idle until the next server event lands.
+        setAgentStatus((prev) => (prev ? { ...prev, status: 'thinking' } : { status: 'thinking' }));
+        return;
+      }
+      // 409: nothing is waiting any more — the turn finished, was cancelled, or
+      // somebody else answered it. Distinguished from a transient failure
+      // because retrying cannot help; the stream ending clears the prompt.
+      setApprovalError(
+        res.status === 409
+          ? t('This turn is no longer waiting for a decision.')
+          : t('Could not send your decision. Please try again.'),
+      );
+    } catch {
+      setApprovalError(t('Could not send your decision. Please try again.'));
+    } finally {
+      setIsSubmittingApproval(false);
+    }
+  };
+
   const handleSendMessage = async () => {
     const steerText = inputValue.trim();
     if (isLoading) {
@@ -529,6 +780,7 @@ export function useChat({
         conversationId: conversationIdRef.current,
         agentSlug,
         pageContext: pageContextRef.current,
+        supportsToolApproval: getApproveUrl() !== null,
       });
       if (fileIds.length > 0) {
         (requestBody as Record<string, unknown>).file_ids = fileIds;
@@ -656,6 +908,11 @@ export function useChat({
 
               case 'done': {
                 doneReceived = true;
+                // A completed segment cannot still be waiting on a decision, so
+                // any prompt left standing (a submission that failed against a
+                // turn somebody else already answered) is stale.
+                setPendingApprovals(null);
+                setApprovalError(null);
                 if (parsed.conversationId) {
                   updateConversationId(parsed.conversationId);
                 }
@@ -685,6 +942,22 @@ export function useChat({
                       : m,
                   ),
                 );
+                break;
+              }
+
+              case 'approval_required': {
+                // The turn stops here and the stream goes silent until a
+                // decision is POSTed back. Not an end state: no segment is
+                // opened or closed, `isLoading` stays true, and the rest of
+                // the turn arrives on this same reader afterwards.
+                approvalConversationIdRef.current = parsed.conversationId ?? conversationIdRef.current;
+                setApprovalError(null);
+                setPendingApprovals(parsed.proposals);
+                // Keep whatever reasoning the turn had already streamed: the
+                // pause interrupts the turn, it does not start a new one, and
+                // the prose leading up to the proposed call is exactly the
+                // context the reviewer is about to judge it on.
+                setAgentStatus((prev) => (prev ? { ...prev, status: 'awaiting_approval' } : { status: 'awaiting_approval' }));
                 break;
               }
 
@@ -729,6 +1002,16 @@ export function useChat({
       setIsLoading(false);
       setAgentStatus(null);
       hasUsedToolsRef.current = false;
+      // The stream is gone, so nothing can carry a decision any more —
+      // whether the turn finished, errored, or was stopped. Leaving the prompt
+      // up would offer an answer to a question nobody is listening for.
+      setPendingApprovals(null);
+      setApprovalError(null);
+      approvalConversationIdRef.current = null;
+      approvalDetachedRef.current = false;
+      // We watched this turn end, so there is nothing for the recovery probe to
+      // find — including on a fresh conversation, whose id only just arrived.
+      probedConversationRef.current = conversationIdRef.current;
     }
   };
 
@@ -749,6 +1032,13 @@ export function useChat({
     // the restore or the first turn fills it back in. Carrying the previous
     // conversation's reading over would be a plain lie.
     setContextUsage(null);
+    setPendingApprovals(null);
+    setApprovalError(null);
+    setIsResumingAfterDecision(false);
+    approvalConversationIdRef.current = null;
+    approvalDetachedRef.current = false;
+    // Re-arm the probe: the conversation being switched to may well be paused.
+    probedConversationRef.current = null;
     hasUsedToolsRef.current = false;
     historyLoadedRef.current = false;
     if (isLegacy) {
@@ -780,6 +1070,14 @@ export function useChat({
     setIsLoading(false);
     setAgentStatus(null);
     hasUsedToolsRef.current = false;
+    // Stopping IS the way out of a pause the reviewer does not want to answer:
+    // the backend waits indefinitely by design, so abandoning the stream is
+    // the client's only other move.
+    setPendingApprovals(null);
+    setApprovalError(null);
+    setIsResumingAfterDecision(false);
+    approvalConversationIdRef.current = null;
+    approvalDetachedRef.current = false;
     setMessages((prev) => prev.filter((m) => !(m.role === 'assistant' && !m.content)));
   };
 
@@ -804,6 +1102,138 @@ export function useChat({
     [],
   );
 
+  /**
+   * Recover a prompt the page never saw, or lost to a reload.
+   *
+   * `approval_required` is one event on one stream: reload while it is showing
+   * and the panel holds nothing — not even the `tool_call_id`s a decision has
+   * to name — while the turn goes on waiting for an answer that can no longer
+   * be given. Asked once per conversation; an empty list is the ordinary
+   * answer, and the whole probe is best-effort, since a host that has not
+   * exposed the route simply keeps the pre-recovery behaviour.
+   *
+   * Skipped while a turn is live: that prompt arrives on the stream, and the
+   * stream is the more current of the two.
+   */
+  useEffect(() => {
+    const convId = conversationId;
+    if (!convId || isLoading) return;
+    if (probedConversationRef.current === convId) return;
+    // Recovering a prompt there is no way to answer would only strand the
+    // reviewer differently, so both routes have to be configured.
+    const url = getPendingApprovalsUrl(convId);
+    if (!url || !getApproveUrl()) return;
+    probedConversationRef.current = convId;
+
+    (async () => {
+      // Best-effort: a failure leaves the panel exactly as it was, which is the
+      // pre-recovery behaviour.
+      const state = await readPendingApprovals(convId);
+      if (!state?.proposals) return;
+      // Validate at apply time against the live refs rather than dropping the
+      // response on effect teardown — the same reasoning as the panel's
+      // history restore. A StrictMode double-invoke or a host re-render tears
+      // this effect down while the request is in flight without the
+      // conversation having changed, and a teardown flag would discard the
+      // recovery in exactly the case it is needed. Only a genuinely superseded
+      // response is dropped: another conversation, or a live turn that has
+      // since started and will carry its own prompt.
+      if (conversationIdRef.current !== convId || isLoadingRef.current) return;
+      approvalConversationIdRef.current = convId;
+      approvalDetachedRef.current = true;
+      setApprovalError(null);
+      setPendingApprovals(state.proposals);
+    })();
+    // Keyed on the conversation and whether a turn is live; the endpoint
+    // getters read current props on each run and must not re-trigger a probe.
+  }, [conversationId, isLoading]);
+
+  /**
+   * Keep a recovered prompt answerable for as long as it is displayed.
+   *
+   * Only for prompts recovered after a reload: a live one is held open by its
+   * own stream, which vouches for the reviewer on its own. Re-reading the
+   * pending approvals is the lightest request that counts as a sign of life,
+   * and its result is deliberately ignored — this is a heartbeat, not a poll,
+   * and a prompt that has since gone stale is better answered with the 409 the
+   * reviewer can see than made to vanish under them.
+   */
+  useEffect(() => {
+    if (!pendingApprovals?.length || !approvalDetachedRef.current) return;
+    const convId = approvalConversationIdRef.current;
+    const url = convId ? getPendingApprovalsUrl(convId) : null;
+    if (!url) return;
+    const id = window.setInterval(() => {
+      fetch(url, { headers: { ...(requestHeaders ?? {}) } }).catch(() => {
+        /* A missed heartbeat is survivable: the next one is well inside the
+           server's window. */
+      });
+    }, APPROVAL_PRESENCE_INTERVAL_MS);
+    return () => window.clearInterval(id);
+    // Re-armed whenever the prompt itself changes; the endpoint getter reads
+    // current props on each run.
+  }, [pendingApprovals]);
+
+  /**
+   * Watch a turn resumed by a decision made on a recovered prompt.
+   *
+   * The turn has no stream left to announce itself on, so its state is read
+   * from the pause-recovery route: keep watching while it reports `running`,
+   * and re-read the conversation once — the answer is there — when it reports
+   * idle. Polling that route rather than the transcript is what makes the stop
+   * condition definite instead of a guess, and it keeps the turn alive as a
+   * side effect.
+   *
+   * A resumed turn can also pause *again* on a second gated call. With no
+   * stream, this poll is the only way that prompt could ever reach the user, so
+   * finding proposals puts the panel straight back into deciding.
+   */
+  useEffect(() => {
+    if (!isResumingAfterDecision) return;
+    const convId = approvalConversationIdRef.current;
+    if (!convId) {
+      setIsResumingAfterDecision(false);
+      return;
+    }
+    if (Date.now() >= resumeDeadlineRef.current) {
+      // Backstop only, for a turn-state marker that never clears. Re-read once
+      // on the way out so a finished answer still lands.
+      setIsResumingAfterDecision(false);
+      reloadHistory();
+      return;
+    }
+
+    let cancelled = false;
+    const id = window.setTimeout(async () => {
+      const state = await readPendingApprovals(convId);
+      if (cancelled) return;
+      if (!state) {
+        // Learned nothing — a transient failure. Try again rather than
+        // declaring a running turn finished.
+        setResumeTick((n) => n + 1);
+        return;
+      }
+      if (state.proposals) {
+        approvalDetachedRef.current = true;
+        setApprovalError(null);
+        setPendingApprovals(state.proposals);
+        setIsResumingAfterDecision(false);
+        return;
+      }
+      if (!state.turnRunning) {
+        setIsResumingAfterDecision(false);
+        reloadHistory();
+        return;
+      }
+      setResumeTick((n) => n + 1);
+    }, RESUME_POLL_MS);
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(id);
+    };
+  }, [isResumingAfterDecision, resumeTick, reloadHistory]);
+
   // Steering affordances are only advertised when the typed text can actually
   // be dispatched mid-run: a response is streaming (isLoading), the REST steer
   // endpoint is configured, and the conversation already has a server id (the
@@ -821,6 +1251,12 @@ export function useChat({
     contextUsage,
     transferredAgent,
     canSteer,
+    pendingApprovals,
+    isSubmittingApproval,
+    approvalError,
+    submitApprovalDecisions,
+    isResumingAfterDecision,
+    historyReloadNonce,
     historyLoadedRef,
     conversationIdRef,
     handleFileAdd,

--- a/packages/filigran-chatbot/src/hooks/useChat.ts
+++ b/packages/filigran-chatbot/src/hooks/useChat.ts
@@ -671,7 +671,20 @@ export function useChat({
   const submitApprovalDecisions = async (decisions: ToolApprovalDecision[]) => {
     const approveUrl = getApproveUrl();
     const convId = approvalConversationIdRef.current ?? conversationIdRef.current;
-    if (!approveUrl || !convId || decisions.length === 0) return;
+    // Nothing decided is a no-op, not a failure — the prompt only submits a
+    // full set, so this is unreachable from the UI.
+    if (decisions.length === 0) return;
+    // Missing prerequisites must be VISIBLE. The prompt is on screen, the turn
+    // is paused behind it, and a silent return would leave the reviewer
+    // clicking a control that does nothing — the exact failure this feature
+    // exists to prevent, reintroduced at the last step. Reachable if the host
+    // never named an approve path, or if a paused turn arrived without a
+    // conversation id on the first turn of a fresh conversation, where the id
+    // is otherwise only learned from `done`.
+    if (!approveUrl || !convId) {
+      setApprovalError(t('This decision could not be sent. Reload the chat and try again.'));
+      return;
+    }
 
     setApprovalError(null);
     setIsSubmittingApproval(true);

--- a/packages/filigran-chatbot/src/index.ts
+++ b/packages/filigran-chatbot/src/index.ts
@@ -15,6 +15,9 @@ export type {
   ChatPromptTemplate,
   ChatQuotaStatus,
   MessageFeedback,
+  ToolApprovalDecision,
+  ToolApprovalProposal,
+  ToolApprovalVerdict,
   XtmAgent,
   ApiEndpoints,
 } from './types';

--- a/packages/filigran-chatbot/src/types.ts
+++ b/packages/filigran-chatbot/src/types.ts
@@ -24,6 +24,46 @@ export interface ApiEndpoints {
    * disable mid-run steering entirely.
    */
   steer?: string | null;
+  /**
+   * Path for submitting tool-approval decisions when the agent pauses on a
+   * gated tool call. The widget POSTs
+   * `{ conversation_id, decisions: [{ tool_call_id, decision, rejection_reason }] }`
+   * and the paused turn resumes on the same stream with the tool result.
+   *
+   * **No default, unlike every sibling entry, and that is deliberate.** Setting
+   * this is what makes the widget advertise `supports_tool_approval` to the
+   * backend, and advertising it is a promise to answer: a backend that pauses a
+   * turn waits indefinitely for a decision, with no timeout and no safe default
+   * action to take on the reviewer's behalf. If this path defaulted to XTM
+   * One's own route, a host proxying the chat (OpenCTI, OpenAEV, OpenGRC) could
+   * upgrade the widget without adding the matching proxy route, claim support,
+   * receive the pause, POST the decision into a 404 — and hang the turn with
+   * the user watching a spinner.
+   *
+   * While unset the widget never claims support and the backend degrades to a
+   * plain assistant message explaining what it could not run, which is why an
+   * un-updated host keeps working untouched.
+   *
+   * REST backend only: `legacy` and `ag-ui` never meet this gate.
+   */
+  approve?: string | null;
+  /**
+   * Base path for recovering what a paused turn is still waiting on, read as
+   * `GET {apiBaseUrl}{pendingApprovals}/{conversation_id}/pending-approvals`
+   * (the same base-plus-suffix idiom as {@link ApiEndpoints.download}). XTM
+   * One serves it at `/chat/conversations`.
+   *
+   * `approval_required` is a single event on a stream, so a reload loses it —
+   * including the `tool_call_id`s a decision has to name. The turn is left
+   * waiting for an answer nobody can give, which reads as a chat that simply
+   * stopped replying. The panel therefore asks once per conversation on mount;
+   * an empty list is the ordinary answer.
+   *
+   * No default, for the same reason as {@link ApiEndpoints.approve}: a proxied
+   * host has to expose the route before the panel starts calling it. Unset, the
+   * live flow still works and only reload recovery is absent.
+   */
+  pendingApprovals?: string | null;
   /** Path for fetching agents. Default: '/chat/agents'. Set to null to disable. */
   agents?: string | null;
   /** Path for fetching session history. Default: '/chat/sessions'. Set to null to disable. */
@@ -99,6 +139,54 @@ export interface ChatQuotaStatus {
   limit: number | null;
   /** Human-readable period label, e.g. "monthly". */
   period: string;
+}
+
+/**
+ * One tool call the agent wants to make and is waiting on a human to approve.
+ *
+ * `inputSchema` travels alongside `arguments` so each value can be rendered
+ * with the tool's own description of what it means. That pairing is the whole
+ * point: `cascade: true` is unjudgeable on its own, while "cascade — also
+ * delete linked entities" is a decision someone can actually make. A prompt
+ * that shows names and values alone is a rubber stamp wearing the costume of a
+ * safety control.
+ */
+export interface ToolApprovalProposal {
+  /**
+   * Identity of the proposed call, and the key every decision is sent back on.
+   * Never the tool name: one turn can propose the same tool twice with
+   * different arguments.
+   */
+  toolCallId: string;
+  toolName: string;
+  toolDescription?: string;
+  arguments: Record<string, unknown>;
+  /** JSON Schema the arguments came from, used to label each one. */
+  inputSchema?: Record<string, unknown>;
+  /** Where the tool comes from, e.g. `integration:opencti`. */
+  source?: string;
+}
+
+/**
+ * A reviewer's verdict on one proposed call.
+ *
+ * There is deliberately no "edit the arguments" verdict. Rewriting a call under
+ * the agent's name would leave a transcript crediting it with arguments it
+ * never chose, and turn a yes/no judgement into authoring. A wrong proposal is
+ * corrected by rejecting it with a reason the agent can act on.
+ */
+export type ToolApprovalVerdict = 'approve' | 'approve_always' | 'reject';
+
+/** One decision, ready to be sent back to the paused turn. */
+export interface ToolApprovalDecision {
+  toolCallId: string;
+  verdict: ToolApprovalVerdict;
+  /**
+   * Why the call was declined. Optional, and the agent's only signal to correct
+   * itself — with argument editing gone, a rejection *is* the correction
+   * channel.
+   */
+  rejectionReason?: string;
 }
 
 /**

--- a/projects/filigran-chat-playground/src/App.tsx
+++ b/projects/filigran-chat-playground/src/App.tsx
@@ -230,6 +230,13 @@ const HostToolbarSlot = ({ onClick, active }: { onClick: () => void; active: boo
 const App = () => {
   const [isOpen, setIsOpen] = useState(false);
   const [mode, setMode] = useState<ChatMode>('floating');
+  // Whether this "host" claims it can answer a tool-approval prompt. Off is not
+  // a broken configuration — it is what every host that has not adopted
+  // approvals looks like, and the degraded path it selects (the turn ends with
+  // a plain message naming the tool) is the one that must keep working when XTM
+  // One ships gating. Worth being able to see side by side, so it is a switch
+  // rather than an edit.
+  const [supportsApproval, setSupportsApproval] = useState(true);
   const [isDark, setIsDark] = useState(true);
   const [log, setLog] = useState<LogEntry[]>([]);
   const [hostToolActive, setHostToolActive] = useState(false);
@@ -389,6 +396,27 @@ const App = () => {
                     </div>
                   </div>
 
+                  {/* Tool approval opt-in */}
+                  <div className="mb-4">
+                    <p className="text-sm text-gray-600 dark:text-white/50 mb-2">Tool approval:</p>
+                    <label className="flex items-start gap-2 text-sm text-gray-700 dark:text-white/70">
+                      <input
+                        type="checkbox"
+                        className="mt-0.5 accent-[#7b5cff]"
+                        checked={supportsApproval}
+                        onChange={(e) => setSupportsApproval(e.target.checked)}
+                      />
+                      <span>
+                        Host can answer approval prompts
+                        <span className="block text-xs text-gray-500 dark:text-white/40">
+                          {supportsApproval
+                            ? 'Sends supports_tool_approval — a gated tool pauses the turn and asks.'
+                            : 'Sends nothing — a gated tool ends the turn with a plain message instead. This is every host that has not adopted approvals.'}
+                        </span>
+                      </span>
+                    </label>
+                  </div>
+
                   {/* Open/close */}
                   <div>
                     <p className="text-sm text-gray-600 dark:text-white/50 mb-2">Panel:</p>
@@ -504,6 +532,18 @@ const App = () => {
             onModeChange={setMode}
             topOffset={HEADER_HEIGHT}
             apiBaseUrl="/api/xtmone"
+            // Tool approval is opt-in and has no default paths: naming them is
+            // how a host promises it can answer a paused turn, so a widget that
+            // cannot must never claim it. Both are plain passthroughs here —
+            // the dev server rewrites `/api/xtmone/*` onto XTM One's
+            // `/api/v1/platform/*` generically, so they need nothing of their
+            // own. Against the mock they simply 404 and the panel degrades,
+            // which is the un-opted-in behaviour every current host has.
+            apiEndpoints={
+              supportsApproval
+                ? { approve: '/chat/messages/approve', pendingApprovals: '/chat/conversations' }
+                : undefined
+            }
             agentDashboardUrl="https://xtm.example.com"
             user={{ firstName: session.state === 'signed-in' ? session.email.split('@')[0] : 'Tester' }}
             accentColor="#7b5cff"


### PR DESCRIPTION
Closes #385. Client half of `XTM-One-Platform/xtm-one#2941`, which names this package as a known consumer and pins the wire contract.

XTM One now requires a human's consent before an agent runs a tool that is not on a platform-wide whitelist. A conversation reaching one pauses mid-answer and cannot continue until somebody decides, so a panel with no way to collect that decision leaves the user with an agent that stopped replying and an administrator to chase.

`ChatApprovalPrompt` renders what the agent proposed and returns a verdict per call, over the channel the panel already has: the pause arrives as an `approval_required` event on the open SSE stream, the decision goes back as a POST beside it, and the same turn resumes with the tool result.

## Worth reviewing

- **`apiEndpoints.approve` and `apiEndpoints.pendingApprovals` have no defaults**, unlike every sibling entry. Setting `approve` is what makes the panel send `supports_tool_approval`, and that flag is a promise to answer — a paused backend waits indefinitely. A default path would let a proxied host claim support without routing it, POST the decision into a 404, and hang the turn with the user watching a spinner. Support is therefore derived from configuration rather than being a prop of its own.
- **Each argument renders next to its description from the tool's `input_schema`.** `cascade: true` is unjudgeable; "cascade — also delete linked entities" is a decision. Names and values alone would be a rubber stamp wearing the costume of a safety control.
- **Three verdicts, and no way to edit the proposed arguments.** Rewriting a call under the agent's name would leave a transcript crediting it with arguments it never chose, so a wrong proposal is corrected by declining it with a reason the agent receives and can adapt to.
- **Submission is all-or-nothing** because the backend requires it: an undecided call leaves a `tool_use` block without its `tool_result`, which the model providers reject outright. The set submits itself on the last verdict, except when it contains `approve_always` — the only decision whose reach outlives the turn, covering unattended scheduled runs — which waits behind a warning and an explicit confirm.
- **A failed submission keeps the prompt on screen** with the controls re-armed. The turn is still paused either way, and clearing it would strand it with nothing able to answer.

## Surviving a page reload

The prompt is one event on one stream, so a reload loses it along with the `tool_call_id`s a decision must name.

- The panel re-reads `pending-approvals` once per conversation on mount and on every switch, validating the response against live refs at apply time rather than dropping it on effect teardown — a StrictMode double-invoke would otherwise discard the recovery in the one case it exists for. Same reasoning as the panel's existing history restore.
- A decision on a recovered prompt resumes a turn whose stream is gone: the backend persists the answer and suppresses the live `done`. The panel shows its ordinary working indicator and polls the same route, using `turn` as the stop condition — `running` means keep waiting, `idle` means re-read the conversation once. An absent `turn` counts as idle, since a backend that cannot say should not be waited on forever.
- That poll also catches a resumed turn pausing **again** on a second gated call, which with no stream open is the only path back to the user.
- A displayed prompt heartbeats the same route every 10 minutes. Presence is inferred from requests, a paused turn is abandoned after 30 minutes with no sign of a client, and a tab left open on an undecided prompt makes no requests of its own.

## Compatibility

No coordinated release is required, in either direction.

- With both endpoints unset — every host today — the panel is unchanged and issues **no new requests**: `supports_tool_approval` is omitted rather than sent `false`, and the recovery probe never fires.
- Against an older XTM One, `PlatformChatRequest` has no `extra="forbid"`, so Pydantic ignores the unknown field rather than answering 422.
- REST backend only; `legacy` and `ag-ui` never meet this gate.

## Testing

Verified live against a local XTM One on `feat/173-per-tool-approval` through `projects/filigran-chat-playground`, which registers as a real platform and signs its own EdDSA JWTs — the same auth path OpenCTI and OpenAEV use. Exercised: a live prompt and its three verdicts, a reload mid-prompt and answering the recovered prompt through the streamless resume, and the degraded path with the opt-in switched off.

The playground needed only to opt in; its dev server already forwards bodies whole, streams chunk by chunk with an explicit flush, and sets no read timeout, so it meets everything the contract asks of a proxy. A Test Controls checkbox turns the opt-in back off so the un-adopted host's behaviour can be seen beside the interactive one.
