### PR TITLE
fix(ci): create the release version bump commit through the api (#387)

### DIFF
--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -174,33 +174,100 @@ jobs:
           echo "UI_ISSUES_TO_CLOSE=$UI_ISSUES" >> $GITHUB_ENV
           echo "ICON_ISSUES_TO_CLOSE=$ICON_ISSUES" >> $GITHUB_ENV
       - name: Commit version changes
+        id: commit
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const fs = require('fs');
+            const { execSync } = require('child_process');
+
+            const packages = [
+              { label: '@filigran/chatbot', version: process.env.FILIGRAN_CHATBOT_VERSION },
+              { label: '@filigran/ui', version: process.env.FILIGRAN_UI_VERSION },
+              { label: '@filigran/icon', version: process.env.FILIGRAN_ICON_VERSION },
+              { label: '@filigran/rich-text-editor', version: process.env.FILIGRAN_RTE_VERSION },
+            ].filter((pkg) => pkg.version);
+
+            if (packages.length === 0) {
+              console.log('No version changes to commit');
+              core.setOutput('committed', 'false');
+              return;
+            }
+
+            const git = (command) => execSync(command, { encoding: 'utf8' }).split('\n').filter(Boolean);
+
+            // `yarn version` touches more than the bumped package.json: it also realigns
+            // dependent workspaces' ranges and yarn.lock. Collect whatever actually changed
+            // rather than assuming, so the commit stays self-consistent.
+            const changed = [...new Set([
+              ...git('git diff --name-only HEAD'),
+              ...git('git ls-files --others --exclude-standard'),
+            ])];
+
+            if (changed.length === 0) {
+              console.log('Versions bumped but working tree is clean; nothing to commit');
+              core.setOutput('committed', 'false');
+              return;
+            }
+
+            console.log(`Changed files:\n${changed.map((path) => `  ${path}`).join('\n')}`);
+
+            const branch = context.ref.replace('refs/heads/', '');
+            const parent = process.env.GITHUB_SHA;
+            const message = `chore: bump ${packages.map((pkg) => `${pkg.label} to v${pkg.version}`).join(', ')}`;
+
+            // The default branch requires verified signatures, which a commit made on the
+            // runner cannot carry. Commits created through the API are signed by GitHub.
+            const parentCommit = await github.rest.git.getCommit({
+              ...context.repo,
+              commit_sha: parent,
+            });
+
+            const entries = [];
+            for (const path of changed) {
+              if (!fs.existsSync(path)) {
+                entries.push({ path, mode: '100644', type: 'blob', sha: null });
+                continue;
+              }
+              const blob = await github.rest.git.createBlob({
+                ...context.repo,
+                content: fs.readFileSync(path).toString('base64'),
+                encoding: 'base64',
+              });
+              const executable = (fs.statSync(path).mode & 0o111) !== 0;
+              entries.push({ path, mode: executable ? '100755' : '100644', type: 'blob', sha: blob.data.sha });
+            }
+
+            const tree = await github.rest.git.createTree({
+              ...context.repo,
+              base_tree: parentCommit.data.tree.sha,
+              tree: entries,
+            });
+
+            const commit = await github.rest.git.createCommit({
+              ...context.repo,
+              message,
+              tree: tree.data.sha,
+              parents: [parent],
+            });
+
+            // Not forced: if the branch moved since the run was dispatched, this fails
+            // rather than discarding whatever landed in between.
+            await github.rest.git.updateRef({
+              ...context.repo,
+              ref: `heads/${branch}`,
+              sha: commit.data.sha,
+            });
+
+            console.log(`Created ${commit.data.sha}: ${message}`);
+            core.setOutput('committed', 'true');
+            core.setOutput('sha', commit.data.sha);
+      - name: Sync checkout to the signed commit
+        if: steps.commit.outputs.committed == 'true'
         run: |
-          git add .
-          
-          PARTS=""
-          if [ -n "$FILIGRAN_CHATBOT_VERSION" ]; then
-            PARTS="@filigran/chatbot to v$FILIGRAN_CHATBOT_VERSION"
-          fi
-          if [ -n "$FILIGRAN_UI_VERSION" ]; then
-            [ -n "$PARTS" ] && PARTS="$PARTS, "
-            PARTS="${PARTS}@filigran/ui to v$FILIGRAN_UI_VERSION"
-          fi
-          if [ -n "$FILIGRAN_ICON_VERSION" ]; then
-            [ -n "$PARTS" ] && PARTS="$PARTS, "
-            PARTS="${PARTS}@filigran/icon to v$FILIGRAN_ICON_VERSION"
-          fi
-          if [ -n "$FILIGRAN_RTE_VERSION" ]; then
-            [ -n "$PARTS" ] && PARTS="$PARTS, "
-            PARTS="${PARTS}@filigran/rich-text-editor to v$FILIGRAN_RTE_VERSION"
-          fi
-          
-          if [ -z "$PARTS" ]; then
-            echo "No version changes to commit"
-            exit 0
-          fi
-          
-          git commit -m "chore: bump $PARTS"
-          git push
+          git fetch origin
+          git reset --hard ${{ steps.commit.outputs.sha }}
       - name: Create Git tags
         run: |
           if [ -n "$FILIGRAN_CHATBOT_VERSION" ]; then

--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -182,6 +182,15 @@ jobs:
             const fs = require('fs');
             const { execSync } = require('child_process');
 
+            // A release commits the bump to the branch it was dispatched from, so a tag or
+            // any other ref cannot work. Refuse it here rather than letting updateRef fail
+            // on a nonsensical `heads/refs/tags/...`.
+            const branchPrefix = 'refs/heads/';
+            if (!context.ref.startsWith(branchPrefix)) {
+              throw new Error(`This workflow must be dispatched from a branch, but got ${context.ref}.`);
+            }
+            const branch = context.ref.slice(branchPrefix.length);
+
             const packages = [
               { label: '@filigran/chatbot', version: process.env.FILIGRAN_CHATBOT_VERSION },
               { label: '@filigran/ui', version: process.env.FILIGRAN_UI_VERSION },
@@ -213,7 +222,6 @@ jobs:
 
             console.log(`Changed files:\n${changed.map((path) => `  ${path}`).join('\n')}`);
 
-            const branch = context.ref.replace('refs/heads/', '');
             const parent = process.env.GITHUB_SHA;
             const message = `chore: bump ${packages.map((pkg) => `${pkg.label} to v${pkg.version}`).join(', ')}`;
 


### PR DESCRIPTION
### Proposed changes

* `Commit version changes` no longer runs `git add . && git commit && git push`. It uses `actions/github-script` with the app token already minted in the job and builds the commit through the git data API (`createBlob` → `createTree` → `createCommit` → `updateRef`). Commits created that way are signed by GitHub, so `required_signatures` is satisfied legitimately — no bypass actor, no signing key to manage.
* The files going into the commit are discovered from the working tree (`git diff --name-only HEAD` ∪ `git ls-files --others --exclude-standard`) rather than assumed to be the bumped `package.json`. `yarn version` also realigns dependent workspaces' ranges and `yarn.lock` — see ab59297, where the icon bump also rewrote `@filigran/ui`'s `peerDependencies` and the lockfile. Hardcoding paths would have silently dropped both and left `yarn install --immutable` failing.
* Blobs are uploaded base64 so any touched file round-trips byte-exact; the executable bit is preserved and a deleted path becomes `sha: null`.
* `updateRef` is deliberately not forced: if `main` moved between dispatch and this step, the run fails instead of discarding what landed in between. The old `git push` behaved the same way.
* New `Sync checkout to the signed commit` step (`git fetch origin && git reset --hard <sha>`). The commit now exists only on the remote, so this moves local `HEAD` onto it — which is what lets `Create Git tags`, `Build packages` and the four publish steps stay **completely unchanged**: tags land on the signed commit and the working tree still holds the bumped `package.json` that `yarn npm publish` reads.
* The commit message is assembled in the same order as before (chatbot, ui, icon, rich-text-editor), so it still reads `chore: bump @filigran/ui to vX.Y.Z` and still passes the `Enforce convention commit format` ruleset.

### Related issues

* Closes #387

### How to test this PR

Once merged, dispatch **Release and Publish to NPM** with `package: @filigran/icon` and `version_type: patch` — the cheapest real exercise, since it also covers the multi-file case (icon `package.json` + ui `peerDependencies` + `yarn.lock`).

Expected:
1. `Commit version changes` logs the changed file list and `Created <sha>: chore: bump @filigran/icon to vX.Y.Z`.
2. The bump commit on `main` shows as **Verified**, authored via the GitHub App.
3. `Sync checkout to the signed commit` succeeds, the tag lands on that commit, and `@filigran/icon` publishes.

### Checklist

- [x] The PR title follows the Conventional Commits convention `type(scope?): description (#issue)`
- [x] I signed my commits
- [x] This PR is linked to an issue
- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [x] I added/updated the relevant documentation
- [x] Where necessary, I refactored code to improve the overall quality

### Further comments

**On testing.** The functionality box is unticked deliberately. A `workflow_dispatch` workflow cannot be exercised from a branch before merge, so this is verified structurally, not by a live run: the YAML parses (27 steps, the sync step correctly between commit and tags), the extracted script passes `node --check`, no `${{` leaks into the JS body, and both file-discovery commands were checked against a real working tree. The first release after merge is the real test.

**⚠️ This fixes one of two blockers — do not expect a release to succeed on merge.** An earlier version of this description claimed the `pull_request` rule did not gate this actor. That was wrong, and the correction matters for how you read this PR. The rejected push reported **two** rule violations, not one:

```
- Commits must have verified signatures.
  Found 1 violation:
  a14795bd522f86154355bc84b12acbde9703856e

- Changes must be made through a pull request.
```

`Found 1 violation` counts the offending commit under the signature rule; it is not a count of rules broken. So the app has no bypass on the `Org ruleset` at all, and `Changes must be made through a pull request` will reject `updateRef` exactly as it rejected `git push` — writing to `main` through the API is still writing to `main`.

What this PR does and does not do:

* **Does** remove the signature blocker, correctly and without a bypass actor. That work stands on its own and is a prerequisite for every option below.
* **Does not** let the release workflow write to `main`. That needs a separate decision, since the options differ in who has to act and how much the release process changes:
  1. Add the app as a bypass actor on the enterprise `Org ruleset`. Smallest change, but needs enterprise admin and bypass is ruleset-scoped, so it also exempts the signature rule (harmless now that commits are signed properly, but broader than needed).
  2. Have the release workflow open a PR with the bump and publish once it merges. Keeps the rules intact; costs the one-click flow and needs a second workflow triggered on merge.
  3. Stop writing to `main` entirely: bump the version in the feature PR, and reduce the release workflow to tag + build + publish from the existing commit. Sidesteps both rules, and it is what was already done by hand for `@filigran/chatbot` 3.9.0. Biggest change to the documented process in `deployment-package.md`.

Also note the effective rules on `main` all come from `Enterprise/filigran`; the repo-level `main` ruleset has an empty `ref_name.include` and therefore targets nothing.

**Alternatives considered.** A bot GPG key via `crazy-max/ghaction-import-gpg` needs a machine user whose verified email matches the key — `github-actions[bot]@users.noreply.github.com` cannot be verified, so the commit would push but still show Unverified. Adding the app as a bypass actor on `required_signatures` is one click but weakens the rule for that identity and needs enterprise admin. The API route satisfies the rule as intended instead of routing around it.

**Deliberately out of scope.** Two unrelated defects were left untouched: the chatbot tag is created without the `v` prefix (line 274) while its release step expects `@filigran/chatbot-v<version>`, producing a duplicate tag on every run; and the workflow publishes without `--provenance` despite requesting `id-token: write`, unlike the root `publish:*` scripts. Both are worth their own issues.
