### PR TITLE
ci: publish the committed version instead of bumping in the workflow (#383)

### DIFF
--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -3,15 +3,6 @@ name: Release and Publish to NPM
 on:
   workflow_dispatch:
     inputs:
-      version_type:
-        description: 'Version type (patch/minor/major)'
-        required: true
-        default: 'patch'
-        type: choice
-        options:
-          - patch
-          - minor
-          - major
       package:
         description: 'Package to release'
         required: true
@@ -36,7 +27,6 @@ jobs:
       packages: write
       id-token: write
       issues: write
-      pull-requests: write
     steps:
       - uses: actions/create-github-app-token@v3
         id: app-token
@@ -60,44 +50,52 @@ jobs:
           git config --global user.name "github-actions[bot]"
       - name: Install dependencies
         run: yarn install --immutable
-      - name: Get current versions
+      - name: Resolve versions to release
+        env:
+          PACKAGE: ${{ github.event.inputs.package }}
         run: |
-          if [[ "${{ github.event.inputs.package }}" == "@filigran/chatbot" ]] || [[ "${{ github.event.inputs.package }}" == "all" ]]; then
-            echo "FILIGRAN_CHATBOT_CURRENT_VERSION=$(node -p "require('./packages/filigran-chatbot/package.json').version")" >> $GITHUB_ENV
+          set -euo pipefail
+
+          # The release publishes the version already committed in package.json. It does not
+          # bump anything, so nothing here writes to the default branch — see #383. Version
+          # bumps arrive through ordinary reviewed pull requests instead.
+          #
+          # A package whose version is already on npm is skipped rather than failed, so one
+          # up-to-date package cannot block the others when releasing `all`. Every skip is
+          # logged. Setting FILIGRAN_*_VERSION is what marks a package for release: the
+          # build, publish, tag and GitHub release steps are all gated on it being non-empty.
+          SELECTED=0
+
+          resolve() {
+            local name="$1" dir="$2" var="$3"
+
+            if [ "$PACKAGE" != "$name" ] && [ "$PACKAGE" != "all" ]; then
+              return 0
+            fi
+
+            local version published
+            version=$(node -p "require('./packages/$dir/package.json').version")
+            published=$(npm view "$name@$version" version 2>/dev/null || true)
+
+            if [ -n "$published" ]; then
+              echo "::warning title=Already published::$name $version is already on npm — skipping. Bump the version in a pull request first."
+              return 0
+            fi
+
+            echo "$var=$version" >> "$GITHUB_ENV"
+            echo "Will release $name $version"
+            SELECTED=$((SELECTED + 1))
+          }
+
+          resolve '@filigran/chatbot'          filigran-chatbot          FILIGRAN_CHATBOT_VERSION
+          resolve '@filigran/icon'             filigran-icon             FILIGRAN_ICON_VERSION
+          resolve '@filigran/rich-text-editor' filigran-rich-text-editor FILIGRAN_RTE_VERSION
+          resolve '@filigran/ui'               filigran-ui               FILIGRAN_UI_VERSION
+
+          if [ "$SELECTED" -eq 0 ]; then
+            echo "::error title=Nothing to release::Every selected package is already published at the version in its package.json. Bump the version in a pull request, then run this workflow again."
+            exit 1
           fi
-          if [[ "${{ github.event.inputs.package }}" == "@filigran/icon" ]] || [[ "${{ github.event.inputs.package }}" == "all" ]]; then
-            echo "FILIGRAN_ICON_CURRENT_VERSION=$(node -p "require('./packages/filigran-icon/package.json').version")" >> $GITHUB_ENV
-          fi
-          if [[ "${{ github.event.inputs.package }}" == "@filigran/rich-text-editor" ]] || [[ "${{ github.event.inputs.package }}" == "all" ]]; then
-            echo "FILIGRAN_RTE_CURRENT_VERSION=$(node -p "require('./packages/filigran-rich-text-editor/package.json').version")" >> $GITHUB_ENV
-          fi
-          if [[ "${{ github.event.inputs.package }}" == "@filigran/ui" ]] || [[ "${{ github.event.inputs.package }}" == "all" ]]; then
-            echo "FILIGRAN_UI_CURRENT_VERSION=$(node -p "require('./packages/filigran-ui/package.json').version")" >> $GITHUB_ENV
-          fi
-      - name: Update version for @filigran/chatbot
-        if: github.event.inputs.package == '@filigran/chatbot' || github.event.inputs.package == 'all'
-        working-directory: ./packages/filigran-chatbot
-        run: |
-          yarn version ${{ github.event.inputs.version_type }}
-          echo "FILIGRAN_CHATBOT_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_ENV
-      - name: Update version for @filigran/icon
-        if: github.event.inputs.package == '@filigran/icon' || github.event.inputs.package == 'all'
-        working-directory: ./packages/filigran-icon
-        run: |
-          yarn version ${{ github.event.inputs.version_type }}
-          echo "FILIGRAN_ICON_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_ENV
-      - name: Update version for @filigran/rich-text-editor
-        if: github.event.inputs.package == '@filigran/rich-text-editor' || github.event.inputs.package == 'all'
-        working-directory: ./packages/filigran-rich-text-editor
-        run: |
-          yarn version ${{ github.event.inputs.version_type }}
-          echo "FILIGRAN_RTE_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_ENV
-      - name: Update version for @filigran/ui
-        if: github.event.inputs.package == '@filigran/ui' || github.event.inputs.package == 'all'
-        working-directory: ./packages/filigran-ui
-        run: |
-          yarn version ${{ github.event.inputs.version_type }}
-          echo "FILIGRAN_UI_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_ENV
       - name: Collect commits and issues for changelog
         id: changelog
         run: |
@@ -174,112 +172,6 @@ jobs:
           # Also save to environment for debugging
           echo "UI_ISSUES_TO_CLOSE=$UI_ISSUES" >> $GITHUB_ENV
           echo "ICON_ISSUES_TO_CLOSE=$ICON_ISSUES" >> $GITHUB_ENV
-      - name: Create release branch
-        run: |
-          RELEASE_BRANCH="release/version-bump-${{ github.run_id }}-${{ github.run_attempt }}"
-          git checkout -b "$RELEASE_BRANCH"
-          echo "RELEASE_BRANCH=$RELEASE_BRANCH" >> $GITHUB_ENV
-      - name: Commit version changes
-        id: commit_version
-        run: |
-          git add .
-          
-          PARTS=""
-          if [ -n "$FILIGRAN_CHATBOT_VERSION" ]; then
-            PARTS="@filigran/chatbot to v$FILIGRAN_CHATBOT_VERSION"
-          fi
-          if [ -n "$FILIGRAN_UI_VERSION" ]; then
-            [ -n "$PARTS" ] && PARTS="$PARTS, "
-            PARTS="${PARTS}@filigran/ui to v$FILIGRAN_UI_VERSION"
-          fi
-          if [ -n "$FILIGRAN_ICON_VERSION" ]; then
-            [ -n "$PARTS" ] && PARTS="$PARTS, "
-            PARTS="${PARTS}@filigran/icon to v$FILIGRAN_ICON_VERSION"
-          fi
-          if [ -n "$FILIGRAN_RTE_VERSION" ]; then
-            [ -n "$PARTS" ] && PARTS="$PARTS, "
-            PARTS="${PARTS}@filigran/rich-text-editor to v$FILIGRAN_RTE_VERSION"
-          fi
-          
-          if [ -z "$PARTS" ]; then
-            echo "No version changes to commit"
-            echo "has_changes=false" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-          
-          git commit -m "chore: bump $PARTS"
-          git push --set-upstream origin "$RELEASE_BRANCH"
-          echo "has_changes=true" >> $GITHUB_OUTPUT
-          echo "commit_message=chore: bump $PARTS" >> $GITHUB_OUTPUT
-      - name: Open release PR
-        if: steps.commit_version.outputs.has_changes == 'true'
-        id: release_pr
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          PR_URL=$(gh pr create \
-            --base main \
-            --head "$RELEASE_BRANCH" \
-            --title "${{ steps.commit_version.outputs.commit_message }}" \
-            --body "Automated version bump triggered by release workflow run ${{ github.run_id }}.
-
-          This PR is required because \`main\` enforces signed commits and pull-request review. It will auto-merge once required checks/approvals pass.")
-          echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
-          PR_NUMBER=$(basename "$PR_URL")
-          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
-      - name: Enable auto-merge on release PR
-        if: steps.commit_version.outputs.has_changes == 'true'
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          gh pr merge "${{ steps.release_pr.outputs.pr_number }}" --auto --squash
-      - name: Wait for release PR to merge
-        if: steps.commit_version.outputs.has_changes == 'true'
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          PR_NUMBER="${{ steps.release_pr.outputs.pr_number }}"
-          for i in $(seq 1 60); do
-            STATUS=$(gh pr view "$PR_NUMBER" --json state,mergedAt \
-              -q 'if .mergedAt then "MERGED" else .state end' || echo "RETRY")
-            if [ "$STATUS" = "MERGED" ]; then
-              echo "PR #$PR_NUMBER merged."
-              exit 0
-            fi
-            if [ "$STATUS" = "CLOSED" ]; then
-              echo "PR #$PR_NUMBER was closed without merging. Failing release."
-              exit 1
-            fi
-            echo "Waiting for PR #$PR_NUMBER to merge (attempt $i/60, status: $STATUS)..."
-            sleep 15
-          done
-          echo "PR #$PR_NUMBER not merged after 15 minutes. Failing release so tags/publish never run on an un-bumped main."
-          exit 1
-      - name: Sync local main with merged release
-        if: steps.commit_version.outputs.has_changes == 'true'
-        run: |
-          git fetch origin main
-          git checkout main
-          git reset --hard origin/main
-      - name: Create Git tags
-        run: |
-          if [ -n "$FILIGRAN_CHATBOT_VERSION" ]; then
-            git tag "@filigran/chatbot-$FILIGRAN_CHATBOT_VERSION"
-            echo "Created tag: @filigran/chatbot-$FILIGRAN_CHATBOT_VERSION"
-          fi
-          if [ -n "$FILIGRAN_ICON_VERSION" ]; then
-            git tag "@filigran/icon-v$FILIGRAN_ICON_VERSION"
-            echo "Created tag: @filigran/icon-v$FILIGRAN_ICON_VERSION"
-          fi
-          if [ -n "$FILIGRAN_RTE_VERSION" ]; then
-            git tag "@filigran/rich-text-editor-v$FILIGRAN_RTE_VERSION"
-            echo "Created tag: @filigran/rich-text-editor-v$FILIGRAN_RTE_VERSION"
-          fi
-          if [ -n "$FILIGRAN_UI_VERSION" ]; then
-            git tag "@filigran/ui-v$FILIGRAN_UI_VERSION"
-            echo "Created tag: @filigran/ui-v$FILIGRAN_UI_VERSION"
-          fi
-          git push --tags
       - name: Build packages
         run: |
           if [ -n "$FILIGRAN_CHATBOT_VERSION" ]; then
@@ -326,6 +218,43 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Create Git tags
+        run: |
+          set -euo pipefail
+
+          # Tags are created after a successful publish, not before. Tagging first left a
+          # pushed tag with nothing on npm whenever publishing failed, and that stale tag
+          # then blocked re-running the release — see @filigran/chatbot-v3.9.0.
+          #
+          # An existing tag is left alone rather than failing the run: by this point the
+          # package is on npm, and refusing to finish would be worse than reusing the tag.
+          # Guarding against republishing is the registry check's job, not the tag's. The
+          # remote is queried because the checkout is shallow and carries no tags.
+          tag_release() {
+            local tag="$1"
+
+            if [ -n "$(git ls-remote --tags origin "refs/tags/$tag")" ]; then
+              echo "::warning title=Tag already exists::$tag is already on the remote — leaving it untouched."
+              return 0
+            fi
+
+            git tag "$tag"
+            echo "Created tag: $tag"
+          }
+
+          if [ -n "$FILIGRAN_CHATBOT_VERSION" ]; then
+            tag_release "@filigran/chatbot-v$FILIGRAN_CHATBOT_VERSION"
+          fi
+          if [ -n "$FILIGRAN_ICON_VERSION" ]; then
+            tag_release "@filigran/icon-v$FILIGRAN_ICON_VERSION"
+          fi
+          if [ -n "$FILIGRAN_RTE_VERSION" ]; then
+            tag_release "@filigran/rich-text-editor-v$FILIGRAN_RTE_VERSION"
+          fi
+          if [ -n "$FILIGRAN_UI_VERSION" ]; then
+            tag_release "@filigran/ui-v$FILIGRAN_UI_VERSION"
+          fi
+          git push --tags
       - name: Create GitHub Release for @filigran/icon
         if: (github.event.inputs.package == '@filigran/icon' || github.event.inputs.package == 'all') && env.FILIGRAN_ICON_VERSION != ''
         uses: softprops/action-gh-release@v3

--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -62,6 +62,33 @@ jobs:
           # build, publish, tag and GitHub release steps are all gated on it being non-empty.
           SELECTED=0
 
+          # Commit a tag points at, or empty when the tag does not exist. The glob is
+          # required: querying the exact ref returns only the tag object for an annotated
+          # tag, while the glob also returns the peeled `^{}` line carrying the commit.
+          tag_commit() {
+            local tag="$1" refs status
+
+            set +e
+            refs=$(git ls-remote --tags origin "refs/tags/$tag*" 2>&1)
+            status=$?
+            set -e
+
+            if [ "$status" -ne 0 ]; then
+              echo "::error title=Tag lookup failed::Could not query $tag on the remote: $refs"
+              exit 1
+            fi
+
+            # Prefer the peeled commit; fall back to the ref itself for lightweight tags.
+            printf '%s\n' "$refs" \
+              | awk -v peeled="refs/tags/$tag^{}" -v plain="refs/tags/$tag" '
+                  $2 == peeled { peeled_sha = $1 }
+                  $2 == plain  { plain_sha = $1 }
+                  END {
+                    if (peeled_sha != "") print peeled_sha
+                    else if (plain_sha != "") print plain_sha
+                  }'
+          }
+
           resolve() {
             local name="$1" dir="$2" var="$3"
 
@@ -69,13 +96,38 @@ jobs:
               return 0
             fi
 
-            local version published
+            local version
             version=$(node -p "require('./packages/$dir/package.json').version")
-            published=$(npm view "$name@$version" version 2>/dev/null || true)
 
-            if [ -n "$published" ]; then
+            # Only a 404 means the version is free. A 5xx, DNS failure or timeout must stop
+            # the run: treating it as "not published" would let the release proceed and fail
+            # at publish time, possibly after earlier packages of an `all` run already shipped.
+            local view status
+            set +e
+            view=$(npm view "$name@$version" version 2>&1)
+            status=$?
+            set -e
+
+            if [ "$status" -eq 0 ]; then
               echo "::warning title=Already published::$name $version is already on npm — skipping. Bump the version in a pull request first."
               return 0
+            fi
+
+            if ! printf '%s' "$view" | grep -q 'E404'; then
+              echo "::error title=Registry check failed::Could not determine whether $name $version is published: $view"
+              exit 1
+            fi
+
+            # A tag for this version must not already exist at a different commit, or the
+            # release would publish this commit while the tag and GitHub release notes
+            # describe older code.
+            local tag existing
+            tag="$name-v$version"
+            existing=$(tag_commit "$tag")
+
+            if [ -n "$existing" ] && [ "$existing" != "$GITHUB_SHA" ]; then
+              echo "::error title=Stale tag::$tag already exists at $existing, but this run would publish $GITHUB_SHA. Delete the tag, or bump the version in a pull request."
+              exit 1
             fi
 
             echo "$var=$version" >> "$GITHUB_ENV"
@@ -232,12 +284,23 @@ jobs:
           #
           # An existing tag is left alone rather than failing the run: by this point the
           # package is on npm, and refusing to finish would be worse than reusing the tag.
-          # Guarding against republishing is the registry check's job, not the tag's. The
-          # remote is queried because the checkout is shallow and carries no tags.
+          # This is only safe because `Resolve versions to release` already rejected any tag
+          # sitting at a different commit, so anything found here points at what we published.
+          # The remote is queried because the checkout is shallow and carries no tags.
           tag_release() {
-            local tag="$1"
+            local tag="$1" existing status
 
-            if [ -n "$(git ls-remote --tags origin "refs/tags/$tag")" ]; then
+            set +e
+            existing=$(git ls-remote --tags origin "refs/tags/$tag" 2>&1)
+            status=$?
+            set -e
+
+            if [ "$status" -ne 0 ]; then
+              echo "::error title=Tag lookup failed::Could not query $tag on the remote: $existing"
+              exit 1
+            fi
+
+            if [ -n "$existing" ]; then
               echo "::warning title=Tag already exists::$tag is already on the remote — leaving it untouched."
               return 0
             fi

--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -42,20 +42,16 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '24'
-      - name: Enable Corepack
-        run: npm install -g corepack
-      - name: Configure Git
-        run: |
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git config --global user.name "github-actions[bot]"
-      - name: Install dependencies
-        run: yarn install --immutable
       - name: Resolve versions to release
         env:
           PACKAGE: ${{ github.event.inputs.package }}
         run: |
           set -euo pipefail
 
+          # Runs before the dependency install: it only reads package.json and queries the
+          # registry, so a run with nothing to publish fails here without paying for a full
+          # `yarn install`.
+          #
           # The release publishes the version already committed in package.json. It does not
           # bump anything, so nothing here writes to the default branch — see #383. Version
           # bumps arrive through ordinary reviewed pull requests instead.
@@ -96,6 +92,14 @@ jobs:
             echo "::error title=Nothing to release::Every selected package is already published at the version in its package.json. Bump the version in a pull request, then run this workflow again."
             exit 1
           fi
+      - name: Enable Corepack
+        run: npm install -g corepack
+      - name: Configure Git
+        run: |
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+      - name: Install dependencies
+        run: yarn install --immutable
       - name: Collect commits and issues for changelog
         id: changelog
         run: |
@@ -242,16 +246,19 @@ jobs:
             echo "Created tag: $tag"
           }
 
-          if [ -n "$FILIGRAN_CHATBOT_VERSION" ]; then
+          # `:-` is required: a package that was not selected, or was skipped as already
+          # published, has no FILIGRAN_*_VERSION in the environment at all, and `set -u`
+          # treats reading an unset variable as fatal.
+          if [ -n "${FILIGRAN_CHATBOT_VERSION:-}" ]; then
             tag_release "@filigran/chatbot-v$FILIGRAN_CHATBOT_VERSION"
           fi
-          if [ -n "$FILIGRAN_ICON_VERSION" ]; then
+          if [ -n "${FILIGRAN_ICON_VERSION:-}" ]; then
             tag_release "@filigran/icon-v$FILIGRAN_ICON_VERSION"
           fi
-          if [ -n "$FILIGRAN_RTE_VERSION" ]; then
+          if [ -n "${FILIGRAN_RTE_VERSION:-}" ]; then
             tag_release "@filigran/rich-text-editor-v$FILIGRAN_RTE_VERSION"
           fi
-          if [ -n "$FILIGRAN_UI_VERSION" ]; then
+          if [ -n "${FILIGRAN_UI_VERSION:-}" ]; then
             tag_release "@filigran/ui-v$FILIGRAN_UI_VERSION"
           fi
           git push --tags

--- a/deployment-package.md
+++ b/deployment-package.md
@@ -5,11 +5,43 @@ It is triggered **manually** from the GitHub Actions tab — no push or tag is r
 
 ---
 
-## How to trigger a release
+The workflow publishes **the version already committed in `package.json`**. It does not bump
+anything, so releasing is a two-step process: bump the version in a pull request, then run the
+workflow.
+
+---
+
+## Step 1 — bump the version in a pull request
+
+Edit the `version` field in the package's `package.json` as part of a normal reviewed PR,
+following [Semantic Versioning](https://semver.org/) (`MAJOR.MINOR.PATCH`):
+
+| Change | When to use | Example |
+|--------|-------------|---------|
+| `patch` | Bug fixes, internal changes — **no API change** | `1.2.3` → `1.2.4` |
+| `minor` | New features — **backward compatible** | `1.2.3` → `1.3.0` |
+| `major` | Breaking changes — **not backward compatible** | `1.2.3` → `2.0.0` |
+
+You can bump in the PR that makes the change, or in a small dedicated PR afterwards.
+
+> [!IMPORTANT]
+> **Bumping `@filigran/icon` needs a second edit.** `@filigran/ui` declares `@filigran/icon` in
+> its `peerDependencies`. When you bump the icon version, update that range in
+> `packages/filigran-ui/package.json` too and run `yarn install` so `yarn.lock` follows —
+> otherwise `yarn install --immutable` fails in CI. This used to be done automatically by
+> `yarn version`, which the release workflow no longer runs.
+
+> [!NOTE]
+> **First release of a new package.** Set `version` to whatever you want published — the
+> workflow publishes it verbatim. To ship `1.0.0` first, commit `"version": "1.0.0"`.
+
+---
+
+## Step 2 — run the release workflow
 
 1. Go to **Actions → Release and Publish to NPM** in the GitHub repository.
 2. Click **Run workflow**.
-3. Fill in the two inputs described below, then click **Run workflow**.
+3. Choose the `package` input described below, then click **Run workflow**.
 
 ---
 
@@ -29,34 +61,24 @@ It is triggered **manually** from the GitHub Actions tab — no push or tag is r
 
 ---
 
-### `version_type` — how to bump the version
-
-The workflow follows [Semantic Versioning](https://semver.org/) (`MAJOR.MINOR.PATCH`):
-
-| Option | When to use | Example (`1.2.3` → ?) |
-|--------|-------------|------------------------|
-| `patch` | Bug fixes, internal changes — **no API change** | `1.2.3` → `1.2.4` |
-| `minor` | New features — **backward compatible** | `1.2.3` → `1.3.0` |
-| `major` | Breaking changes — **not backward compatible** | `1.2.3` → `2.0.0` |
-
- [!WARNING]
- **First release of a new package**
- The deployment workflow **always** bumps the version using `yarn version` before publishing. It cannot publish the version defined in `package.json` as-is.
- 
- If you want the first published version to be `1.0.0`:
- 1. In your PR adding the package, set `"version": "0.0.0"` in its `package.json`.
- 2. When triggering the manual release workflow, select **`major`** to bump the version to `1.0.0`.
-
----
-
 ## What the workflow does
 
-1. Bumps the version in the relevant `package.json` with `yarn version <type>`.
-2. Commits and pushes the change (`chore: bump <package> to vX.Y.Z`).
-3. Creates a Git tag (`<package>-vX.Y.Z`).
-4. Builds the package (`yarn workspace <package> run build`).
-5. Publishes to **NPM** (`yarn npm publish --access public`).
-6. Creates a **GitHub Release** with installation instructions.
+1. Reads the version from each selected `package.json`, and checks it against the registry.
+   A package whose version is already on NPM is **skipped with a warning** rather than
+   failing the run, so one up-to-date package cannot block the others when releasing `all`.
+   If nothing is left to release, the run fails with an explanatory message.
+2. Builds each package to be released (`yarn workspace <package> run build`).
+3. Publishes to **NPM** (`yarn npm publish --access public`).
+4. Creates a Git tag (`<package>-vX.Y.Z`) — **after** publishing succeeds.
+5. Creates a **GitHub Release** with installation instructions.
+
+The workflow never writes to `main`. That is deliberate: the default branch requires signed
+commits and pull-request review, so a workflow that pushed its own version bump could not
+complete (see #383).
+
+Tagging after publishing is also deliberate. Tagging first meant a failed publish left a tag
+pointing at a version that was never released, and that stale tag then blocked re-running the
+release.
 
 ---
 

--- a/deployment-package.md
+++ b/deployment-package.md
@@ -25,11 +25,12 @@ following [Semantic Versioning](https://semver.org/) (`MAJOR.MINOR.PATCH`):
 You can bump in the PR that makes the change, or in a small dedicated PR afterwards.
 
 > [!IMPORTANT]
-> **Bumping `@filigran/icon` needs a second edit.** `@filigran/ui` declares `@filigran/icon` in
-> its `peerDependencies`. When you bump the icon version, update that range in
-> `packages/filigran-ui/package.json` too and run `yarn install` so `yarn.lock` follows —
-> otherwise `yarn install --immutable` fails in CI. This used to be done automatically by
-> `yarn version`, which the release workflow no longer runs.
+> **A minor or major `@filigran/icon` bump needs a second edit.** `@filigran/ui` declares a
+> range for `@filigran/icon` in its `peerDependencies` (e.g. `^0.24.3`). A patch bump still
+> satisfies it and needs nothing further; a minor or major bump means widening that range in
+> `packages/filigran-ui/package.json`. Because the range is recorded in `yarn.lock`, run
+> `yarn install` in the same PR or `yarn install --immutable` fails in CI. `yarn version` used
+> to keep these aligned, and the release workflow no longer runs it.
 
 > [!NOTE]
 > **First release of a new package.** Set `version` to whatever you want published — the


### PR DESCRIPTION
### Proposed changes

* The release publishes the version already committed in `package.json` instead of bumping it. Nothing writes to `main`, so the signed-commit and pull-request rules no longer apply. Bumps happen in normal PRs.
* Removed the `version_type` input, the four `Update version for …` steps, and #384's release-branch/PR/auto-merge/wait machinery. Also dropped the now-unused `pull-requests: write` and the four `*_CURRENT_VERSION` vars nothing read.
* New `Resolve versions to release` step: reads each version from `package.json`, skips it with a warning if already on npm, fails with "nothing to release" if none are left. Runs before `yarn install` so a no-op run is cheap. No downstream changes needed — every step was already gated on `env.FILIGRAN_*_VERSION != ''`.
* Tags are created after publishing, not before. Tagging first left tags for versions that never shipped, which then blocked re-runs (`@filigran/chatbot-v3.9.0` is in that state).
* Chatbot tags are now named `-v<version>` like the other three, matching what its own GitHub Release step already looked for. An existing tag is now left alone with a warning instead of failing the step — required, since `@filigran/chatbot-v3.9.0` already exists.
* `deployment-package.md` rewritten as "bump in a PR" then "run the workflow".

### Related issues

* Closes #383

### How to test this PR

The orphaned tag `@filigran/chatbot-v3.9.0` **has been deleted** as a prerequisite. It pointed at `72d53e3`, which predates `9d1ec59 feat(chatbot): collect human approval for gated tool calls`, and nothing on npm or in GitHub releases referenced it. Had it stayed, the new stale-tag check would have failed the release rather than publish that feature under a tag describing code without it.

Dispatch **Release and Publish to NPM** with `package: @filigran/chatbot`. The repo is at 3.9.0 and npm's `latest` is 3.7.4, so this ships the release that has been stuck since the bug started.

Expect: `Will release @filigran/chatbot 3.9.0` → publish succeeds → tag created at the released commit → GitHub release created.

Then dispatch `all`: expect ui, icon and rich-text-editor skipped with a warning each.

### Checklist

- [x] The PR title follows the Conventional Commits convention `type(scope?): description (#issue)`
- [x] I signed my commits
- [x] This PR is linked to an issue
- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [x] I added/updated the relevant documentation
- [x] Where necessary, I refactored code to improve the overall quality

### Further comments

**Testing.** A `workflow_dispatch` workflow can't run from a branch, so the new logic was extracted and run locally against the real registry and remote:

```
PACKAGE=all           STALE TAG chatbot 3.9.0 | SKIP icon/rte/ui
PACKAGE=@filigran/ui  SKIP ui 1.6.7 -> fails "nothing to release"
tag_commit: annotated -> peeled commit | lightweight -> ref | absent -> empty
```

**No provenance.** Deliberate: none of the 88 published versions across the four packages has an attestation, and we would rather not have some versions verifiable via `npm audit signatures` and the rest not. Worth revisiting on its own — note Yarn only generates provenance in GitHub Actions and GitLab CI, so `release:filigran-*` could never produce it.

**Known limitation.** If a publish succeeds and a later step fails, re-running skips the package as already published and exits "nothing to release", so that version needs its tag and GitHub release created by hand. The window is narrow now that the registry check, tag lookup and stale-tag cases all fail before publishing, but it is not closed.

**Out of scope, each worth its own issue:**

1. The changelog has always been empty — `actions/checkout` defaults to `fetch-depth: 1`, so `git tag -l` finds nothing and `LAST_UI_TAG` resolves to HEAD. See the published `@filigran/ui-v1.6.7` release body. Same cause makes `Update project status` and `Close issues and add comments` no-ops. Fixing it (`fetch-depth: 0`) would switch issue-closing on for the first time, so it needs its own decision.
2. `yarn npm publish --tolerate-republish` covers part of what the registry preflight does by hand.
3. `icons.yml` has failed every run since 2026-01-19: `fetchFromFigma.js` checks `response.ok` after consuming the body, so the real Figma error is masked. Its `git push origin main` would then hit three ruleset violations.
