### PR TITLE
fix(chatbot): close a nested-fence block at its own closer, not the last one (#391)

### DIFF
--- a/packages/filigran-chatbot/src/utils/index.ts
+++ b/packages/filigran-chatbot/src/utils/index.ts
@@ -40,25 +40,69 @@ export function hardenNestedCodeFences(raw: string): string {
   }
   if (openerIdx === -1) return raw;
 
-  let maxRun = 3;
-  let nestedCount = 0;
-  let lastBareFence = -1;
+  // Find the outer block's *matching* closer rather than the last bare fence in
+  // the message. Same-length fences are ambiguous — an inner ``` looks exactly
+  // like the outer closer — so inner fences are paired off with two structural
+  // signals:
+  //   • a labelled fence (```lang) opens a nested block, and the next bare
+  //     fence closes it (depth tracking); and
+  //   • two consecutive *bare* fences wrapping a non-blank body form an
+  //     unlabelled nested code block — a ``` … ``` example inside the document.
+  // A bare fence at depth 0 is the outer closer when the next fence is
+  // labelled, absent, or bare-but-separated-by-only-blank-lines: that last case
+  // is a block boundary (this closer followed by a *separate* block), not
+  // nesting, so the separate block is never absorbed.
+  //
+  // Taking the last bare fence instead swallowed everything up to it — trailing
+  // prose and unrelated code blocks alike — whenever a later block followed the
+  // markdown one.
+  const fences: { idx: number; run: number; bare: boolean }[] = [];
   for (let i = openerIdx + 1; i < lines.length; i++) {
     const m = lines[i].match(fenceRe);
-    if (!m) continue;
-    nestedCount++;
-    maxRun = Math.max(maxRun, m[2].length);
-    if (m[3].trim() === '') lastBareFence = i;
+    if (m) fences.push({ idx: i, run: m[2].length, bare: m[3].trim() === '' });
   }
-  if (nestedCount === 0) return raw;
+
+  // True when every line strictly between two fence lines is blank — which
+  // separates a nested code block (real body) from a mere block boundary.
+  const blankBetween = (a: number, b: number): boolean => {
+    for (let k = a + 1; k < b; k++) {
+      if (lines[k].trim() !== '') return false;
+    }
+    return true;
+  };
+
+  let depth = 0;
+  let maxRun = 3;
+  let nestedCount = 0;
+  let closerIdx = -1;
+  for (let j = 0; j < fences.length; j++) {
+    const f = fences[j];
+    if (f.bare && depth === 0) {
+      const next = fences[j + 1];
+      if (!next || !next.bare || blankBetween(f.idx, next.idx)) {
+        closerIdx = f.idx;
+        break;
+      }
+      depth++; // opens an unlabelled nested code block
+    } else {
+      // A labelled fence opens a nested block; a bare fence at depth > 0 closes
+      // the innermost one.
+      depth = f.bare ? Math.max(0, depth - 1) : depth + 1;
+    }
+    nestedCount++;
+    maxRun = Math.max(maxRun, f.run);
+  }
+
+  // Only harden when the block really contains nested fences AND its own closer
+  // was found — otherwise leave the text alone rather than extending the block
+  // over whatever follows.
+  if (closerIdx === -1 || nestedCount === 0) return raw;
 
   const fence = '`'.repeat(Math.max(maxRun + 1, 4));
   const om = lines[openerIdx].match(fenceRe)!;
   lines[openerIdx] = `${om[1]}${fence}${om[3]}`;
-  if (lastBareFence > openerIdx) {
-    const cm = lines[lastBareFence].match(fenceRe)!;
-    lines[lastBareFence] = `${cm[1]}${fence}`;
-  }
+  const cm = lines[closerIdx].match(fenceRe)!;
+  lines[closerIdx] = `${cm[1]}${fence}`;
   return lines.join('\n');
 }
 


### PR DESCRIPTION
## The bug

`hardenNestedCodeFences` takes the **last bare fence in the message** as the outer block's closer. Everything between the real closer and that fence is swallowed into the code block — trailing prose and unrelated code blocks alike.

`````md
```markdown
# doc
```js
inner
```
```          <- the real closer

Some prose.

```py        <- everything from the opener to here becomes one block
x = 1
```
`````

Measured against the published 3.9.0:

```
PUBLISHED 3.9.0 : closer=11 → prose inside code block: true
FIXED           : closer=5  → prose inside code block: false
```

## The fix

Restores the closer-detection that XTM One's local copy had been carrying and that was never upstreamed. Same-length fences are ambiguous — an inner ` ``` ` looks exactly like the outer closer — so inner fences are paired off structurally:

- a **labelled** fence opens a nested block, and the next bare fence closes it (depth tracking);
- two consecutive **bare** fences wrapping a non-blank body form an unlabelled nested block.

A bare fence at depth 0 is the outer closer unless the next fence is bare *and* wraps real content. A blank-only gap is a block boundary, not nesting — which is what stops a separate block being absorbed.

Two behaviour changes fall out, both fixes:

- a markdown block containing **no** nested fences is left alone instead of pointlessly hardened;
- a block whose closer is never found is left alone instead of extended to the end of the message.

## Verification

Compared against the previous local implementation across 8 inputs — both repros above, unlabelled nesting, several trailing blocks, an unterminated block, the empty string — **identical output on every one**.

Worth noting what this correction is *not*: the reviewer report that surfaced it claimed the trailing **bare** block regressed. It does not — both implementations swallow the prose there, identically. The genuine trigger is a trailing **labelled** block, which the local copy handled and the package did not.

## Context

Found reviewing a report on XTM-One-Platform/xtm-one#2800, which imports these helpers from the package. Until this ships, that repo keeps a local override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)