### PR TITLE
fix(filigran-chatbot): translate remaining strings and interpolate with placeholders (#390)

### DIFF
--- a/packages/filigran-chatbot/README.md
+++ b/packages/filigran-chatbot/README.md
@@ -121,13 +121,14 @@ import { ChatToggleButton } from '@filigran/chatbot';
 
 #### Props
 
-| Prop          | Type              | Default      | Description                    |
-| ------------- | ----------------- | ------------ | ------------------------------ |
-| `isOpen`      | `boolean`         | **required** | Whether the chat panel is open |
-| `onToggle`    | `() => void`      | **required** | Called when button is clicked  |
-| `label`       | `string`          | `'Chat'`     | Tooltip/aria label             |
-| `accentColor` | `string`          | `'#7b5cff'`  | Button background color        |
-| `icon`        | `React.ReactNode` | default icon | Custom icon                    |
+| Prop          | Type                      | Default      | Description                                                                |
+| ------------- | ------------------------- | ------------ | -------------------------------------------------------------------------- |
+| `isOpen`      | `boolean`                 | **required** | Whether the chat panel is open                                             |
+| `onToggle`    | `() => void`              | **required** | Called when button is clicked                                              |
+| `label`       | `string`                  | built-in     | Button text, already translated by the host; omit for `t('Ask Assistant')` |
+| `t`           | `(key: string) => string` | identity     | Translation function, used for the default label                           |
+| `accentColor` | `string`                  | `'#7b5cff'`  | Button background color                                                    |
+| `icon`        | `React.ReactNode`         | default icon | Custom icon                                                                |
 
 ## API Contract
 
@@ -571,59 +572,230 @@ function App() {
 }
 ```
 
-**Translation keys used:**
+`t` is only ever asked for a lookup — key in, translated string out — so any
+i18n library works and the package never carries a dictionary of its own.
+Untranslated hosts can omit it: the default is the identity function, so every
+key is its own English text.
 
-- `'Thinking...'`
-- `'Using tools…'`
-- `'Analyzing results…'`
-- `'Composing answer…'`
-- `'Incorporating your message…'`
-- `'Ask a question...'`
-- `'Stop generating'`
-- `'Send now'`
-- `'Enter to send now · Esc to stop'`
-- `'Attachments wait for the current response'`
-- `'New chat'`
-- `'Conversation history'`
-- `'No conversations yet'`
-- `'Untitled conversation'`
-- `'New conversation'`
-- `'Delete conversation'`
-- `'just now'` / `'m ago'` / `'h ago'` / `'d ago'`
-- `'Switch view'`
-- `'Close'`
-- `'Switch to another agent'`
+#### Values inside sentences
+
+A key is always a **whole sentence**, with `{placeholder}` slots for the values.
+The panel fills the slots in _after_ the lookup, so a locale is free to move the
+value, and a translator sees the sentence rather than a fragment of one:
+
+| Key | Renders as |
+| --- | --- |
+| `'Waiting for {count} background tasks…'` | Waiting for 3 background tasks… |
+| `'Transferred from {agent}'` | Transferred from Threat Analyst |
+| `'{percent}% full'` | 84% full |
+| `'How can {agent} help you, {name}?'` | How can **Threat Analyst** help you, John? |
+
+Two consequences worth knowing when writing the locale files:
+
+- **Plurals are separate keys** — `'1 tool call'` and `'{count} tool calls'`,
+  `'Delegating one task…'` and `'Delegating {count} tasks…'`. A lookup cannot
+  select a plural form, so the panel picks the sentence and the locale
+  translates it whole; a language with more plural forms than English can route
+  the plural key through its own rules.
+- **A missing slot is not fatal** — a translation that drops a `{placeholder}`
+  renders the rest of the sentence as it is, and the value is simply absent.
+  That includes the greeting, where the agent's name is markup: a locale that
+  rewords the sentence without `{agent}` gets the sentence, not a name dangling
+  off the end of it.
+
+`promptSuggestions` (and any suggestions the backend serves) also go through
+`t`, so a host may pass either keys or final text.
+
+#### Translation keys used
+
+Every key the package can ask for, grouped by where it appears:
+
+**Toggle button**
+
+- `'Ask Assistant'`
+
+**Header, agent menu and history**
+
+- `'Agent switching is not available here'`
 - `'Browse agents'`
+- `'Close'`
+- `'Conversation history'`
+- `'Could not reach the assistant service. Check the connection and try again.'`
 - `'Create agent'`
+- `'Delete conversation'`
+- `'Floating'`
+- `'Full screen'`
+- `'New chat'`
+- `'New conversation'`
+- `'No agent matches'`
+- `'No conversations yet'`
+- `'Search agents...'`
+- `'Sidebar'`
+- `'Switch to'`
+- `'Switch to another agent'`
+- `'Switch view'`
+- `'Transferred from {agent}'`
+- `'Untitled conversation'`
+
+**Conversation sidebar**
+
+- `'Conversation title'`
+- `'Hide conversations'`
+- `'No conversation matches'`
+- `'Rename conversation'`
+- `'Search conversations...'`
+- `'Show conversations'`
+
+**Welcome screen**
+
+- `'Assistant'`
+- `'Help me create a new simulation scenario'`
+- `'How can I help you, {name}?'`
+- `'How can {agent} help you, {name}?'`
+- `'How do I configure detection rules?'`
+- `'Suggestions'`
+- `'Summarize my recent findings'`
+- `'What are the latest attack patterns?'`
+
+**Composer**
+
+- `'Ask a question...'`
+- `'Attachments wait for the current response'`
+- `'Dictate a message'`
+- `'Enter to send now · Esc to stop'`
+- `'Files uploading...'`
+- `'Insert prompt template'`
+- `'No prompt matches'`
+- `'Search prompts...'`
+- `'Send now'`
+- `'Stop dictation'`
+- `'Stop generating'`
+- `'Uses AI. Verify results.'`
+
+**Messages, markdown and files**
+
+- `'Bad response'`
+- `'Copied'`
+- `'Copied!'`
+- `'Copy code'`
+- `'Copy response'`
+- `'Download'`
+- `'Expand image'`
+- `'Good response'`
+- `'Image could not be loaded'`
+- `'Image preview'`
+- `'Load earlier messages'`
+- `'Loading image…'`
 - `'Reasoning details'`
 - `'Reasoning details — turn limit reached'`
+
+**Agent status**
+
+- `'Analyzing results…'`
+- `'Collecting results from one task…'`
+- `'Collecting results from {count} tasks…'`
+- `'Composing answer…'`
+- `'Consulting {agent}…'`
+- `'Delegating one task…'`
+- `'Delegating {count} tasks…'`
+- `'Incorporating your message…'`
+- `'Thinking...'`
+- `'Transferring to {agent}…'`
+- `'Using tools…'`
+- `'Waiting for one background task…'`
+- `'Waiting for your approval…'`
+- `'Waiting for {count} background tasks…'`
+- `'the agent'`
+- `'{tool} (+{count} more)…'`
+
+**Waiting mini-game**
+
+- `'Almost there'`
+- `'Analyzing the details'`
+- `'Connecting the dots'`
+- `'Consulting the sources'`
+- `'Crunching the data'`
+- `'Polishing the answer'`
+- `'Putting it together'`
+- `'Reticulating splines'`
+- `'Thinking it through'`
+- `'Turn off the waiting mini-game'`
+- `'Turn on the waiting mini-game'`
+- `'Wrapping things up'`
+
+**Reasoning details**
+
+- `'(no output)'`
+- `'1 tool call'`
+- `'1 transfer'`
+- `'Input'`
 - `'Model reasoning'`
-- `'iterations'`
-- `'transfer'` / `'transfers'`
+- `'Output'`
+- `"The agent's iteration budget was exhausted - execution stopped before completing all planned steps. The final response is a best-effort summary of work done so far."`
 - `'Transfer chain'`
 - `'Turn limit reached.'`
-- `"The agent's iteration budget was exhausted - execution stopped before completing all planned steps. The final response is a best-effort summary of work done so far."`
-- `'Input'` / `'Output'` / `'(no output)'`
-- `'Download'`
-- `'tool call'` / `'tool calls'`
-- `'Uses AI. Verify results.'`
-- `'How can I help you, '`
-- `'Suggestions'`
-- `'Waiting for your approval…'`
-- `'The agent needs your approval to run a tool:'` / `'The agent needs your approval to run these tools:'`
-- `'Yes'` / `'No'` / `'Yes, always'` / `'Back'` / `'Confirm'` / `'Sending…'` / `'decided'`
-- `'Approved'` / `'Declined'` / `'Always allowed'`
-- `'Decline this call'`
-- `'Why not? The agent sees this and can adapt (optional)'`
-- `'e.g. wrong environment — use staging instead'`
+- `'{count} iterations'`
+- `'{count} tool calls'`
+- `'{count} transfers'`
+
+**Tool approval**
+
 - `'Also applies to your scheduled runs, until you revoke it'`
+- `'Always allowed'`
+- `'Approved'`
+- `'Back'`
+- `'Confirm'`
+- `'Decline this call'`
+- `'Declined'`
+- `'No'`
+- `'Sending…'`
+- `'The agent needs your approval to run a tool:'`
+- `'The agent needs your approval to run these tools:'`
+- `'Why not? The agent sees this and can adapt (optional)'`
+- `'Yes'`
+- `'Yes, always'`
+- `'e.g. wrong environment — use staging instead'`
+- `'unknown tool'`
+- `'{decided}/{total} decided'`
 - `'“Yes, always” saves a preference for you. That tool will then run without asking — including on scheduled runs nobody is watching — until you revoke it.'`
-- `'This turn is no longer waiting for a decision.'`
+
+**Context gauge**
+
+- `'Context full — older turns are being dropped'`
+- `'Context nearly full — older turns are being summarized'`
+- `'Context used'`
+- `'Conversation'`
+- `'MCP & dynamic tools'`
+- `'Summarized conversation'`
+- `'System prompt'`
+- `'Tool definitions'`
+- `'Tool results'`
+- `'{counts} tokens'`
+- `'{percent}% full'`
+- `'{summary} — click for details'`
+
+**Quota**
+
+- `'Quota'`
+- `'Quota reached'`
+- `'Usage'`
+- `'Usage · {period}'`
+
+**Notices, errors and timestamps**
+
 - `'Could not send your decision. Please try again.'`
+- `'No response.'`
+- `'Response ready'`
+- `'Sorry, an error occurred. Please try again.'`
 - `'This decision could not be sent. Reload the chat and try again.'`
-- `'Floating'`
-- `'Sidebar'`
-- `'Full screen'`
+- `'This turn is no longer waiting for a decision.'`
+- `'Unable to connect. Please check the configuration.'`
+- `'Your answer is ready'`
+- `'just now'`
+- `'{agent} has finished'`
+- `'{count}d ago'`
+- `'{count}h ago'`
+- `'{count}m ago'`
 
 ## Styling
 

--- a/packages/filigran-chatbot/package.json
+++ b/packages/filigran-chatbot/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "git+https://github.com/FiligranHQ/filigran-ui.git"
   },
-  "version": "3.9.0",
+  "version": "3.9.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/filigran-chatbot/src/components/ChatApprovalPrompt.tsx
+++ b/packages/filigran-chatbot/src/components/ChatApprovalPrompt.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useId, useRef, useState } from 'react';
 import type { ToolApprovalDecision, ToolApprovalProposal, ToolApprovalVerdict } from '../types';
+import { translate } from '../utils';
 import { AlertTriangleIcon, CheckIcon, WrenchIcon, XCircleIcon } from './icons';
 
 interface ChatApprovalPromptProps {
@@ -117,7 +118,10 @@ const ApprovalCard = ({ proposal, decision, onDecide, disabled, t }: ApprovalCar
         <div className="min-w-0 flex items-start gap-2">
           <WrenchIcon size={13} className="mt-0.5 shrink-0 text-amber-600 dark:text-amber-400" />
           <div className="min-w-0">
-            <p className="truncate font-mono text-xs text-gray-800 dark:text-white/85">{proposal.toolName}</p>
+            {/* An unnamed tool is a malformed proposal, not a tool called
+                "unknown tool": the placeholder is the package's own text and
+                therefore translated here, not in the parser. */}
+            <p className="truncate font-mono text-xs text-gray-800 dark:text-white/85">{proposal.toolName || t('unknown tool')}</p>
             {proposal.toolDescription && <p className="mt-0.5 text-[0.7rem] text-gray-600 dark:text-white/60">{proposal.toolDescription}</p>}
             {proposal.source && <p className="mt-0.5 text-[0.65rem] text-gray-400 dark:text-white/35">{proposal.source}</p>}
           </div>
@@ -324,7 +328,7 @@ export const ChatApprovalPrompt = ({ proposals, onSubmit, isSubmitting, error, t
             to count; on a single proposal it reads as a progress bar for a
             one-step process. */}
         <span className="text-[0.7rem] text-gray-500 dark:text-white/40">
-          {proposals.length > 1 ? `${decidedCount}/${proposals.length} ${t('decided')}` : ''}
+          {proposals.length > 1 ? translate(t, '{decided}/{total} decided', { decided: decidedCount, total: proposals.length }) : ''}
         </span>
         <button
           type="button"

--- a/packages/filigran-chatbot/src/components/ChatHeader.tsx
+++ b/packages/filigran-chatbot/src/components/ChatHeader.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import type { ChatConversationSummary, ChatMode, XtmAgent } from '../types';
-import { timeAgo } from '../utils';
+import type { ChatConversationSummary, ChatMode, Translate, XtmAgent } from '../types';
+import { timeAgo, translate } from '../utils';
 import {
   AlertTriangleIcon,
   ChevronDownIcon,
@@ -50,13 +50,17 @@ interface ChatHeaderProps {
   activeConversationId?: string | null;
   onSelectConversation?: (id: string) => void;
   onDeleteConversation?: (id: string) => void;
-  t: (key: string) => string;
+  t: Translate;
 }
 
-const modeOptions: { mode: ChatMode; label: string; getIcon: (p: { size: number; className: string }) => React.ReactNode }[] = [
-  { mode: 'floating', label: 'Floating', getIcon: (p) => <FloatingIcon {...p} /> },
-  { mode: 'sidebar', label: 'Sidebar', getIcon: (p) => <SidebarIcon {...p} /> },
-  { mode: 'fullscreen', label: 'Full screen', getIcon: (p) => <FullscreenIcon {...p} /> },
+// Labels are thunks rather than bare strings so each key stays a literal call
+// on the host's translator in the source: a table of plain keys resolved later
+// through a variable works at runtime but is invisible to key extraction, which
+// is how a locale ends up missing exactly the strings nobody typed by hand.
+const modeOptions: { mode: ChatMode; label: (t: Translate) => string; getIcon: (p: { size: number; className: string }) => React.ReactNode }[] = [
+  { mode: 'floating', label: (t) => t('Floating'), getIcon: (p) => <FloatingIcon {...p} /> },
+  { mode: 'sidebar', label: (t) => t('Sidebar'), getIcon: (p) => <SidebarIcon {...p} /> },
+  { mode: 'fullscreen', label: (t) => t('Full screen'), getIcon: (p) => <FullscreenIcon {...p} /> },
 ];
 
 export const ChatHeader = ({
@@ -132,7 +136,7 @@ export const ChatHeader = ({
         </button>
         {transferredFrom && (
           <div className="pl-10 pr-2 text-[0.6rem] font-normal text-gray-400 dark:text-white/30">
-            {t('Transferred from')} {transferredFrom}
+            {translate(t, 'Transferred from {agent}', { agent: transferredFrom })}
           </div>
         )}
       </div>
@@ -355,7 +359,7 @@ export const ChatHeader = ({
               }`}
             >
               {opt.getIcon({ size: 18, className: 'text-gray-400 dark:text-white/40' })}
-              <span className="text-[0.8125rem] text-gray-700 dark:text-white/70">{t(opt.label)}</span>
+              <span className="text-[0.8125rem] text-gray-700 dark:text-white/70">{opt.label(t)}</span>
             </button>
           ))}
         </div>

--- a/packages/filigran-chatbot/src/components/ChatPanel.tsx
+++ b/packages/filigran-chatbot/src/components/ChatPanel.tsx
@@ -1,5 +1,5 @@
 import { type FunctionComponent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import type { ChatAttachment, ChatMessage, ChatPanelProps } from '../types';
+import type { ChatAttachment, ChatMessage, ChatPanelProps, Translate } from '../types';
 import { hexAlpha, identity } from '../utils';
 import { parseAttachments, parseContextUsage, parseToolCallTrace, parseTransferChain } from '../hooks/protocols/parseRestEvent';
 import { useChat } from '../hooks/useChat';
@@ -20,11 +20,16 @@ const FLOATING_WIDTH = 380;
 const FLOATING_HEIGHT = 560;
 const SIDEBAR_GAP = 6;
 
-const DEFAULT_SUGGESTIONS = [
-  'Help me create a new simulation scenario',
-  'What are the latest attack patterns?',
-  'How do I configure detection rules?',
-  'Summarize my recent findings',
+/**
+ * Fallback suggestions, translated where they are written so extraction sees
+ * the keys — the host's own list and the backend's are translated too (they may
+ * be keys), but only these belong to the package.
+ */
+const defaultSuggestions = (t: Translate) => [
+  t('Help me create a new simulation scenario'),
+  t('What are the latest attack patterns?'),
+  t('How do I configure detection rules?'),
+  t('Summarize my recent findings'),
 ];
 
 export const ChatPanel: FunctionComponent<ChatPanelProps> = ({
@@ -39,7 +44,7 @@ export const ChatPanel: FunctionComponent<ChatPanelProps> = ({
   t = identity,
   accentColor = '#7b5cff',
   logoIcon,
-  promptSuggestions = DEFAULT_SUGGESTIONS,
+  promptSuggestions,
   draftBorderColor,
   resizable = false,
   onWidthChange,
@@ -119,6 +124,17 @@ export const ChatPanel: FunctionComponent<ChatPanelProps> = ({
     requestHeaders,
     agentSlug: selectedAgent?.slug,
   });
+
+  /**
+   * Suggestions shown on the welcome screen, resolved to final text here rather
+   * than in `ChatWelcome`: the backend's and the host's lists still go through
+   * `t` (a host may well pass keys), while the package's own fallback is
+   * translated at its definition so the keys stay extractable.
+   */
+  const suggestions = useMemo(
+    () => (agentSuggestions ?? promptSuggestions)?.map((s) => t(s)) ?? defaultSuggestions(t),
+    [agentSuggestions, promptSuggestions, t],
+  );
 
   const { prompts, quota, refreshQuota } = useComposerExtras({
     apiBaseUrl,
@@ -242,7 +258,7 @@ export const ChatPanel: FunctionComponent<ChatPanelProps> = ({
    * the same agent that will answer, so the two now agree.
    */
   const [conversationAgentName, setConversationAgentName] = useState<string | null>(null);
-  const agentName = transferredAgent?.name || conversationAgentName || selectedAgent?.name || 'Assistant';
+  const agentName = transferredAgent?.name || conversationAgentName || selectedAgent?.name || t('Assistant');
 
   // "Viewing the chat" must mean the panel is on screen in the active tab —
   // NOT that an element inside it currently holds focus. In sidebar (and
@@ -610,8 +626,9 @@ export const ChatPanel: FunctionComponent<ChatPanelProps> = ({
           firstName={firstName}
           logoIcon={resolvedLogo}
           // The agent's own suggestions when the backend serves them, the
-          // host's list otherwise — never an empty section.
-          promptSuggestions={agentSuggestions ?? promptSuggestions}
+          // host's list otherwise, this package's list when there is neither —
+          // never an empty section.
+          promptSuggestions={suggestions}
           suggestionsLoading={suggestionsLoading}
           agentName={selectedAgent?.name}
           agentDescription={selectedAgent?.description}

--- a/packages/filigran-chatbot/src/components/ChatThinking.tsx
+++ b/packages/filigran-chatbot/src/components/ChatThinking.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import type { AgentStatusState, IconProps } from '../types';
+import type { AgentStatusState, IconProps, Translate } from '../types';
 import {
   AlertTriangleIcon,
   BrainIcon,
@@ -13,12 +13,13 @@ import {
   UserPlusIcon,
   WrenchIcon,
 } from './icons';
+import { translate } from '../utils';
 import { ChatWaitingGame } from './ChatWaitingGame';
 
 interface ChatThinkingProps {
   agentStatus: AgentStatusState | null;
   logoIcon?: React.ReactNode;
-  t: (key: string) => string;
+  t: Translate;
   /** Host-level override for the waiting mini-game / dynamic messages. */
   miniGameEnabled?: boolean;
 }
@@ -31,7 +32,24 @@ interface StatusVisual {
   showDots: boolean;
 }
 
-function resolveStatusVisual(agentStatus: AgentStatusState | null, t: (key: string) => string): StatusVisual {
+/**
+ * Whole-sentence keys, one per plural branch: a lookup-only `t` cannot select a
+ * plural form, so the branch is chosen here and the locale translates the
+ * finished sentence — including where the count sits in it.
+ */
+function delegatingLabel(count: number, t: Translate): string {
+  return count > 1 ? translate(t, 'Delegating {count} tasks…', { count }) : t('Delegating one task…');
+}
+
+function pollingLabel(count: number, t: Translate): string {
+  return count > 1 ? translate(t, 'Waiting for {count} background tasks…', { count }) : t('Waiting for one background task…');
+}
+
+function collectingLabel(count: number, t: Translate): string {
+  return count > 1 ? translate(t, 'Collecting results from {count} tasks…', { count }) : t('Collecting results from one task…');
+}
+
+function resolveStatusVisual(agentStatus: AgentStatusState | null, t: Translate): StatusVisual {
   if (!agentStatus) {
     return { label: t('Thinking...'), StatusIcon: BrainIcon, showDots: false };
   }
@@ -43,18 +61,15 @@ function resolveStatusVisual(agentStatus: AgentStatusState | null, t: (key: stri
       // Delegation tools have dedicated statuses
       if (lower.some((n) => n === 'spawn_background_task')) {
         const count = rawNames.filter((n) => n === 'spawn_background_task').length;
-        const label = count > 1 ? `${t('Delegating')} ${count} ${t('tasks')}…` : `${t('Delegating task')}…`;
-        return { label, StatusIcon: UserPlusIcon, showDots: false };
+        return { label: delegatingLabel(count, t), StatusIcon: UserPlusIcon, showDots: false };
       }
       if (lower.some((n) => n === 'check_task_status')) {
         const count = rawNames.filter((n) => n === 'check_task_status').length;
-        const target = count > 1 ? `${count} ${t('background tasks')}` : t('background task');
-        return { label: `${t('Waiting for')} ${target}…`, StatusIcon: SparklesIcon, showDots: false };
+        return { label: pollingLabel(count, t), StatusIcon: SparklesIcon, showDots: false };
       }
       if (lower.some((n) => n === 'get_task_result')) {
         const count = rawNames.filter((n) => n === 'get_task_result').length;
-        const from = count > 1 ? `${count} ${t('tasks')}` : t('task');
-        return { label: `${t('Collecting results from')} ${from}…`, StatusIcon: SparklesIcon, showDots: false };
+        return { label: collectingLabel(count, t), StatusIcon: SparklesIcon, showDots: false };
       }
 
       let StatusIcon: IconComponent = WrenchIcon;
@@ -73,7 +88,7 @@ function resolveStatusVisual(agentStatus: AgentStatusState | null, t: (key: stri
       if (rawNames.length > 0) {
         const display = rawNames.map((n) => n.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase()));
         const unique = Array.from(new Set(display));
-        label = unique.length === 1 ? `${unique[0]}…` : `${unique[0]} (+${unique.length - 1} more)…`;
+        label = unique.length === 1 ? `${unique[0]}…` : translate(t, '{tool} (+{count} more)…', { tool: unique[0], count: unique.length - 1 });
       } else {
         label = t('Using tools…');
       }
@@ -92,30 +107,24 @@ function resolveStatusVisual(agentStatus: AgentStatusState | null, t: (key: stri
     case 'composing':
       return { label: t('Composing answer…'), StatusIcon: BrainIcon, showDots: true };
     case 'consulting': {
-      const consultName = agentStatus.tools?.[0] ?? 'agent';
-      return { label: `${t('Consulting')} ${consultName}…`, StatusIcon: UserPlusIcon, showDots: false };
+      const consultName = agentStatus.tools?.[0] ?? t('the agent');
+      return { label: translate(t, 'Consulting {agent}…', { agent: consultName }), StatusIcon: UserPlusIcon, showDots: false };
     }
     case 'delegating': {
       const count = agentStatus.tools?.filter((n) => n === 'spawn_background_task').length ?? 0;
-      return {
-        label: count > 1 ? `${t('Delegating')} ${count} ${t('tasks')}…` : `${t('Delegating task')}…`,
-        StatusIcon: UserPlusIcon,
-        showDots: false,
-      };
+      return { label: delegatingLabel(count, t), StatusIcon: UserPlusIcon, showDots: false };
     }
     case 'polling': {
       const checkCount = agentStatus.tools?.filter((n) => n === 'check_task_status').length ?? 0;
-      const target = checkCount > 1 ? `${checkCount} ${t('background tasks')}` : t('background task');
-      return { label: `${t('Waiting for')} ${target}…`, StatusIcon: SparklesIcon, showDots: false };
+      return { label: pollingLabel(checkCount, t), StatusIcon: SparklesIcon, showDots: false };
     }
     case 'collecting': {
       const fetchCount = agentStatus.tools?.filter((n) => n === 'get_task_result').length ?? 0;
-      const from = fetchCount > 1 ? `${fetchCount} ${t('tasks')}` : t('task');
-      return { label: `${t('Collecting results from')} ${from}…`, StatusIcon: SparklesIcon, showDots: false };
+      return { label: collectingLabel(fetchCount, t), StatusIcon: SparklesIcon, showDots: false };
     }
     case 'transferring': {
-      const targetName = agentStatus.tools?.[0] ?? 'agent';
-      return { label: `${t('Transferring to')} ${targetName}…`, StatusIcon: ExternalLinkIcon, showDots: false };
+      const targetName = agentStatus.tools?.[0] ?? t('the agent');
+      return { label: translate(t, 'Transferring to {agent}…', { agent: targetName }), StatusIcon: ExternalLinkIcon, showDots: false };
     }
     case 'thinking':
     default:

--- a/packages/filigran-chatbot/src/components/ChatToggleButton.tsx
+++ b/packages/filigran-chatbot/src/components/ChatToggleButton.tsx
@@ -1,14 +1,15 @@
 import type { FunctionComponent } from 'react';
 import type { ChatToggleButtonProps } from '../types';
-import { hexAlpha } from '../utils';
+import { hexAlpha, identity } from '../utils';
 import { DefaultLogoIcon } from './icons';
 
 export const ChatToggleButton: FunctionComponent<ChatToggleButtonProps> = ({
   isOpen,
   onToggle,
-  label = 'Ask Assistant',
+  label,
   accentColor = '#7b5cff',
   icon,
+  t = identity,
 }) => {
   const resolvedIcon = icon ?? <DefaultLogoIcon size={16} />;
 
@@ -32,7 +33,7 @@ export const ChatToggleButton: FunctionComponent<ChatToggleButtonProps> = ({
       }}
     >
       <span className="[&>svg]:w-4 [&>svg]:h-4">{resolvedIcon}</span>
-      {label}
+      {label ?? t('Ask Assistant')}
     </button>
   );
 };

--- a/packages/filigran-chatbot/src/components/ChatWaitingGame.tsx
+++ b/packages/filigran-chatbot/src/components/ChatWaitingGame.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
+import type { Translate } from '../types';
 import { GamepadIcon } from './icons';
 
 /**
@@ -8,17 +9,17 @@ import { GamepadIcon } from './icons';
  * fades in. Kept short and upbeat so they fit on one line in the narrow
  * floating panel and read as a sense of progress rather than noise.
  */
-const DEFAULT_MESSAGES = [
-  'Crunching the data',
-  'Connecting the dots',
-  'Consulting the sources',
-  'Thinking it through',
-  'Reticulating splines',
-  'Analyzing the details',
-  'Almost there',
-  'Putting it together',
-  'Polishing the answer',
-  'Wrapping things up',
+const defaultMessages = (t: Translate) => [
+  t('Crunching the data'),
+  t('Connecting the dots'),
+  t('Consulting the sources'),
+  t('Thinking it through'),
+  t('Reticulating splines'),
+  t('Analyzing the details'),
+  t('Almost there'),
+  t('Putting it together'),
+  t('Polishing the answer'),
+  t('Wrapping things up'),
 ];
 
 /** localStorage key for the per-browser mini-game preference (on by default). */
@@ -326,7 +327,7 @@ function createInvaderGame(canvas: HTMLCanvasElement, messages: string[], onMess
 }
 
 interface ChatWaitingGameProps {
-  t: (key: string) => string;
+  t: Translate;
   /** Host-level override; when false the feature is hidden entirely. */
   enabled?: boolean;
 }
@@ -340,7 +341,7 @@ interface ChatWaitingGameProps {
  * text, so the "dynamic loading messages" feedback always stands on its own.
  */
 export const ChatWaitingGame = ({ t, enabled = true }: ChatWaitingGameProps) => {
-  const messages = useMemo(() => DEFAULT_MESSAGES.map((m) => t(m)), [t]);
+  const messages = useMemo(() => defaultMessages(t), [t]);
   const reducedMotion = usePrefersReducedMotion();
   const [minigameOn, setMinigameOn] = useState(readPref);
   const [msgIndex, setMsgIndex] = useState(0);

--- a/packages/filigran-chatbot/src/components/ChatWelcome.tsx
+++ b/packages/filigran-chatbot/src/components/ChatWelcome.tsx
@@ -65,30 +65,34 @@ export const ChatWelcome = ({
     )}
     {!agentDescription && <span className="mb-5" />}
 
-    <div className="w-full max-w-[320px]">
-      <span className="block text-center mb-2 text-[0.65rem] tracking-[1.5px] uppercase text-[var(--chat-accent)] font-semibold">
-        {t('Suggestions')}
-      </span>
-      {suggestionsLoading ? (
-        // Placeholder rows rather than an empty gap: the list is about to be
-        // replaced by the new agent's own suggestions.
-        <div aria-hidden className="space-y-1">
-          {[0, 1, 2].map((i) => (
-            <div key={i} className="h-8 rounded-lg border border-gray-200 dark:border-white/10 bg-gray-100/50 dark:bg-white/[0.03] animate-pulse" />
-          ))}
-        </div>
-      ) : (
-        promptSuggestions.map((prompt) => (
-          <button
-            key={prompt}
-            type="button"
-            onClick={() => onPromptClick(prompt)}
-            className="w-full text-left text-[0.8125rem] text-gray-800 dark:text-white py-1.5 px-3 mb-1 rounded-lg border border-gray-200 dark:border-white/10 bg-transparent transition-colors hover:bg-[var(--chat-accent-10)] hover:border-[var(--chat-accent-50)]"
-          >
-            {prompt}
-          </button>
-        ))
-      )}
-    </div>
+    {/* A host that passes no suggestions gets no section: the heading on its own
+        used to sit above an empty gap. */}
+    {(suggestionsLoading || promptSuggestions.length > 0) && (
+      <div className="w-full max-w-[320px]">
+        <span className="block text-center mb-2 text-[0.65rem] tracking-[1.5px] uppercase text-[var(--chat-accent)] font-semibold">
+          {t('Suggestions')}
+        </span>
+        {suggestionsLoading ? (
+          // Placeholder rows rather than an empty gap: the list is about to be
+          // replaced by the new agent's own suggestions.
+          <div aria-hidden className="space-y-1">
+            {[0, 1, 2].map((i) => (
+              <div key={i} className="h-8 rounded-lg border border-gray-200 dark:border-white/10 bg-gray-100/50 dark:bg-white/[0.03] animate-pulse" />
+            ))}
+          </div>
+        ) : (
+          promptSuggestions.map((prompt) => (
+            <button
+              key={prompt}
+              type="button"
+              onClick={() => onPromptClick(prompt)}
+              className="w-full text-left text-[0.8125rem] text-gray-800 dark:text-white py-1.5 px-3 mb-1 rounded-lg border border-gray-200 dark:border-white/10 bg-transparent transition-colors hover:bg-[var(--chat-accent-10)] hover:border-[var(--chat-accent-50)]"
+            >
+              {prompt}
+            </button>
+          ))
+        )}
+      </div>
+    )}
   </div>
 );

--- a/packages/filigran-chatbot/src/components/ChatWelcome.tsx
+++ b/packages/filigran-chatbot/src/components/ChatWelcome.tsx
@@ -1,6 +1,27 @@
+import type { Translate } from '../types';
+import { translate, translateAround } from '../utils';
+
+/**
+ * The greeting, as one sentence the locale owns end to end. The agent's name is
+ * markup (it carries the accent colour), so it cannot be spliced into a string —
+ * hence the split around its slot rather than three separate fragments.
+ */
+const Greeting = ({ firstName, agentName, t }: { firstName: string; agentName?: string; t: Translate }) => {
+  if (!agentName) return <>{translate(t, 'How can I help you, {name}?', { name: firstName })}</>;
+  const { before, after, hasSlot } = translateAround(t, 'How can {agent} help you, {name}?', 'agent', { name: firstName });
+  return (
+    <>
+      {before}
+      {hasSlot && <span className="text-[var(--chat-accent)]">{agentName}</span>}
+      {after}
+    </>
+  );
+};
+
 interface ChatWelcomeProps {
   firstName: string;
   logoIcon: React.ReactNode;
+  /** Already translated by the caller — see `ChatPanel`. */
   promptSuggestions: string[];
   onPromptClick: (prompt: string) => void;
   /** Selected agent, so the screen says who is about to answer. */
@@ -8,7 +29,7 @@ interface ChatWelcomeProps {
   agentDescription?: string | null;
   /** True while agent-specific suggestions are being fetched. */
   suggestionsLoading?: boolean;
-  t: (key: string) => string;
+  t: Translate;
 }
 
 export const ChatWelcome = ({
@@ -36,19 +57,7 @@ export const ChatWelcome = ({
       className="text-xl font-medium mb-1 text-center text-gray-900 dark:text-white"
       style={{ fontFamily: '"Geologica", sans-serif', animation: 'chat-fade-in 0.35s ease-out' }}
     >
-      {agentName ? (
-        <>
-          {t('How can ')}
-          <span className="text-[var(--chat-accent)]">{agentName}</span>
-          {t(' help you, ')}
-          {firstName}?
-        </>
-      ) : (
-        <>
-          {t('How can I help you, ')}
-          {firstName}?
-        </>
-      )}
+      <Greeting firstName={firstName} agentName={agentName} t={t} />
     </h2>
 
     {agentDescription && (
@@ -76,7 +85,7 @@ export const ChatWelcome = ({
             onClick={() => onPromptClick(prompt)}
             className="w-full text-left text-[0.8125rem] text-gray-800 dark:text-white py-1.5 px-3 mb-1 rounded-lg border border-gray-200 dark:border-white/10 bg-transparent transition-colors hover:bg-[var(--chat-accent-10)] hover:border-[var(--chat-accent-50)]"
           >
-            {t(prompt)}
+            {prompt}
           </button>
         ))
       )}

--- a/packages/filigran-chatbot/src/components/ContextUsageIndicator.tsx
+++ b/packages/filigran-chatbot/src/components/ContextUsageIndicator.tsx
@@ -1,12 +1,12 @@
 import { useRef, useState } from 'react';
-import type { ChatContextBreakdown, ChatContextUsage } from '../types';
-import { compactCount } from '../utils';
+import type { ChatContextBreakdown, ChatContextUsage, Translate } from '../types';
+import { compactCount, translate } from '../utils';
 import { Dropdown } from './Dropdown';
 import { Tooltip } from './Tooltip';
 
 interface ContextUsageIndicatorProps {
   usage: ChatContextUsage;
-  t: (key: string) => string;
+  t: Translate;
 }
 
 // Thresholds are the agent loop's own gates, not design choices: at 80 %
@@ -34,13 +34,13 @@ const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
  * without a legend lookup. Labels name what the user can act on, not the
  * backend's internals: "Tool results" rather than "role=tool messages".
  */
-const ROWS: ReadonlyArray<{ field: keyof ChatContextBreakdown; label: string; color: string }> = [
-  { field: 'system', label: 'System prompt', color: '#9ca3af' },
-  { field: 'tools', label: 'Tool definitions', color: '#a78bfa' },
-  { field: 'dynamicTools', label: 'MCP & dynamic tools', color: '#f0abfc' },
-  { field: 'summary', label: 'Summarized conversation', color: '#fb7185' },
-  { field: 'toolResults', label: 'Tool results', color: '#34d399' },
-  { field: 'conversation', label: 'Conversation', color: '#a1a1aa' },
+const ROWS: ReadonlyArray<{ field: keyof ChatContextBreakdown; label: (t: Translate) => string; color: string }> = [
+  { field: 'system', label: (t) => t('System prompt'), color: '#9ca3af' },
+  { field: 'tools', label: (t) => t('Tool definitions'), color: '#a78bfa' },
+  { field: 'dynamicTools', label: (t) => t('MCP & dynamic tools'), color: '#f0abfc' },
+  { field: 'summary', label: (t) => t('Summarized conversation'), color: '#fb7185' },
+  { field: 'toolResults', label: (t) => t('Tool results'), color: '#34d399' },
+  { field: 'conversation', label: (t) => t('Conversation'), color: '#a1a1aa' },
 ];
 
 /**
@@ -81,7 +81,10 @@ export const ContextUsageIndicator = ({ usage, t }: ContextUsageIndicatorProps) 
     : compacting
       ? t('Context nearly full — older turns are being summarized')
       : t('Context used');
-  const summary = `${headline} · ${counts} ${t('tokens')}`;
+  const tokens = translate(t, '{counts} tokens', { counts });
+  // Separator only — nothing to translate, so no key of its own: both halves
+  // are already whole translated readouts.
+  const summary = `${headline} · ${tokens}`;
 
   const rows = breakdown ? ROWS.filter((r) => (breakdown[r.field] ?? 0) > 0) : [];
   // Without a breakdown there is nothing to open, so the readout stays inert
@@ -91,14 +94,7 @@ export const ContextUsageIndicator = ({ usage, t }: ContextUsageIndicatorProps) 
   const gauge = (
     <span className="flex items-center gap-1.5">
       <svg width={SIZE} height={SIZE} viewBox={`0 0 ${SIZE} ${SIZE}`} className={ringColor} aria-hidden="true">
-        <circle
-          cx={SIZE / 2}
-          cy={SIZE / 2}
-          r={RADIUS}
-          fill="none"
-          strokeWidth={STROKE}
-          className="stroke-gray-200 dark:stroke-white/15"
-        />
+        <circle cx={SIZE / 2} cy={SIZE / 2} r={RADIUS} fill="none" strokeWidth={STROKE} className="stroke-gray-200 dark:stroke-white/15" />
         <circle
           cx={SIZE / 2}
           cy={SIZE / 2}
@@ -131,7 +127,7 @@ export const ContextUsageIndicator = ({ usage, t }: ContextUsageIndicatorProps) 
 
   return (
     <>
-      <Tooltip title={open ? '' : `${summary} — ${t('click for details')}`}>
+      <Tooltip title={open ? '' : translate(t, '{summary} — click for details', { summary })}>
         <button
           ref={anchorRef}
           type="button"
@@ -147,12 +143,10 @@ export const ContextUsageIndicator = ({ usage, t }: ContextUsageIndicatorProps) 
 
       <Dropdown open={open} onClose={() => setOpen(false)} anchorRef={anchorRef} placement="bottom-end" width={296}>
         <div className="px-3.5 pt-3 pb-1 flex items-baseline justify-between gap-3">
-          <span className={`text-[0.8125rem] tabular-nums ${textColor}`}>{t('{percent}% full').replace('{percent}', String(percent))}</span>
+          <span className={`text-[0.8125rem] tabular-nums ${textColor}`}>{translate(t, '{percent}% full', { percent })}</span>
           {/* The tilde is load-bearing: these are char-derived estimates, and a
               bare "168k/200k" would read as a measured count. */}
-          <span className="text-[0.7rem] tabular-nums text-gray-400 dark:text-white/40 shrink-0">
-            ~{counts} {t('tokens')}
-          </span>
+          <span className="text-[0.7rem] tabular-nums text-gray-400 dark:text-white/40 shrink-0">~{tokens}</span>
         </div>
 
         {/* One stacked bar over the whole window: the segments are the legend's
@@ -184,8 +178,10 @@ export const ContextUsageIndicator = ({ usage, t }: ContextUsageIndicatorProps) 
                   pill, which turns the swatches into dots that read as bullets
                   rather than as keys to the bar's segments. */}
               <span className="h-2 w-2 shrink-0" style={{ backgroundColor: row.color, borderRadius: 2 }} aria-hidden="true" />
-              <span className="text-[0.75rem] text-gray-700 dark:text-white/70 truncate">{t(row.label)}</span>
-              <span className="ml-auto text-[0.7rem] tabular-nums text-gray-500 dark:text-white/40 shrink-0">{compactCount(breakdown?.[row.field] ?? 0)}</span>
+              <span className="text-[0.75rem] text-gray-700 dark:text-white/70 truncate">{row.label(t)}</span>
+              <span className="ml-auto text-[0.7rem] tabular-nums text-gray-500 dark:text-white/40 shrink-0">
+                {compactCount(breakdown?.[row.field] ?? 0)}
+              </span>
             </div>
           ))}
         </div>

--- a/packages/filigran-chatbot/src/components/QuotaIndicator.tsx
+++ b/packages/filigran-chatbot/src/components/QuotaIndicator.tsx
@@ -1,5 +1,5 @@
 import type { ChatQuotaStatus } from '../types';
-import { compactCount as compact } from '../utils';
+import { compactCount as compact, translate } from '../utils';
 import { Tooltip } from './Tooltip';
 
 interface QuotaIndicatorProps {
@@ -20,7 +20,7 @@ export const QuotaIndicator = ({ quota, t }: QuotaIndicatorProps) => {
   // No ceiling: report consumption without implying a limit that isn't there.
   if (limit === null) {
     return (
-      <Tooltip title={period ? `${t('Usage')} · ${period}` : t('Usage')}>
+      <Tooltip title={period ? translate(t, 'Usage · {period}', { period }) : t('Usage')}>
         <span className="text-[0.68rem] tabular-nums text-gray-400 dark:text-white/30">{compact(used)}</span>
       </Tooltip>
     );
@@ -39,7 +39,8 @@ export const QuotaIndicator = ({ quota, t }: QuotaIndicatorProps) => {
       : 'text-gray-400 dark:text-white/30';
 
   const label = `${compact(used)}/${compact(limit)}`;
-  const title = [exhausted ? t('Quota reached') : t('Quota'), period].filter(Boolean).join(' · ');
+  const headline = exhausted ? t('Quota reached') : t('Quota');
+  const title = period ? `${headline} · ${period}` : headline;
 
   return (
     <Tooltip title={title}>

--- a/packages/filigran-chatbot/src/components/ReasoningDetailsDialog.tsx
+++ b/packages/filigran-chatbot/src/components/ReasoningDetailsDialog.tsx
@@ -13,7 +13,7 @@ import {
   XCircleIcon,
 } from './icons';
 import { cleanReasoningText } from './ChatThinking';
-import { findChatbotRoot } from '../utils';
+import { findChatbotRoot, translate } from '../utils';
 
 /** Trace values longer than this are shown raw instead of pretty-printed JSON. */
 const TRACE_PRETTY_LIMIT = 10_000;
@@ -162,9 +162,9 @@ export const ReasoningDetailsDialog = ({ msg, onClose, t }: ReasoningDetailsDial
   const reasoning = (msg.reasoning ?? '').trim();
 
   const summaryParts = [
-    iterations > 1 ? `${iterations} ${t('iterations')}` : '',
-    `${totalCalls} ${totalCalls === 1 ? t('tool call') : t('tool calls')}`,
-    transfers.length > 0 ? `${transfers.length} ${transfers.length === 1 ? t('transfer') : t('transfers')}` : '',
+    iterations > 1 ? translate(t, '{count} iterations', { count: iterations }) : '',
+    totalCalls === 1 ? t('1 tool call') : translate(t, '{count} tool calls', { count: totalCalls }),
+    transfers.length === 1 ? t('1 transfer') : transfers.length > 1 ? translate(t, '{count} transfers', { count: transfers.length }) : '',
   ].filter(Boolean);
 
   return (

--- a/packages/filigran-chatbot/src/hooks/protocols/parseAgUiEvent.ts
+++ b/packages/filigran-chatbot/src/hooks/protocols/parseAgUiEvent.ts
@@ -25,7 +25,10 @@ export function parseAgUiEvent(evt: Record<string, unknown>, ctx: ProtocolContex
   }
 
   if (type === 'RUN_ERROR') {
-    return { action: 'error', content: (evt.message as string) || 'Unknown error' };
+    // Empty rather than a literal English fallback: the content is rendered as
+    // the assistant's message, and the consumer supplies its own translated
+    // text when the backend sends none — as the other protocols already do.
+    return { action: 'error', content: (evt.message as string) || '' };
   }
 
   // --- Step lifecycle ---

--- a/packages/filigran-chatbot/src/hooks/protocols/parseAgUiEvent.ts
+++ b/packages/filigran-chatbot/src/hooks/protocols/parseAgUiEvent.ts
@@ -28,7 +28,7 @@ export function parseAgUiEvent(evt: Record<string, unknown>, ctx: ProtocolContex
     // Empty rather than a literal English fallback: the content is rendered as
     // the assistant's message, and the consumer supplies its own translated
     // text when the backend sends none — as the other protocols already do.
-    return { action: 'error', content: (evt.message as string) || '' };
+    return { action: 'error', content: typeof evt.message === 'string' ? evt.message : '' };
   }
 
   // --- Step lifecycle ---

--- a/packages/filigran-chatbot/src/hooks/protocols/parseRestEvent.ts
+++ b/packages/filigran-chatbot/src/hooks/protocols/parseRestEvent.ts
@@ -152,7 +152,9 @@ export function parseToolApprovalProposals(raw: unknown): ToolApprovalProposal[]
     const schema = p.input_schema;
     out.push({
       toolCallId,
-      toolName: typeof p.tool_name === 'string' && p.tool_name ? p.tool_name : 'unknown tool',
+      // Left empty for the UI to label: a parser has no `t`, and a placeholder
+      // baked in here would reach the reviewer untranslated.
+      toolName: typeof p.tool_name === 'string' && p.tool_name ? p.tool_name : '',
       toolDescription: typeof p.tool_description === 'string' ? p.tool_description : undefined,
       arguments: args && typeof args === 'object' && !Array.isArray(args) ? (args as Record<string, unknown>) : {},
       inputSchema: schema && typeof schema === 'object' && !Array.isArray(schema) ? (schema as Record<string, unknown>) : undefined,

--- a/packages/filigran-chatbot/src/hooks/useAwayCompletionNotice.ts
+++ b/packages/filigran-chatbot/src/hooks/useAwayCompletionNotice.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import { translate } from '../utils';
 
 /**
  * A turn must run at least this long before its completion is worth a
@@ -156,7 +157,7 @@ export function useAwayCompletionNotice({
       // Focused tab + looking at the chat → the streamed answer is the feedback.
       if (!away && viewingChat) return;
       const title = t('Response ready');
-      const body = agentName ? `${agentName} ${t('has finished')}` : t('Your answer is ready');
+      const body = agentName ? translate(t, '{agent} has finished', { agent: agentName }) : t('Your answer is ready');
       if (away) {
         startTitleFlash(title);
         notifyOS(title, body);

--- a/packages/filigran-chatbot/src/hooks/useChat.ts
+++ b/packages/filigran-chatbot/src/hooks/useChat.ts
@@ -726,9 +726,7 @@ export function useChat({
       // somebody else answered it. Distinguished from a transient failure
       // because retrying cannot help; the stream ending clears the prompt.
       setApprovalError(
-        res.status === 409
-          ? t('This turn is no longer waiting for a decision.')
-          : t('Could not send your decision. Please try again.'),
+        res.status === 409 ? t('This turn is no longer waiting for a decision.') : t('Could not send your decision. Please try again.'),
       );
     } catch {
       setApprovalError(t('Could not send your decision. Please try again.'));
@@ -979,7 +977,10 @@ export function useChat({
                 const segId = currentAssistantId;
                 setMessages((prev) =>
                   prev.map((m) =>
-                    m.id === segId ? { ...m, content: parsed.content || t('Unable to connect. Please check the configuration.') } : m,
+                    // The backend reported a failure of its own, so the generic
+                    // apology rather than "check the configuration": the
+                    // connection plainly worked.
+                    m.id === segId ? { ...m, content: parsed.content || t('Sorry, an error occurred. Please try again.') } : m,
                   ),
                 );
                 return;
@@ -1004,7 +1005,7 @@ export function useChat({
       if (accumulated && !doneReceived) {
         const segId = currentAssistantId;
         const text = accumulated;
-        setMessages((prev) => prev.map((m) => (m.id === segId ? { ...m, content: text || 'No response.' } : m)));
+        setMessages((prev) => prev.map((m) => (m.id === segId ? { ...m, content: text || t('No response.') } : m)));
       }
     } catch (err) {
       if (err instanceof DOMException && err.name === 'AbortError') return;

--- a/packages/filigran-chatbot/src/index.ts
+++ b/packages/filigran-chatbot/src/index.ts
@@ -18,6 +18,7 @@ export type {
   ToolApprovalDecision,
   ToolApprovalProposal,
   ToolApprovalVerdict,
+  Translate,
   XtmAgent,
   ApiEndpoints,
 } from './types';

--- a/packages/filigran-chatbot/src/types.ts
+++ b/packages/filigran-chatbot/src/types.ts
@@ -1,4 +1,13 @@
 export type ChatMode = 'sidebar' | 'floating' | 'fullscreen';
+
+/**
+ * The host's translation lookup, passed down to every component that renders
+ * text. Key in, translated string out — the package never owns a dictionary of
+ * its own, and never asks the host's `t` for more than a lookup: values are
+ * spliced into the *translated* sentence by `translate()` in `utils`, so a key
+ * is always a whole sentence and a locale stays free to reorder it.
+ */
+export type Translate = (key: string) => string;
 export type BackendType = 'legacy' | 'rest' | 'ag-ui';
 /** A user's rating of one assistant answer. */
 export type MessageFeedback = 'up' | 'down';
@@ -158,6 +167,7 @@ export interface ToolApprovalProposal {
    * different arguments.
    */
   toolCallId: string;
+  /** Empty when the backend named no tool; the UI labels that case itself. */
   toolName: string;
   toolDescription?: string;
   arguments: Record<string, unknown>;
@@ -245,7 +255,7 @@ export interface ChatPanelProps {
   apiEndpoints?: ApiEndpoints;
   agentDashboardUrl?: string;
   user: { firstName: string };
-  t?: (key: string) => string;
+  t?: Translate;
   accentColor?: string;
   logoIcon?: React.ReactNode;
   promptSuggestions?: string[];
@@ -371,7 +381,9 @@ export interface ChatPanelProps {
 export interface ChatToggleButtonProps {
   isOpen: boolean;
   onToggle: () => void;
+  /** Overrides the built-in label; already translated by the host. */
   label?: string;
+  t?: Translate;
   accentColor?: string;
   icon?: React.ReactNode;
 }

--- a/packages/filigran-chatbot/src/utils/index.ts
+++ b/packages/filigran-chatbot/src/utils/index.ts
@@ -1,3 +1,5 @@
+import type { Translate } from '../types';
+
 export function hexAlpha(hex: string, alpha: number): string {
   const a = Math.round(alpha * 255)
     .toString(16)
@@ -287,7 +289,56 @@ export function markdownUrlTransform(url: string): string {
   return '';
 }
 
-export const identity = (key: string) => key;
+export const identity: Translate = (key) => key;
+
+/**
+ * Translates `key`, then splices `values` into the result's `{name}` slots.
+ *
+ * The point is that the key stays a whole sentence. Building a phrase out of
+ * translated fragments — "Waiting for" + count + "tasks" — freezes English word
+ * order and English plural rules into the layout, and a translator sees each
+ * fragment with no sentence around it. Here the locale owns the whole sentence
+ * and decides where the number goes; the host's `t` still does nothing but look
+ * a key up, so this needs no support from it.
+ *
+ * Plurals stay two explicit keys (`'1 tool call'` / `'{count} tool calls'`) for
+ * the same reason: a lookup cannot select a plural form, so the call site picks
+ * the sentence and the locale translates it whole.
+ */
+export function translate(t: Translate, key: string, values: Record<string, string | number>): string {
+  // One pass over the sentence rather than one pass per value: a value that
+  // happens to contain `{something}` is then never mistaken for a slot of its
+  // own. A slot with no value keeps its braces, so a stray one is visible
+  // rather than silently blank.
+  return t(key).replace(/\{(\w+)\}/g, (slot, name) => (name in values ? String(values[name] ?? '') : slot));
+}
+
+/**
+ * Same as `translate`, but leaves one slot unfilled and returns the text on
+ * either side of it — for the case where the value has to be markup (a coloured
+ * agent name, a link) and so cannot be spliced into a string.
+ *
+ * Without this the sentence gets cut into "How can " + node + " help you, ",
+ * which is untranslatable in any language that would not put the node in that
+ * spot. Here the locale still owns the whole sentence and decides where the slot
+ * sits.
+ *
+ * `hasSlot` is false for a translation that dropped the slot — a locale that
+ * reworded the sentence so it no longer names the value. The caller then renders
+ * the sentence without the node instead of letting it dangle off the end.
+ */
+export function translateAround(
+  t: Translate,
+  key: string,
+  slot: string,
+  values: Record<string, string | number> = {},
+): { before: string; after: string; hasSlot: boolean } {
+  const sentence = translate(t, key, values);
+  const token = `{${slot}}`;
+  const at = sentence.indexOf(token);
+  if (at === -1) return { before: sentence, after: '', hasSlot: false };
+  return { before: sentence.slice(0, at), after: sentence.slice(at + token.length), hasSlot: true };
+}
 
 /**
  * Nearest chatbot panel root (`.filigran-chatbot`) for portal-based overlays
@@ -320,18 +371,18 @@ export function compactCount(n: number): string {
  * Returns an empty string for missing/unparseable timestamps so the row
  * simply omits the label instead of showing "Invalid Date".
  */
-export function timeAgo(iso: string | undefined, t: (key: string) => string): string {
+export function timeAgo(iso: string | undefined, t: Translate): string {
   if (!iso) return '';
   const then = new Date(iso).getTime();
   if (Number.isNaN(then)) return '';
   const diffMs = Date.now() - then;
   const minutes = Math.floor(diffMs / 60_000);
   if (minutes < 1) return t('just now');
-  if (minutes < 60) return `${minutes}${t('m ago')}`;
+  if (minutes < 60) return translate(t, '{count}m ago', { count: minutes });
   const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}${t('h ago')}`;
+  if (hours < 24) return translate(t, '{count}h ago', { count: hours });
   const days = Math.floor(hours / 24);
-  if (days < 7) return `${days}${t('d ago')}`;
+  if (days < 7) return translate(t, '{count}d ago', { count: days });
   return new Date(iso).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
 }
 

--- a/packages/filigran-chatbot/src/utils/index.ts
+++ b/packages/filigran-chatbot/src/utils/index.ts
@@ -310,7 +310,7 @@ export function translate(t: Translate, key: string, values: Record<string, stri
   // happens to contain `{something}` is then never mistaken for a slot of its
   // own. A slot with no value keeps its braces, so a stray one is visible
   // rather than silently blank.
-  return t(key).replace(/\{(\w+)\}/g, (slot, name) => (name in values ? String(values[name] ?? '') : slot));
+  return t(key).replace(/\{(\w+)\}/g, (slot, name) => (Object.hasOwn(values, name) ? String(values[name] ?? '') : slot));
 }
 
 /**


### PR DESCRIPTION
Closes #390.

- `translate(t, key, values)` fills `{placeholder}` slots after the lookup, so a key is a whole sentence and a locale can reorder it.
- `translateAround` covers the case where the value is markup (the accent-coloured agent name in the greeting), and reports a slot the locale dropped so the name is omitted rather than trailed.
- Plurals are two keys per branch — a lookup cannot select a plural form.
- Constant tables (modes, gauge rows, mini-game messages, fallback suggestions) hold `(t) => t('…')` thunks, so extraction sees every key (§2).
- `ChatToggleButton` takes its own `t`; `Translate` is exported. Parsers leave unnamed-tool and empty-error cases blank for the UI to label.
- README: all 148 keys by area, plus the placeholder and plural conventions.

`t` stays a plain key lookup — no dictionary in the package, no signature change.

**Breaking for locale files:** ~20 keys are renamed (`'Waiting for'` + `'tasks'` → `'Waiting for {count} background tasks…'`, `'m ago'` → `'{count}m ago'`, etc.). Version is 3.9.1; a `^3.9.0` host picks it up and those strings fall back to English until its locale files are updated.