### PR TITLE
feat(accordion): add accordion variant (#393)

### DIFF
--- a/packages/filigran-ui/src/components/clients/accordion.tsx
+++ b/packages/filigran-ui/src/components/clients/accordion.tsx
@@ -2,7 +2,9 @@
 
 import * as AccordionPrimitive from '@radix-ui/react-accordion'
 import {ArrowDropDownIcon} from '@filigran/icon'
+import {cva, type VariantProps} from 'class-variance-authority'
 import * as React from 'react'
+import {buttonVariants} from '../servers/button'
 import {cn} from '../../lib/utils'
 
 const Accordion = AccordionPrimitive.Root
@@ -19,23 +21,58 @@ const AccordionItem = React.forwardRef<
 ))
 AccordionItem.displayName = 'AccordionItem'
 
+const accordionTriggerVariants = cva(
+  'flex flex-1 items-center justify-between py-2 pr-2 font-medium transition-all hover:underline',
+  {
+    variants: {
+      variant: {
+        default: '[&[data-state=open]>.accordion-arrow-icon]:rotate-180',
+        colored:
+          'border-t border-elevation-background-layer-3 hover:cursor-pointer [&[data-state=open]_.accordion-arrow-icon]:rotate-180',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  }
+)
+
+interface AccordionTriggerProps
+  extends React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Trigger>,
+    VariantProps<typeof accordionTriggerVariants> {}
+
 const AccordionTrigger = React.forwardRef<
   React.ElementRef<typeof AccordionPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Trigger>
->(({className, children, ...props}, ref) => (
-  <AccordionPrimitive.Header className="flex">
-    <AccordionPrimitive.Trigger
-      ref={ref}
-      className={cn(
-        'flex flex-1 items-center justify-between py-2 pr-2 font-medium transition-all hover:underline [&[data-state=open]>svg]:rotate-180',
-        className
-      )}
-      {...props}>
-      {children}
-      <ArrowDropDownIcon className="h-5 w-5 shrink-0 transition-transform duration-200" />
-    </AccordionPrimitive.Trigger>
-  </AccordionPrimitive.Header>
-))
+  AccordionTriggerProps
+>(({className, children, variant, ...props}, ref) => {
+  const showColoredTrigger = variant === 'colored'
+
+  return (
+    <AccordionPrimitive.Header
+      className={cn('flex', showColoredTrigger && 'items-center gap-1')}>
+      <AccordionPrimitive.Trigger
+        ref={ref}
+        className={cn(
+          accordionTriggerVariants({variant}),
+          className
+        )}
+        {...props}>
+        {children}
+        {showColoredTrigger ? (
+          <span
+            className={cn(
+              buttonVariants({variant: 'secondary', size: 'icon'}),
+              'shrink-0'
+            )}>
+            <ArrowDropDownIcon className="accordion-arrow-icon h-5 w-5 shrink-0 transition-transform duration-200" />
+          </span>
+        ) : (
+          <ArrowDropDownIcon className="accordion-arrow-icon h-5 w-5 shrink-0 transition-transform duration-200" />
+        )}
+      </AccordionPrimitive.Trigger>
+    </AccordionPrimitive.Header>
+  )
+})
 AccordionTrigger.displayName = AccordionPrimitive.Trigger.displayName
 
 const AccordionContent = React.forwardRef<

--- a/projects/filigran-website/components/react-live/ReactLiveDisplay.tsx
+++ b/projects/filigran-website/components/react-live/ReactLiveDisplay.tsx
@@ -2,9 +2,10 @@
 
 import {LiveProvider, LiveEditor, LiveError, LivePreview} from 'react-live'
 import {FunctionComponent} from 'react'
-import {tw} from 'twind'
 import * as FiligranUIComponent from '@filigran/ui'
 import * as FiligranIcon from '@filigran/icon'
+
+const tw = (className: string) => className
 
 interface ReactLiveDisplayProps {
   scope?: any

--- a/projects/filigran-website/content/docs/components/accordion.mdx
+++ b/projects/filigran-website/content/docs/components/accordion.mdx
@@ -5,25 +5,79 @@ title: Accordion
 # Accordion example
 
 Displays an accordion that can be folded.
-
-<Accordion
-  type="single"
-  collapsible
-  className="w-full">
+<div className="not-prose">
+  <Accordion
+    type="single"
+    collapsible
+    className="w-full">
   <AccordionItem value="item-1">
     <AccordionTrigger>Is it accessible?</AccordionTrigger>
     <AccordionContent>
-      Yes. It adheres to the WAI-ARIA design pattern.
+      Starter culture, cheese board, havarti, aged, gorgonzola, paired with wine. Taleggio, morbier, asiago, cheese curds, mont d’or, raclette, crackers. Savory, pepper jack, aromatic, wensleydale, caciocavallo, slices, perfectly ripened. Handcrafted colby ferments farmer's favorite. Platter, burrata, wensleydale, feta, hard rind, halloumi, curd. Fig jam served with emmental creates a crumbly combination. Cheshire, gruyere, edam, honeycomb, crackers, ricotta, epoisses. Experience the savory texture of chutney perfectly ripened.
+
+      Smelly and funky appenzeller enhances on a wooden board. Pepper jack garnished with baguette creates a delicious combination. Valençay, and, swiss, and, scamorza, featuring, fig jam, with herbal notes. Crackers, with, brie, featuring, raclette, garnished with, red leicester, from local dairies. Experience the smelly texture of milk fat with pickles.
+
+      The aged red leicester infuses beautifully with honey. Roquefort is toasty paired with starter culture. Handcrafted, grapes, melted, havarti, chutney, enhances, with flaky sea salt. Tomme combined with valençay creates a local combination. This velvety brie grates wonderfully on a wooden board. The tangy reblochon transforms beautifully wrapped in wax.
+
+      Experience the rich texture of blue cheese on the cheese plate. Bubbly, rennet, silky, grapes, fontina, oozes, with crusty bread. Premium and mild paneer spreads cave-aged to perfection. Fig jam is smooth paired with gratin. Savory hard rind transforms farmer's favorite. Rind, fresh curds, cave aging, comté, cheshire, mozzarella, double gloucester. Halloumi, limburger, sbrinz, golden, taleggio, with crusty bread.
+
+      This gooey rennet ages wonderfully in the fondue pot. Starter culture is premium featuring burrata. Rind, saint-nectaire, manchego, silky, mascarpone, with pickles. Asiago, baguette, gloucester, silky, feta, with cracked pepper. Hard and smoky fondue bubbles paired with wine. Stinky panini enhances in the fondue pot. Cantal, cheshire, cheshire, paneer, gratin, monterey jack, stracciatella. This smoky wax rind pairs wonderfully served at room temperature.
+
+      Experience the savory texture of salt crystals traditionally crafted. Artisan and savory saint-nectaire enhances with chutney. The velvety emmental ferments beautifully with fig jam. Lancashire, appenzeller, ricotta, velvety, gloucester, on a wooden board. Chutney and grapes creates a aromatic combination. Experience the stinky texture of rind with herbal notes.
+
+      Aromatic red leicester matures traditionally crafted. Fondue, paneer, monterey jack, pungent, panini, on the cheese plate. Imported and smelly cantal mingles with herbal notes. Mont d’or with chèvre creates a stinky combination. Camembert, platter, mascarpone, savory, salt crystals, chef's choice. Bleu d’auvergne, ricotta, camembert, platter, bleu d’auvergne, cantal, milk fat. Gourmet, valençay, pungent, wensleydale, crackers, bubbles, from the alps. Goat cheese, alongside, gouda, combined with, cheese curds, served with, roquefort, with flaky sea salt. Pear slices, with, crottin, alongside, havarti, served with, reblochon, with honey.
+
+      Mild, curd, handcrafted, gouda, sbrinz, combines, with pickles. Hard rind, boursin, cheshire, bubbly, fondue, perfectly ripened. Cantal, cave aging, muenster, nutty, cheshire, on a wooden board. Delicious, mont d’or, organic, jarlsberg, burrata, grates, with pickles. Organic queso elevates with flaky sea salt. The smooth cheshire enhances beautifully award-winning.
+
+      Fondue is salty topped with hard rind. The stretchy mimolette grates beautifully perfectly ripened. The artisan jarlsberg oozes beautifully on the cheese plate. Aged and aromatic paneer enhances cave-aged to perfection. Pear slices, queso, gorgonzola, delicious, ricotta, paired with wine. Premium and hard parmesan drizzles from the alps.
+
+      Goat cheese, mont d’or, mascarpone, handcrafted, provolone, award-winning. Melted, scamorza, soft, swiss, mascarpone, grates, on a wooden board. This golden chèvre browns wonderfully paired with wine. Brie is hard served with havarti. Bubbly and savory gorgonzola swirls award-winning. Delicious, washed rind, crumbly, curd, camembert, bubbles, with honey. Starter culture, washed rind, leicester, nutty, brie, with chutney. Saint-nectaire, and, limburger, served with, gruyere, featuring, provolone, with chutney. Gourmet, bleu d’auvergne, firm, lancashire, chutney, crumbles, under candlelight.
+
+      Mozzarella, gratin, provolone, mozzarella, cantal, chèvre, cheese curds. This tangy valençay transforms wonderfully in the fondue pot. Aromatic, swiss, rich, crottin, reblochon, complements, on a wooden board. Toastie, tomme, bleu d’auvergne, roquefort, queso, stilton, scamorza. This imported platter infuses wonderfully wrapped in wax.
+
+      Experience the premium texture of feta wrapped in wax. Mild tomme stretches traditionally crafted. The stinky crottin complements beautifully with a hint of truffle. Crumbly cantal blends farmer's favorite. Experience the savory texture of edam from local dairies. Experience the sharp texture of goat cheese from the alps. Goat cheese, garnished with, gorgonzola, garnished with, provolone, and, gouda, from the alps.
+
+      Wax rind, blue cheese, queso, fresh, taleggio, with a hint of truffle. This fresh mimolette mingles wonderfully wrapped in wax. Aromatic and sharp lancashire infuses traditionally crafted. Provolone, provolone, bleu d’auvergne, manchego, boursin, rind, cheese board. Experience the organic texture of asiago on the cheese plate. The artisan cheshire grates beautifully paired with wine. Appenzeller, garnished with, edam, and, feta, combined with, whey, with chutney.
     </AccordionContent>
   </AccordionItem>
   <AccordionItem value="item-2">
     <AccordionTrigger>Is it styled?</AccordionTrigger>
     <AccordionContent>
-      Yes. It comes with default styles that matches the other components&apos;
-      aesthetic.
+      Starter culture, cheese board, havarti, aged, gorgonzola, paired with wine. Taleggio, morbier, asiago, cheese curds, mont d’or, raclette, crackers. Savory, pepper jack, aromatic, wensleydale, caciocavallo, slices, perfectly ripened. Handcrafted colby ferments farmer's favorite. Platter, burrata, wensleydale, feta, hard rind, halloumi, curd. Fig jam served with emmental creates a crumbly combination. Cheshire, gruyere, edam, honeycomb, crackers, ricotta, epoisses. Experience the savory texture of chutney perfectly ripened.
+
+      Smelly and funky appenzeller enhances on a wooden board. Pepper jack garnished with baguette creates a delicious combination. Valençay, and, swiss, and, scamorza, featuring, fig jam, with herbal notes. Crackers, with, brie, featuring, raclette, garnished with, red leicester, from local dairies. Experience the smelly texture of milk fat with pickles.
+
+      The aged red leicester infuses beautifully with honey. Roquefort is toasty paired with starter culture. Handcrafted, grapes, melted, havarti, chutney, enhances, with flaky sea salt. Tomme combined with valençay creates a local combination. This velvety brie grates wonderfully on a wooden board. The tangy reblochon transforms beautifully wrapped in wax.
+
+      Experience the rich texture of blue cheese on the cheese plate. Bubbly, rennet, silky, grapes, fontina, oozes, with crusty bread. Premium and mild paneer spreads cave-aged to perfection. Fig jam is smooth paired with gratin. Savory hard rind transforms farmer's favorite. Rind, fresh curds, cave aging, comté, cheshire, mozzarella, double gloucester. Halloumi, limburger, sbrinz, golden, taleggio, with crusty bread.
+
+      This gooey rennet ages wonderfully in the fondue pot. Starter culture is premium featuring burrata. Rind, saint-nectaire, manchego, silky, mascarpone, with pickles. Asiago, baguette, gloucester, silky, feta, with cracked pepper. Hard and smoky fondue bubbles paired with wine. Stinky panini enhances in the fondue pot. Cantal, cheshire, cheshire, paneer, gratin, monterey jack, stracciatella. This smoky wax rind pairs wonderfully served at room temperature.
+
+      Experience the savory texture of salt crystals traditionally crafted. Artisan and savory saint-nectaire enhances with chutney. The velvety emmental ferments beautifully with fig jam. Lancashire, appenzeller, ricotta, velvety, gloucester, on a wooden board. Chutney and grapes creates a aromatic combination. Experience the stinky texture of rind with herbal notes.
+
+      Aromatic red leicester matures traditionally crafted. Fondue, paneer, monterey jack, pungent, panini, on the cheese plate. Imported and smelly cantal mingles with herbal notes. Mont d’or with chèvre creates a stinky combination. Camembert, platter, mascarpone, savory, salt crystals, chef's choice. Bleu d’auvergne, ricotta, camembert, platter, bleu d’auvergne, cantal, milk fat. Gourmet, valençay, pungent, wensleydale, crackers, bubbles, from the alps. Goat cheese, alongside, gouda, combined with, cheese curds, served with, roquefort, with flaky sea salt. Pear slices, with, crottin, alongside, havarti, served with, reblochon, with honey.
+
+      Mild, curd, handcrafted, gouda, sbrinz, combines, with pickles. Hard rind, boursin, cheshire, bubbly, fondue, perfectly ripened. Cantal, cave aging, muenster, nutty, cheshire, on a wooden board. Delicious, mont d’or, organic, jarlsberg, burrata, grates, with pickles. Organic queso elevates with flaky sea salt. The smooth cheshire enhances beautifully award-winning.
+
+      Fondue is salty topped with hard rind. The stretchy mimolette grates beautifully perfectly ripened. The artisan jarlsberg oozes beautifully on the cheese plate. Aged and aromatic paneer enhances cave-aged to perfection. Pear slices, queso, gorgonzola, delicious, ricotta, paired with wine. Premium and hard parmesan drizzles from the alps.
+
+      Goat cheese, mont d’or, mascarpone, handcrafted, provolone, award-winning. Melted, scamorza, soft, swiss, mascarpone, grates, on a wooden board. This golden chèvre browns wonderfully paired with wine. Brie is hard served with havarti. Bubbly and savory gorgonzola swirls award-winning. Delicious, washed rind, crumbly, curd, camembert, bubbles, with honey. Starter culture, washed rind, leicester, nutty, brie, with chutney. Saint-nectaire, and, limburger, served with, gruyere, featuring, provolone, with chutney. Gourmet, bleu d’auvergne, firm, lancashire, chutney, crumbles, under candlelight.
+
+      Mozzarella, gratin, provolone, mozzarella, cantal, chèvre, cheese curds. This tangy valençay transforms wonderfully in the fondue pot. Aromatic, swiss, rich, crottin, reblochon, complements, on a wooden board. Toastie, tomme, bleu d’auvergne, roquefort, queso, stilton, scamorza. This imported platter infuses wonderfully wrapped in wax.
+
+      Experience the premium texture of feta wrapped in wax. Mild tomme stretches traditionally crafted. The stinky crottin complements beautifully with a hint of truffle. Crumbly cantal blends farmer's favorite. Experience the savory texture of edam from local dairies. Experience the sharp texture of goat cheese from the alps. Goat cheese, garnished with, gorgonzola, garnished with, provolone, and, gouda, from the alps.
+
+      Wax rind, blue cheese, queso, fresh, taleggio, with a hint of truffle. This fresh mimolette mingles wonderfully wrapped in wax. Aromatic and sharp lancashire infuses traditionally crafted. Provolone, provolone, bleu d’auvergne, manchego, boursin, rind, cheese board. Experience the organic texture of asiago on the cheese plate. The artisan cheshire grates beautifully paired with wine. Appenzeller, garnished with, edam, and, feta, combined with, whey, with chutney.
     </AccordionContent>
   </AccordionItem>
-</Accordion>
+  <AccordionItem value="item-3">
+      <AccordionTrigger variant="colored">Does it have variant?</AccordionTrigger>
+      <AccordionContent>
+       Yes a beautiful variant!
+      </AccordionContent>
+    </AccordionItem>
+  </Accordion>
+</div>
 
 ## How to use this accordion
 
@@ -35,6 +89,7 @@ Displays an accordion that can be folded.
 | **type**          | _enum ("single" \| "multiple")_     | -        | Determines whether one or multiple items can be opened at the same time.                                                                     |
 | **value**         | _string_                            | -        | The controlled value of the item to expand when type is "single". Must be used in conjunction with onValueChange.                            |
 | **value**         | _string[]_                          | -        | The controlled value of the item to expand when type is "multiple". Must be used in conjunction with onValueChange.                          |
+| **variant**       | _enum ("default" \| "colored")      | default  | The displayed variant                          |
 | **defaultValue**  | _string_                            | -        | The value of the item to expand when initially rendered and type is "single". Use when you do not need to control the state of the items.    |
 | **defaultValue**  | _string[]_                          | -        | The value of the item to expand when initially rendered when type is "multiple". Use when you do not need to control the state of the items. |
 | **onValueChange** | _(value: string) => void_           | -        | Event handler called when the expanded state of an item changes and type is "single".                                                        |
@@ -43,6 +98,7 @@ Displays an accordion that can be folded.
 | **disabled**      | _boolean_                           | false    | When true, prevents the user from interacting with the accordion and all its items.                                                          |
 | **dir**           | _enum ("ltr" \| "rtl")_             | ltr      | The reading direction of the accordion when applicable. If omitted, assumes LTR (left-to-right) reading mode.                                |
 | **orientation**   | _enum ("vertical" \| "horizontal")_ | vertical | The orientation of the accordion.                                                                                                            |
+| **variant** (AccordionTrigger) | _enum ("default" \| "colored")_ | default | Applies trigger-specific styling. Use `colored` to enable the bordered trigger with the secondary icon button.                               |
 
 ### Playground
 
@@ -53,15 +109,20 @@ Import \{Accordion, AccordionItem, AccordionTrigger, AccordionContent\} from '@f
 <ReactLiveDisplay
   codeExample={`
   <div className={tw(\`flex gap-2\`)}>
-<Accordion type="single" collapsible className="w-full">
+<Accordion
+  type="single"
+  collapsible
+  showNextItemAnchor
+  nextItemScrollOffset={96}
+  className="w-full">
   <AccordionItem value="item-1">
-    <AccordionTrigger>Is it accessible?</AccordionTrigger>
+    <AccordionTrigger variant="colored">Is it accessible?</AccordionTrigger>
     <AccordionContent>
       Yes. It adheres to the WAI-ARIA design pattern.
     </AccordionContent>
   </AccordionItem>
   <AccordionItem value="item-2">
-    <AccordionTrigger>Is it styled?</AccordionTrigger>
+    <AccordionTrigger variant="colored">Is it styled?</AccordionTrigger>
     <AccordionContent>
       Yes. It comes with default styles that matches the other
       components&apos; aesthetic.


### PR DESCRIPTION
Add the new variant "colored"

<img width="1697" height="221" alt="image" src="https://github.com/user-attachments/assets/ce063bb4-b7bc-4799-8518-b36d62e01eae" />

<img width="1703" height="246" alt="image" src="https://github.com/user-attachments/assets/3adaed96-4b72-4330-954b-0e1311b1bde3" />

### Proposed changes

* Add a new variant with: the right icon in a secondary button; the trigger with a top blue border
* Fix ReactLiveDisplay in Filgiran-website


