### PR TITLE
fix(chatbot): show the server's message when a send is refused (#398)

### DIFF
--- a/packages/filigran-chatbot/README.md
+++ b/packages/filigran-chatbot/README.md
@@ -787,6 +787,7 @@ Every key the package can ask for, grouped by where it appears:
 - `'No response.'`
 - `'Response ready'`
 - `'Sorry, an error occurred. Please try again.'`
+- `'The request failed ({status}).'`
 - `'This decision could not be sent. Reload the chat and try again.'`
 - `'This turn is no longer waiting for a decision.'`
 - `'Unable to connect. Please check the configuration.'`

--- a/packages/filigran-chatbot/package.json
+++ b/packages/filigran-chatbot/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "git+https://github.com/FiligranHQ/filigran-ui.git"
   },
-  "version": "3.9.1",
+  "version": "3.9.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/filigran-chatbot/src/hooks/protocols/parseAgUiEvent.ts
+++ b/packages/filigran-chatbot/src/hooks/protocols/parseAgUiEvent.ts
@@ -1,3 +1,4 @@
+import { extractErrorText } from '../../utils';
 import type { ParsedAction, ProtocolContext } from './types';
 
 /**
@@ -28,7 +29,7 @@ export function parseAgUiEvent(evt: Record<string, unknown>, ctx: ProtocolContex
     // Empty rather than a literal English fallback: the content is rendered as
     // the assistant's message, and the consumer supplies its own translated
     // text when the backend sends none — as the other protocols already do.
-    return { action: 'error', content: typeof evt.message === 'string' ? evt.message : '' };
+    return { action: 'error', content: extractErrorText(evt.message) };
   }
 
   // --- Step lifecycle ---

--- a/packages/filigran-chatbot/src/hooks/protocols/parseLegacyEvent.ts
+++ b/packages/filigran-chatbot/src/hooks/protocols/parseLegacyEvent.ts
@@ -1,3 +1,4 @@
+import { extractErrorText } from '../../utils';
 import type { ParsedAction, ProtocolContext } from './types';
 
 /**
@@ -54,7 +55,7 @@ export function parseLegacyEvent(evt: Record<string, unknown>, ctx: ProtocolCont
   }
 
   if (eventType === 'error') {
-    return { action: 'error', content: (evt.data as string) || '' };
+    return { action: 'error', content: extractErrorText(evt.data) };
   }
 
   if (eventType === 'end') {

--- a/packages/filigran-chatbot/src/hooks/protocols/parseRestEvent.ts
+++ b/packages/filigran-chatbot/src/hooks/protocols/parseRestEvent.ts
@@ -6,6 +6,7 @@ import type {
   ToolCallTraceEntry,
   TransferChainEntry,
 } from '../../types';
+import { extractErrorText } from '../../utils';
 import type { ParsedAction, ProtocolContext } from './types';
 
 /** Wire key → the breakdown field it populates. */
@@ -171,7 +172,10 @@ export function parseRestEvent(evt: Record<string, unknown>, ctx: ProtocolContex
   const type = evt.type as string | undefined;
 
   if (type === 'error') {
-    return { action: 'error', content: (evt.content as string) || '' };
+    // `content` is not always a string: a refusal can arrive as the raw error
+    // body (`{detail: {code, message}}`), which reaches the bubble as
+    // "[object Object]" unless the text is pulled out of it here.
+    return { action: 'error', content: extractErrorText(evt.content) };
   }
 
   if (type === 'status') {

--- a/packages/filigran-chatbot/src/hooks/useChat.ts
+++ b/packages/filigran-chatbot/src/hooks/useChat.ts
@@ -812,8 +812,8 @@ export function useChat({
         // misconfigured connection: the host puts the line meant for the user
         // in the error body, so it wins over any generic text we could write.
         const reason = await responseErrorText(res);
-        const content = reason || translate(t, 'The request failed ({status}).', { status: res.status });
-        setMessages((prev) => prev.map((m) => (m.id === assistantId ? { ...m, content } : m)));
+        const errorLine = reason || translate(t, 'The request failed ({status}).', { status: res.status });
+        setMessages((prev) => prev.map((m) => (m.id === assistantId ? { ...m, content: errorLine } : m)));
         return;
       }
 

--- a/packages/filigran-chatbot/src/hooks/useChat.ts
+++ b/packages/filigran-chatbot/src/hooks/useChat.ts
@@ -12,6 +12,7 @@ import type {
 import type { ParsedAction, ProtocolContext } from './protocols';
 import { parseAgUiEvent, parseLegacyEvent, parseRestEvent } from './protocols';
 import { parseToolApprovalProposals } from './protocols/parseRestEvent';
+import { responseErrorText, translate } from '../utils';
 
 const STORAGE_KEY = 'filigranChatConversationId';
 const LEGACY_CHAT_ID_KEY = 'filigranChatLegacyChatId';
@@ -806,7 +807,17 @@ export function useChat({
         signal: controller.signal,
       });
 
-      if (!res.ok || !res.body) {
+      if (!res.ok) {
+        // A refused request (403 on a gated agent, a quota rejection) is not a
+        // misconfigured connection: the host puts the line meant for the user
+        // in the error body, so it wins over any generic text we could write.
+        const reason = await responseErrorText(res);
+        const content = reason || translate(t, 'The request failed ({status}).', { status: res.status });
+        setMessages((prev) => prev.map((m) => (m.id === assistantId ? { ...m, content } : m)));
+        return;
+      }
+
+      if (!res.body) {
         setMessages((prev) =>
           prev.map((m) => (m.id === assistantId ? { ...m, content: t('Unable to connect. Please check the configuration.') } : m)),
         );

--- a/packages/filigran-chatbot/src/utils/index.ts
+++ b/packages/filigran-chatbot/src/utils/index.ts
@@ -451,3 +451,33 @@ export function splitFileMarkers(content: string): FileMarkerPart[] {
   if (tail) parts.push({ type: 'text', value: tail });
   return parts;
 }
+
+/**
+ * Human-readable text out of a backend error payload.
+ *
+ * Shapes differ per host: a bare string, `{message}`, or FastAPI's `{detail}` —
+ * itself either a string or a `{code, message}` object. Anything else (a
+ * validation array, an opaque object) yields `''` so the caller falls back to
+ * its own line instead of rendering `[object Object]`.
+ */
+export function extractErrorText(payload: unknown): string {
+  if (typeof payload === 'string') return payload.trim();
+  if (!payload || typeof payload !== 'object') return '';
+  const { message, detail } = payload as { message?: unknown; detail?: unknown };
+  if (typeof message === 'string' && message.trim()) return message.trim();
+  if (typeof detail === 'string' && detail.trim()) return detail.trim();
+  if (detail && typeof detail === 'object' && !Array.isArray(detail)) {
+    const nested = (detail as { message?: unknown }).message;
+    if (typeof nested === 'string' && nested.trim()) return nested.trim();
+  }
+  return '';
+}
+
+/** `extractErrorText` on a failed response's body; `''` when it is not JSON. */
+export async function responseErrorText(res: Response): Promise<string> {
+  try {
+    return extractErrorText(await res.json());
+  } catch {
+    return '';
+  }
+}


### PR DESCRIPTION
Closes #398.

A failed send discarded the response body for a fixed "check the configuration" line — wrong for a 403, where the connection worked and the host put the user-facing text in `detail.message` (`useChat.ts:809`).

- `extractErrorText` / `responseErrorText` (`utils/index.ts`): pull text from a string, `{message}`, `detail` as string, or `detail.message`; `''` for anything else (validation arrays, opaque objects) so callers fall back rather than print an object.
- Send path: `!res.ok` uses the body's message, falling back to `'The request failed ({status}).'`; `!res.body` keeps the old configuration line.
- REST and legacy SSE parsers cast an error payload to string unchecked — an object rendered as `[object Object]`. Both go through the extractor now. Not the path behind #398 (a 403 lands before the stream opens), but the same defect.
- New translation key documented; version bumped to 3.9.2.

The literal `Error — ` exists nowhere in this package or in the published 3.9.1 `dist`, so that prefix comes from the host. The panel now shows `detail.message` on its own.

Vibe coded.