### PR TITLE
feat(filigran-ui): expose textarea resize props (#400)

### DIFF
--- a/packages/filigran-ui/src/components/servers/textarea.tsx
+++ b/packages/filigran-ui/src/components/servers/textarea.tsx
@@ -1,17 +1,33 @@
 import * as React from 'react'
+import {cva, type VariantProps} from 'class-variance-authority'
 import {cn} from '../../lib/utils'
 
+const textareaVariants = cva(
+  'flex min-h-[80px] w-full rounded bg-input-bg-default px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
+  {
+    variants: {
+      resize: {
+        none: 'resize-none',
+        vertical: 'resize-y',
+        horizontal: 'resize-x',
+        both: 'resize',
+      },
+    },
+    defaultVariants: {
+      resize: 'vertical',
+    },
+  }
+)
+
 export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement>,
+    VariantProps<typeof textareaVariants> {}
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
-  ({className, ...props}, ref) => {
+  ({className, resize, ...props}, ref) => {
     return (
       <textarea
-        className={cn(
-          'flex min-h-[80px] w-full rounded bg-input-bg-default px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
-          className
-        )}
+        className={cn(textareaVariants({resize}), className)}
         ref={ref}
         {...props}
       />
@@ -20,4 +36,4 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
 )
 Textarea.displayName = 'Textarea'
 
-export {Textarea}
+export {Textarea, textareaVariants}

--- a/projects/filigran-website/content/docs/components/textarea.mdx
+++ b/projects/filigran-website/content/docs/components/textarea.mdx
@@ -29,6 +29,7 @@ title: Textarea
 | **name**           | string              | -       | Name of the form control. Submitted with the form as part of a name/value pair.         |
 | **placeholder**    | string              | -       | Text that appears in the form control when it has no value set.                         |
 | **readonly**       | boolean             | false   | The value is not editable.                                                              |
+| **resize**        | 'none' \| 'vertical' \| 'horizontal' \| 'both' | vertical | Controls which resize handle the textarea exposes.                                      |
 | **required**       | boolean             | false   | A value is required or must be checked for the form to be submittable.                  |
 | **value**          | string              | -       | The value of the control. When specified in the HTML, corresponds to the initial value. |
 | **onChange**       | () => void          | -       | Triggered function when the value changes.                                              |
@@ -37,7 +38,7 @@ title: Textarea
 
 _Import from @filigran/ui :_
 
-Import \{Separator\} from '@filigran/ui'
+Import \{Textarea\} from '@filigran/ui'
 
 ## Playground
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request! We as a community driven project
depend on support and contributions like this.

Title convention (Conventional Commits + GitHub reference):
  type(scope?): description (#issue)
Types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert.
See .github/LABELS.md for the full taxonomy.
-->

### Proposed changes

* expose a resize prop on Textarea to allow clients to specificy how it should be resizable

### Related issues

<!-- This PR must be linked to an issue. Use a closing keyword. -->
* Closes #

### How to test this PR

<!-- Please give example or instructions for the reviewer to test this PR. -->

### Checklist

- [ ] The PR title follows the Conventional Commits convention `type(scope?): description (#issue)`
- [ ] I signed my commits
- [ ] This PR is linked to an issue
- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I added/updated the relevant documentation
- [ ] Where necessary, I refactored code to improve the overall quality

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you considered. -->
