### PR TITLE
feat(gradient-background): align gradient background with design system (#403)

### DIFF
--- a/packages/filigran-ui/package.json
+++ b/packages/filigran-ui/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "git+https://github.com/FiligranHQ/filigran-ui.git"
   },
-  "version": "1.6.12",
+  "version": "1.6.13",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/filigran-ui/src/theme.css
+++ b/packages/filigran-ui/src/theme.css
@@ -638,11 +638,7 @@
     var(--color-filigran-ia-secondary) 0%,
     var(--color-filigran-ia-main) 100%
   );
-  --gradient-background: linear-gradient(
-    135deg,
-    var(--color-elevation-bg) 0%,
-    var(--color-elevation-bg) 100%
-  );
+  --gradient-background: var(--gradient-layer-0-white);
   --gradient-layer-0-layer-1: linear-gradient(
     100.35deg,
     var(--color-elevation-background-layer-0) 0%,
@@ -1186,13 +1182,13 @@
   --text-light: 231 5% 30%;
   --text-disabled: 219 11% 48%;
 
-  --gradient-background: linear-gradient(100.35deg, #ececf2 0%, #f7f7f7 100%);
+  --gradient-background: var(--gradient-layer-0);
   --gradient-layer-0-layer-1: linear-gradient(
     100.35deg,
     var(--color-elevation-background-layer-0) 0%,
     var(--color-elevation-background-layer-1) 100%
   );
-  --gradient-layer-0-white: linear-gradient(
+  --gradient-layer-0: linear-gradient(
     100.35deg,
     var(--color-elevation-background-layer-0) 0%,
     var(--color-elevation-background-layer-0-gradient) 100%
@@ -2224,7 +2220,7 @@ body[data-theme='Dark'] {
   --entity-victimology: 265.21 100% 76.67%;
   --entity-locations: 186.7 94.95% 38.82%;
 
-  --gradient-background: linear-gradient(100.35deg, #070d19 0%, #08101d 100%);
+  --gradient-background: var(--gradient-layer-0);
 
   --gradient-ia: linear-gradient(90deg, #d6c2fa 0.67%, #b286ff 100.67%);
   --gradient-focus: linear-gradient(90deg, #0fbcff -3.68%, #00f1bd 106.62%);


### PR DESCRIPTION
This PR aligns the default background gradient with the design tokens for `Elevation/Background/Default/layer-0` and `layer-0-gradient`

### Proposed changes

* redefine `--gradient-background` to use the `layer-0` -> `layer-0-gradient` gradient
* introduce `--gradient-layer-0` as the semantic token for that gradient

### Related issues

<!-- This PR must be linked to an issue. Use a closing keyword. -->
* Closes #

### How to test this PR

<!-- Please give example or instructions for the reviewer to test this PR. -->

### Checklist

- [ ] The PR title follows the Conventional Commits convention `type(scope?): description (#issue)`
- [ ] I signed my commits
- [ ] This PR is linked to an issue
- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I added/updated the relevant documentation
- [ ] Where necessary, I refactored code to improve the overall quality

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you considered. -->
